### PR TITLE
plan,exec,docs: make Output mapping ordered and unambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,9 +71,8 @@ a block matched no incoming field and so renamed nothing at all, and the
 diagnostic says so. It has no behaviour to preserve — swap those pairs back to
 what you originally meant.
 
-`mapping:` is now a column **selection**, not a rename overlay, so an item that
-resolves to nothing removes a column from the file rather than leaving it
-unrenamed. Five silent outcomes are therefore compile errors:
+`mapping:` is now a column **selection**, not a rename overlay. Four silent
+outcomes are therefore compile errors:
 
 - a repeated output name (**E364**);
 - an empty block, `mapping: {}` or `mapping: []` (**E364**) — it declares an
@@ -81,22 +80,70 @@ unrenamed. Five silent outcomes are therefore compile errors:
 - an output name that `include_unmapped: true` would also carry through
   (**E364**) — the file would carry the column twice and readers would resolve
   the passthrough copy, losing the renamed value;
-- `exclude:` naming a column the mapping *produces* (**E364**) — `exclude:`
-  matches incoming names and runs before the rename, so it suppressed nothing;
 - an item naming a column that does not exist at that point in the pipeline
   (**E365**, with the available column list and a `did you mean`).
 
-Where the compiler cannot prove a column absent — inside a composition body, or
-for a column arriving through the `auto_widen` sidecar — **E365** is raised at
-the write boundary instead, once per output, before the first byte is written.
+`exclude:` naming a column the mapping *produces* is deliberately **not** an
+error. `exclude:` matches incoming column names, so it removes the upstream
+column of that name and leaves the mapped one standing — which is exactly the
+fix the collision diagnostic above prescribes.
 
 A `mapping:` item may name an `auto_widen` drift column when the output sets
 `include_unmapped: true`, which is what expands the sidecar to top-level
 columns; under `include_unmapped: false` the sidecar stays packed and the item
-is rejected. Column names in `mapping:` are matched bare — there is no qualified
-`input.column` spelling.
+is rejected. The sidecar waiver is per item, not per block: a name one edit away
+from a column the row *does* declare keeps its **E365** and its `did you mean`,
+because that is a misspelling however the column travels. Column names in
+`mapping:` are matched bare — there is no qualified `input.column` spelling.
 
 Run `clinker explain E364` or `clinker explain E365` for the full pages.
+
+### Changed — every record writes every column an Output's `mapping:` declares
+
+**Breaking change for streams whose records differ in shape.** When a record
+does not carry an item's source column, that column is now written **empty**
+rather than omitted. Previously such a record passed through without the column,
+so the file's shape depended on the data.
+
+The declared column set is the same for every record, in declaration order. That
+follows from what the surface already promises: `mapping:` is the author's
+statement of which columns the file carries and in what order, and a column that
+vanishes on some rows contradicts both. It also makes the output schema a
+function of the config rather than of whichever record happened to arrive first —
+which matters, because most write paths derive the file's header from exactly
+that first record.
+
+Affected: a multi-record-type source, a composition body's open row, and columns
+reaching the sink through the `auto_widen` sidecar. A homogeneous stream, where
+every record carries every mapped column, is unchanged.
+
+If a `mapping:` block relied on the old behaviour to produce a
+per-record-variable column set, remove the items for the columns that vary and
+let `include_unmapped: true` append them instead — that path still follows the
+data.
+
+### Added — end-of-run reporting for an Output's `mapping:` block
+
+Two advisory warnings, printed to standard error when a run finishes. Neither
+changes the exit code: both describe a file that was written and is readable,
+and by the time a stream ends the run's other outputs have already been flushed.
+
+- **W365** — a `mapping:` item whose source column *no record* carried, so the
+  item wrote an empty column in every row. This replaces a write-boundary
+  **E365** that aborted such runs. The abort tested the wrong thing: it checked
+  the established output schema, which on most write paths is derived from the
+  first record, so it killed runs whose first record merely happened to be
+  sparse while staying silent about a column absent from every record after the
+  first. Tracking resolution across the whole stream separates the two cases
+  exactly — a misspelling is carried by no record, an ordinary sparse column is
+  carried by some record and is not reported.
+- **W366** — an upstream column dropped because a `mapping:` output name
+  occupies its place in the header. The mapped value still wins, unchanged; what
+  is new is that the displaced column is named rather than lost in silence.
+  Where the planner can enumerate the columns reaching that output, the same
+  collision remains an **E364** at compile time.
+
+Run `clinker explain W365` or `clinker explain W366` for the full pages.
 
 ### Removed — the `best_effort` error strategy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,12 +91,19 @@ fix the collision diagnostic above prescribes.
 A `mapping:` item may name an `auto_widen` drift column when the output sets
 `include_unmapped: true`, which is what expands the sidecar to top-level
 columns; under `include_unmapped: false` the sidecar stays packed and the item
-is rejected. The sidecar waiver is per item, not per block: a name one edit away
-from a column the row *does* declare keeps its **E365** and its `did you mean`,
-because that is a misspelling however the column travels. Column names in
-`mapping:` are matched bare — there is no qualified `input.column` spelling.
+is rejected. Similarity to a declared name does not change that waiver: edit
+distance can suggest a spelling only after absence is known, and a real drift
+column may happen to be similar. **W365** reports the item after the run if no
+written record supplied it. Column names in `mapping:` are matched bare — there
+is no qualified `input.column` spelling.
 
-Run `clinker explain E364` or `clinker explain E365` for the full pages.
+Rust callers must also migrate `OutputConfig.mapping` from
+`Option<IndexMap<String, String>>` to `Option<OutputMapping>` (constructed from
+`Vec<MappingEntry>`). `OutputSpec.mapping` is now a `Vec<MappingEntry>`, and
+`ExecutionReport` struct literals must supply the new `advisories` field.
+
+Run `clinker explain --code E364` or `clinker explain --code E365` for the full
+pages.
 
 ### Changed — every record writes every column an Output's `mapping:` declares
 
@@ -143,7 +150,8 @@ and by the time a stream ends the run's other outputs have already been flushed.
   Where the planner can enumerate the columns reaching that output, the same
   collision remains an **E364** at compile time.
 
-Run `clinker explain W365` or `clinker explain W366` for the full pages.
+Run `clinker explain --code W365` or `clinker explain --code W366` for the full
+pages.
 
 ### Removed — the `best_effort` error strategy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,42 @@ Clinker diagnostics must register its codes before upgrading.
 `PlanDiagnostics` also records whether its line-only spans are safe to resolve
 against the pipeline document. Untrusted spans remain in the structured value
 for consumers that can attribute them; the CLI simply omits the source snippet.
+### Changed — an Output's `mapping:` is an ordered sequence, and its direction is fixed
+
+**Breaking change to a hand-written YAML key.** `mapping:` was a map of column
+name to column name. It is now a sequence, one item per output column:
+
+```yaml
+mapping:
+  - order_id                # carried through under its own name
+  - sold_to: customer_id    # written as `sold_to`, read from `customer_id`
+```
+
+A bare scalar carries a column through unchanged; a single-key pair renames.
+Declaration order is the output column order — which the map form could not
+express at all. Columns the block does not list are appended after it when
+`include_unmapped: true` (the default) and dropped when it is `false`.
+
+**The pair direction is `output_name: source_column` — output on the left.**
+That is the direction the user guide always documented and the plan layer
+always assumed; the executor's rename pass implemented the reverse, so a block
+written to the documentation renamed nothing and the run still exited 0. Both
+halves now agree on the documented direction.
+
+Migration, both mechanical:
+
+- Put `- ` in front of each line. A pair whose two sides are the same column
+  collapses to a bare name.
+- If your block was written against the old *behaviour* (source column on the
+  left), swap the two sides. A block written against the old *documentation*
+  lifts unchanged.
+
+A map-valued `mapping:` is rejected at compile time with **E364**, and the
+message prints your own block already rewritten. Two silent failure modes are
+now compile errors as well: a repeated output name (**E364**), and an item
+naming a column that does not exist at that point in the pipeline (**E365**,
+with the available column list and a `did you mean`). Run `clinker explain E364`
+or `clinker explain E365` for the full pages.
 
 ### Removed — the `best_effort` error strategy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,16 +58,45 @@ Migration, both mechanical:
 
 - Put `- ` in front of each line. A pair whose two sides are the same column
   collapses to a bare name.
-- If your block was written against the old *behaviour* (source column on the
-  left), swap the two sides. A block written against the old *documentation*
-  lifts unchanged.
+- **Swap the two sides of each remaining pair.** The engine looked map entries
+  up by the incoming field name, so the key was the *source* column:
+  `customer_id: sold_to` renamed `customer_id` to `sold_to`, which is now
+  `- sold_to: customer_id`.
 
 A map-valued `mapping:` is rejected at compile time with **E364**, and the
-message prints your own block already rewritten. Two silent failure modes are
-now compile errors as well: a repeated output name (**E364**), and an item
-naming a column that does not exist at that point in the pipeline (**E365**,
-with the available column list and a `did you mean`). Run `clinker explain E364`
-or `clinker explain E365` for the full pages.
+message prints your own block already converted — lifted, collapsed, and with
+each pair swapped as above. The one block that swap is wrong for is one written
+to follow the *old documentation*, which described the opposite direction: such
+a block matched no incoming field and so renamed nothing at all, and the
+diagnostic says so. It has no behaviour to preserve — swap those pairs back to
+what you originally meant.
+
+`mapping:` is now a column **selection**, not a rename overlay, so an item that
+resolves to nothing removes a column from the file rather than leaving it
+unrenamed. Five silent outcomes are therefore compile errors:
+
+- a repeated output name (**E364**);
+- an empty block, `mapping: {}` or `mapping: []` (**E364**) — it declares an
+  output with no columns; remove the key to write every upstream column;
+- an output name that `include_unmapped: true` would also carry through
+  (**E364**) — the file would carry the column twice and readers would resolve
+  the passthrough copy, losing the renamed value;
+- `exclude:` naming a column the mapping *produces* (**E364**) — `exclude:`
+  matches incoming names and runs before the rename, so it suppressed nothing;
+- an item naming a column that does not exist at that point in the pipeline
+  (**E365**, with the available column list and a `did you mean`).
+
+Where the compiler cannot prove a column absent — inside a composition body, or
+for a column arriving through the `auto_widen` sidecar — **E365** is raised at
+the write boundary instead, once per output, before the first byte is written.
+
+A `mapping:` item may name an `auto_widen` drift column when the output sets
+`include_unmapped: true`, which is what expands the sidecar to top-level
+columns; under `include_unmapped: false` the sidecar stays packed and the item
+is rejected. Column names in `mapping:` are matched bare — there is no qualified
+`input.column` spelling.
+
+Run `clinker explain E364` or `clinker explain E365` for the full pages.
 
 ### Removed — the `best_effort` error strategy
 

--- a/benches/pipelines/features/projection_mapping.yaml
+++ b/benches/pipelines/features/projection_mapping.yaml
@@ -30,7 +30,10 @@ nodes:
       type: csv
       path: bench://output.csv
       include_unmapped: true
+      # `output_name: source_column` — each pair renames one upstream column.
+      # `out` is not listed, so `include_unmapped: true` appends it after the
+      # three declared columns.
       mapping:
-        output_a: f0
-        output_b: f1
-        output_c: f2
+        - output_a: f0
+        - output_b: f1
+        - output_c: f2

--- a/crates/clinker-benchmarks/src/report.rs
+++ b/crates/clinker-benchmarks/src/report.rs
@@ -466,6 +466,7 @@ mod tests {
             per_stage_spill_bytes: Default::default(),
             peak_consumer_usage_bytes: 0,
             interrupted: false,
+            advisories: Vec::new(),
         };
         report.counters.total_count = 1000;
         report.counters.ok_count = 995;
@@ -550,6 +551,7 @@ mod tests {
             per_stage_spill_bytes: Default::default(),
             peak_consumer_usage_bytes: 0,
             interrupted: false,
+            advisories: Vec::new(),
         };
         let output = format_summary_table("test/bad", "small", &report);
         assert!(

--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -204,6 +204,8 @@ diagnostic_registry! {
     "E361", Error, "`multiple: true` column on a source whose format has no way to produce more than one value";
     "E362", Error, "Malformed `join_values:` output declaration (the write-side mirror of E358)";
     "E363", Error, "A source's `record_path` is not a path in its format's grammar — an XPath descendant step (`//`), a JSONPath root marker (`$.`), a leading `/`, an empty segment, or an XML segment no element can be named";
+    "E364", Error, "An Output `mapping:` block uses the superseded map form or declares a projection that cannot produce unique, meaningful columns";
+    "E365", Error, "An Output `mapping:` item reads a column the pipeline does not carry at that point in the graph";
     // ── Path security ───────────────────────────────────────────────────
     "E-SEC-001", Error, "Path security violation (escape, symlink, etc.)";
     // ── Warnings ────────────────────────────────────────────────────────

--- a/crates/clinker-exec/src/executor/correlation_dispatch.rs
+++ b/crates/clinker-exec/src/executor/correlation_dispatch.rs
@@ -381,6 +381,21 @@ fn flush_clean_records_to_writers(
                     };
                     if let Err(e) = flush_result {
                         push_write_error(&mut ctx.output_errors, e);
+                    } else if out_cfg.mapping.is_some() {
+                        // Correlation records were projected before their group
+                        // disposition. Observe only after this clean queue is
+                        // fully written and flushed, so rejected groups, dry
+                        // runs, and failed writers cannot affect advisories.
+                        // Re-walking retained originals here is bounded and
+                        // avoids storing per-record probe state in the group.
+                        let probe = crate::executor::dispatch::mapping_probe(
+                            &mut ctx.mapping_probes,
+                            &output_name,
+                            out_cfg,
+                        );
+                        for slot in &slots {
+                            probe.observe_committed_record(&slot.original_record, out_cfg);
+                        }
                     }
                 }
             }

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1148,7 +1148,9 @@ impl<'a> ExecutorContext<'a> {
         out_cfg: &clinker_plan::config::OutputConfig,
         probe: &crate::projection::MappingProbe,
     ) {
-        mapping_probe(&mut self.mapping_probes, output_name, out_cfg).merge(probe);
+        if out_cfg.mapping.is_some() {
+            mapping_probe(&mut self.mapping_probes, output_name, out_cfg).merge(probe);
+        }
     }
 
     /// Poll the run's shutdown flag at an operator chunk boundary. When

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -16,7 +16,7 @@
 //! where `recursive_term.execute(partition, Arc::clone(&task_context))`
 //! re-enters the same execution loop with a different plan.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::Write;
 use std::sync::{Arc, LazyLock};
 
@@ -760,6 +760,15 @@ pub(crate) struct ExecutorContext<'a> {
     /// still fail-fast and bypass the rewind path.
     pub(crate) combine_input_snapshots: HashMap<NodeIndex, HashMap<Arc<str>, u64>>,
     pub(crate) output_errors: Vec<PipelineError>,
+    /// Per-Output `mapping:` resolution evidence, keyed by Output node name and
+    /// accumulated across every arm and every chunk. Drained once at the end of
+    /// the run into the report's advisory findings.
+    ///
+    /// Run-scoped rather than arm-scoped because an Output's records can reach
+    /// the projection from several arms and several chunks; only the union over
+    /// the whole stream can distinguish a column no record carried (a typo) from
+    /// one that some record carried (a sparse column in a heterogeneous stream).
+    pub(crate) mapping_probes: BTreeMap<String, crate::projection::MappingProbe>,
     pub(crate) ok_source_rows: HashSet<u64>,
     pub(crate) records_emitted: u64,
     pub(crate) transform_timer: stage_metrics::CumulativeTimer,
@@ -1107,7 +1116,41 @@ pub(crate) struct RetainedAggregatorState {
     pub(crate) consumer_id: crate::pipeline::memory::ConsumerId,
 }
 
+/// The `mapping:` probe for one Output, created on first use and sized from
+/// that Output's block.
+///
+/// Takes the map rather than the whole [`ExecutorContext`] so a per-record
+/// projection can hold the probe alongside a disjoint borrow of another
+/// context field — the correlation buffers, the writer registry, the
+/// projection timer. Looks up before inserting so the steady-state path
+/// allocates nothing: `entry()` would build the owned key on every record.
+pub(crate) fn mapping_probe<'p>(
+    probes: &'p mut BTreeMap<String, crate::projection::MappingProbe>,
+    output_name: &str,
+    out_cfg: &clinker_plan::config::OutputConfig,
+) -> &'p mut crate::projection::MappingProbe {
+    if !probes.contains_key(output_name) {
+        probes.insert(
+            output_name.to_string(),
+            crate::projection::MappingProbe::for_config(out_cfg),
+        );
+    }
+    probes
+        .get_mut(output_name)
+        .expect("inserted above when absent")
+}
+
 impl<'a> ExecutorContext<'a> {
+    /// Fold a probe accumulated off the dispatcher's thread into the run's.
+    pub(crate) fn merge_mapping_probe(
+        &mut self,
+        output_name: &str,
+        out_cfg: &clinker_plan::config::OutputConfig,
+        probe: &crate::projection::MappingProbe,
+    ) {
+        mapping_probe(&mut self.mapping_probes, output_name, out_cfg).merge(probe);
+    }
+
     /// Poll the run's shutdown flag at an operator chunk boundary. When
     /// the token has tripped (SIGINT/SIGTERM, or a programmatic
     /// request), record the interruption and return

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -486,13 +486,24 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
                 self.arbitrator.unregister_consumer(consumer_id);
                 return Ok(());
             }
-            let probe = mapping_probe(&mut ctx.mapping_probes, &self.output_name, self.out_cfg);
-            projected.push(crate::projection::project_output_probed(
-                &record,
-                self.out_cfg,
-                cxl_emit_names_opt,
-                Some(probe),
-            ));
+            let record = match self.out_cfg.mapping.as_ref() {
+                Some(_) => {
+                    let probe =
+                        mapping_probe(&mut ctx.mapping_probes, &self.output_name, self.out_cfg);
+                    crate::projection::project_output_probed(
+                        &record,
+                        self.out_cfg,
+                        cxl_emit_names_opt,
+                        Some(probe),
+                    )
+                }
+                None => crate::projection::project_output_from_record(
+                    &record,
+                    self.out_cfg,
+                    cxl_emit_names_opt,
+                ),
+            };
+            projected.push(record);
             if ctx.ok_source_rows.insert(row_num) {
                 self.ok_count += 1;
             }
@@ -518,13 +529,23 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
             return;
         }
         let projected = {
-            let probe = mapping_probe(&mut ctx.mapping_probes, &self.output_name, self.out_cfg);
-            crate::projection::project_output_probed(
-                &record,
-                self.out_cfg,
-                self.cxl_emit_names.as_deref(),
-                Some(probe),
-            )
+            match self.out_cfg.mapping.as_ref() {
+                Some(_) => {
+                    let probe =
+                        mapping_probe(&mut ctx.mapping_probes, &self.output_name, self.out_cfg);
+                    crate::projection::project_output_probed(
+                        &record,
+                        self.out_cfg,
+                        self.cxl_emit_names.as_deref(),
+                        Some(probe),
+                    )
+                }
+                None => crate::projection::project_output_from_record(
+                    &record,
+                    self.out_cfg,
+                    self.cxl_emit_names.as_deref(),
+                ),
+            }
         };
         if ctx.ok_source_rows.insert(row_num) {
             self.ok_count += 1;

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -61,13 +61,13 @@ use std::sync::Arc;
 use clinker_record::{DocumentId, Record};
 
 use crate::executor::dispatch::{
-    ExecutorContext, MERGED_SOURCE_FILE, push_dlq, source_file_arc_of, source_name_arc_of,
+    ExecutorContext, MERGED_SOURCE_FILE, mapping_probe, push_dlq, source_file_arc_of,
+    source_name_arc_of,
 };
 use crate::executor::node_buffer::NodeBuffer;
 use crate::executor::stream_event::StreamEvent;
 use crate::executor::structured_output_guard::StructuredOutputDocumentGuard;
 use crate::executor::{DlqEntry, build_format_writer};
-use crate::projection::project_output_from_record;
 use clinker_plan::config::OutputConfig;
 use clinker_plan::error::PipelineError;
 
@@ -486,10 +486,12 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
                 self.arbitrator.unregister_consumer(consumer_id);
                 return Ok(());
             }
-            projected.push(project_output_from_record(
+            let probe = mapping_probe(&mut ctx.mapping_probes, &self.output_name, self.out_cfg);
+            projected.push(crate::projection::project_output_probed(
                 &record,
                 self.out_cfg,
                 cxl_emit_names_opt,
+                Some(probe),
             ));
             if ctx.ok_source_rows.insert(row_num) {
                 self.ok_count += 1;
@@ -515,8 +517,15 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
             ctx.output_errors.push(err);
             return;
         }
-        let projected =
-            project_output_from_record(&record, self.out_cfg, self.cxl_emit_names.as_deref());
+        let projected = {
+            let probe = mapping_probe(&mut ctx.mapping_probes, &self.output_name, self.out_cfg);
+            crate::projection::project_output_probed(
+                &record,
+                self.out_cfg,
+                self.cxl_emit_names.as_deref(),
+                Some(probe),
+            )
+        };
         if ctx.ok_source_rows.insert(row_num) {
             self.ok_count += 1;
         }

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -154,6 +154,10 @@ pub(crate) struct DispatchOutcome {
     /// walk unwound early. Carried up so the report surfaces the
     /// interrupted state to the CLI.
     pub(crate) interrupted: bool,
+    /// Advisory end-of-run findings, already rendered. Today: the per-Output
+    /// `mapping:` report (W365 / W366). Never fatal — by the time a stream
+    /// ends its sibling Outputs have written.
+    pub(crate) advisories: Vec<String>,
 }
 
 /// Borrowed, read-only inputs threaded through `execute_dag` and
@@ -707,6 +711,7 @@ impl PipelineExecutor {
             per_stage_spill_bytes,
             peak_consumer_usage_bytes,
             interrupted,
+            advisories,
         } = Self::execute_dag(
             &DagExecInputs {
                 config,
@@ -816,6 +821,7 @@ impl PipelineExecutor {
             per_stage_spill_bytes,
             peak_consumer_usage_bytes,
             interrupted,
+            advisories,
         })
     }
 
@@ -1236,6 +1242,7 @@ impl PipelineExecutor {
             rollback_cursors: HashMap::new(),
             combine_input_snapshots: HashMap::new(),
             output_errors: Vec::new(),
+            mapping_probes: BTreeMap::new(),
             ok_source_rows: HashSet::new(),
             records_emitted: 0,
             transform_timer: stage_metrics::CumulativeTimer::new(),
@@ -1537,6 +1544,16 @@ impl PipelineExecutor {
         let per_stage_spill_bytes = ctx.memory_budget.per_stage_spill_bytes();
         let peak_consumer_usage_bytes = ctx.memory_budget.peak_consumer_usage();
         let interrupted = ctx.interrupted;
+        // Per-Output `mapping:` findings, over the WHOLE stream. Drained here
+        // rather than at each arm's close because an Output's records can reach
+        // the projection from several arms and several chunks, and only the
+        // union distinguishes a column no record carried from one some record
+        // did.
+        let advisories: Vec<String> = ctx
+            .mapping_probes
+            .iter()
+            .flat_map(|(output_name, probe)| probe.findings(output_name))
+            .collect();
         Ok(DispatchOutcome {
             counters: std::mem::take(counters),
             dlq_entries: std::mem::take(dlq_entries),
@@ -1549,6 +1566,7 @@ impl PipelineExecutor {
             per_stage_spill_bytes,
             peak_consumer_usage_bytes,
             interrupted,
+            advisories,
         })
     }
 

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1549,11 +1549,7 @@ impl PipelineExecutor {
         // the projection from several arms and several chunks, and only the
         // union distinguishes a column no record carried from one some record
         // did.
-        let advisories: Vec<String> = ctx
-            .mapping_probes
-            .iter()
-            .flat_map(|(output_name, probe)| probe.findings(output_name))
-            .collect();
+        let advisories = collect_mapping_advisories(ctx.output_configs, &ctx.mapping_probes);
         Ok(DispatchOutcome {
             counters: std::mem::take(counters),
             dlq_entries: std::mem::take(dlq_entries),
@@ -1596,6 +1592,24 @@ impl PipelineExecutor {
             .map_err(PipelineError::plan_diagnostics_unanchored)?;
         Ok((validated_plan.dag().clone(), ()))
     }
+}
+
+/// Render mapping findings in the same order the Outputs appear in the
+/// pipeline. The probe registry is keyed for lookup, not presentation; walking
+/// it directly would sort advisories by output name.
+fn collect_mapping_advisories(
+    output_configs: &[clinker_plan::config::OutputConfig],
+    mapping_probes: &BTreeMap<String, crate::projection::MappingProbe>,
+) -> Vec<String> {
+    output_configs
+        .iter()
+        .filter_map(|output| {
+            mapping_probes
+                .get(&output.name)
+                .map(|probe| (output.name.as_str(), probe))
+        })
+        .flat_map(|(output_name, probe)| probe.findings(output_name))
+        .collect()
 }
 
 /// Project the per-source finalized ingest counts into the report-facing map:
@@ -1651,6 +1665,62 @@ mod tests {
     //! in-crate symbols.
 
     use super::*;
+
+    #[test]
+    fn mapping_advisories_follow_output_declaration_order() {
+        let config = clinker_plan::config::parse_config(
+            r#"
+pipeline:
+  name: advisory_order
+nodes:
+  - type: source
+    name: source
+    config:
+      name: source
+      type: json
+      path: input.json
+      schema:
+        - { name: id, type: string }
+  - type: output
+    name: z_out
+    input: source
+    config:
+      name: z_out
+      type: csv
+      path: z.csv
+      mapping:
+        - z_missing
+  - type: output
+    name: a_out
+    input: source
+    config:
+      name: a_out
+      type: csv
+      path: a.csv
+      mapping:
+        - a_missing
+"#,
+        )
+        .expect("pipeline parses");
+        let outputs: Vec<_> = config.output_configs().cloned().collect();
+        let record = clinker_record::Record::new(
+            clinker_record::SchemaBuilder::new()
+                .with_field("id")
+                .build(),
+            vec![clinker_record::Value::String("1".into())],
+        );
+        let mut probes = BTreeMap::new();
+        for output in &outputs {
+            let mut probe = crate::projection::MappingProbe::for_config(output);
+            probe.observe_committed_record(&record, output);
+            probes.insert(output.name.clone(), probe);
+        }
+
+        let advisories = collect_mapping_advisories(&outputs, &probes);
+        assert_eq!(advisories.len(), 2, "{advisories:?}");
+        assert!(advisories[0].contains("z_out"), "{}", advisories[0]);
+        assert!(advisories[1].contains("a_out"), "{}", advisories[1]);
+    }
 
     mod aggregation;
     mod combine_consumer_lifecycle;

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -363,6 +363,12 @@ pub(crate) fn dispatch_output(
         };
         Arc::clone(projected.schema())
     };
+    // Write-boundary E365, checked here as well as in `build_format_writer`
+    // because this arm establishes its schema BEFORE it looks for a writer —
+    // so a dry-run, or an Output whose writer a sibling already took, still
+    // reports a `mapping:` entry the stream cannot supply instead of silently
+    // reporting what it "would" have written.
+    crate::projection::check_mapping_against_schema(&output_schema, out_cfg, name)?;
 
     // Find and take the writer for this output. Errors from
     // build_format_writer / write_record / flush are captured

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -312,20 +312,17 @@ pub(crate) fn dispatch_output(
     // commit arm emits a `GroupSizeExceeded` trigger.
     if !buffered.is_empty() {
         let max_buf = ctx.correlation_max_group_buffer;
-        // Disjoint field borrows: the probe map and the correlation buffers are
-        // separate fields, so both may be held across the loop.
-        let probe = mapping_probe(&mut ctx.mapping_probes, name, out_cfg);
         let buffers = ctx
             .correlation_buffers
             .as_mut()
             .expect("correlation_buffers is Some — we just checked above");
         for (record, rn, group_key) in buffered.iter() {
-            let projected = crate::projection::project_output_probed(
-                record,
-                out_cfg,
-                cxl_emit_names_opt,
-                Some(probe),
-            );
+            // Do not feed the run-wide mapping probe yet: a dirty correlation
+            // group is rejected wholesale, so its fields did not populate the
+            // delivered file. Clean groups contribute their evidence at the
+            // commit boundary without rebuilding this projection.
+            let projected =
+                crate::projection::project_output_from_record(record, out_cfg, cxl_emit_names_opt);
             let entry = buffers.entry(group_key.clone()).or_default();
             entry.total_records += 1;
             if max_buf > 0 && entry.total_records > max_buf {
@@ -415,7 +412,10 @@ pub(crate) fn dispatch_output(
             strategy,
             dlq_pending: &mut dlq_pending,
             written_rows: &mut written_rows,
-            mapping_probe: mapping_probe(&mut ctx.mapping_probes, name, out_cfg),
+            mapping_probe: out_cfg
+                .mapping
+                .as_ref()
+                .map(|_| mapping_probe(&mut ctx.mapping_probes, name, out_cfg)),
         };
         if let Some(per_file) = fan_out_writers {
             emit_fan_out(&mut fan_ctx, &unbuffered, per_file, scan_timer);
@@ -672,16 +672,23 @@ fn dispatch_output_envelope(
             return Ok(());
         }
         let projected = {
-            // Disjoint field borrows: the projection timer and the probe map are
-            // separate context fields, so the stage timing survives the probe.
             let _guard = ctx.projection_timer.guard();
-            let probe = mapping_probe(&mut ctx.mapping_probes, name, &out_cfg);
-            crate::projection::project_output_probed(
-                &record,
-                &out_cfg,
-                cxl_emit_names_opt,
-                Some(probe),
-            )
+            match out_cfg.mapping.as_ref() {
+                Some(_) => {
+                    let probe = mapping_probe(&mut ctx.mapping_probes, name, &out_cfg);
+                    crate::projection::project_output_probed(
+                        &record,
+                        &out_cfg,
+                        cxl_emit_names_opt,
+                        Some(probe),
+                    )
+                }
+                None => crate::projection::project_output_from_record(
+                    &record,
+                    &out_cfg,
+                    cxl_emit_names_opt,
+                ),
+            }
         };
         {
             let _guard = ctx.write_timer.guard();
@@ -929,7 +936,7 @@ struct FanOutContext<'a> {
     collector: &'a mut crate::executor::stage_metrics::StageCollector,
     /// This Output's `mapping:` resolution evidence, carried in so the per-record
     /// projections below feed the same probe the rest of the run's arms do.
-    mapping_probe: &'a mut crate::projection::MappingProbe,
+    mapping_probe: Option<&'a mut crate::projection::MappingProbe>,
     /// The run's error strategy, so a `join_values` `on_conflict: error`
     /// collision dead-letters under `Continue` but still aborts under
     /// `FailFast` — the same disposition every other per-record failure gets.
@@ -969,18 +976,28 @@ fn emit_single_writer(
             for (record, rn) in unbuffered {
                 let projected = {
                     let _guard = fan_ctx.projection_timer.guard();
-                    crate::projection::project_output_probed(
-                        record,
-                        fan_ctx.out_cfg,
-                        fan_ctx.cxl_emit_names_opt,
-                        Some(fan_ctx.mapping_probe),
-                    )
+                    match fan_ctx.mapping_probe.as_deref_mut() {
+                        Some(probe) => crate::projection::project_output_staged(
+                            record,
+                            fan_ctx.out_cfg,
+                            fan_ctx.cxl_emit_names_opt,
+                            probe,
+                        ),
+                        None => crate::projection::project_output_from_record(
+                            record,
+                            fan_ctx.out_cfg,
+                            fan_ctx.cxl_emit_names_opt,
+                        ),
+                    }
                 };
                 let write_result = {
                     let _guard = fan_ctx.write_timer.guard();
                     csv_writer.write_record(&projected)
                 };
                 if let Err(e) = write_result {
+                    if let Some(probe) = fan_ctx.mapping_probe.as_deref_mut() {
+                        probe.discard_staged_record();
+                    }
                     // A `join_values` `on_conflict: error` collision dead-letters
                     // the one offending record and keeps writing the rest (unless
                     // FailFast); any other write error is fatal for this writer.
@@ -993,6 +1010,12 @@ fn emit_single_writer(
                     push_write_error(fan_ctx.output_errors, e);
                     write_failed = true;
                     break;
+                }
+                // Advisories describe the delivered file. A record rejected by
+                // `join_values on_conflict: error` above must not contribute
+                // mapping evidence or hide an all-empty written column.
+                if let Some(probe) = fan_ctx.mapping_probe.as_deref_mut() {
+                    probe.commit_staged_record();
                 }
                 fan_ctx.written_rows.push(*rn);
             }
@@ -1071,18 +1094,28 @@ fn emit_fan_out(
         };
         let projected = {
             let _guard = fan_ctx.projection_timer.guard();
-            crate::projection::project_output_probed(
-                record,
-                fan_ctx.out_cfg,
-                fan_ctx.cxl_emit_names_opt,
-                Some(fan_ctx.mapping_probe),
-            )
+            match fan_ctx.mapping_probe.as_deref_mut() {
+                Some(probe) => crate::projection::project_output_staged(
+                    record,
+                    fan_ctx.out_cfg,
+                    fan_ctx.cxl_emit_names_opt,
+                    probe,
+                ),
+                None => crate::projection::project_output_from_record(
+                    record,
+                    fan_ctx.out_cfg,
+                    fan_ctx.cxl_emit_names_opt,
+                ),
+            }
         };
         let write_result = {
             let _guard = fan_ctx.write_timer.guard();
             fw.write_record(&projected)
         };
         if let Err(e) = write_result {
+            if let Some(probe) = fan_ctx.mapping_probe.as_deref_mut() {
+                probe.discard_staged_record();
+            }
             if fan_ctx.strategy != ErrorStrategy::FailFast
                 && let Some(entry) = sink_collision_dlq_entry(record, *rn, fan_ctx.name, &e)
             {
@@ -1091,6 +1124,9 @@ fn emit_fan_out(
             }
             push_write_error(fan_ctx.output_errors, e);
             continue;
+        }
+        if let Some(probe) = fan_ctx.mapping_probe.as_deref_mut() {
+            probe.commit_staged_record();
         }
         fan_ctx.written_rows.push(*rn);
     }

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -18,7 +18,7 @@ use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
     CorrelationRecordSlot, ExecutorContext, buffer_key_for_record, drain_node_buffer_slot,
-    push_dlq, push_write_error, sink_collision_dlq_entry, source_file_path_of,
+    mapping_probe, push_dlq, push_write_error, sink_collision_dlq_entry, source_file_path_of,
 };
 use crate::executor::schema_check::check_input_schema;
 use crate::executor::structured_output_guard::{
@@ -312,12 +312,20 @@ pub(crate) fn dispatch_output(
     // commit arm emits a `GroupSizeExceeded` trigger.
     if !buffered.is_empty() {
         let max_buf = ctx.correlation_max_group_buffer;
+        // Disjoint field borrows: the probe map and the correlation buffers are
+        // separate fields, so both may be held across the loop.
+        let probe = mapping_probe(&mut ctx.mapping_probes, name, out_cfg);
         let buffers = ctx
             .correlation_buffers
             .as_mut()
             .expect("correlation_buffers is Some — we just checked above");
         for (record, rn, group_key) in buffered.iter() {
-            let projected = project_output_from_record(record, out_cfg, cxl_emit_names_opt);
+            let projected = crate::projection::project_output_probed(
+                record,
+                out_cfg,
+                cxl_emit_names_opt,
+                Some(probe),
+            );
             let entry = buffers.entry(group_key.clone()).or_default();
             entry.total_records += 1;
             if max_buf > 0 && entry.total_records > max_buf {
@@ -363,12 +371,6 @@ pub(crate) fn dispatch_output(
         };
         Arc::clone(projected.schema())
     };
-    // Write-boundary E365, checked here as well as in `build_format_writer`
-    // because this arm establishes its schema BEFORE it looks for a writer —
-    // so a dry-run, or an Output whose writer a sibling already took, still
-    // reports a `mapping:` entry the stream cannot supply instead of silently
-    // reporting what it "would" have written.
-    crate::projection::check_mapping_against_schema(&output_schema, out_cfg, name)?;
 
     // Find and take the writer for this output. Errors from
     // build_format_writer / write_record / flush are captured
@@ -413,6 +415,7 @@ pub(crate) fn dispatch_output(
             strategy,
             dlq_pending: &mut dlq_pending,
             written_rows: &mut written_rows,
+            mapping_probe: mapping_probe(&mut ctx.mapping_probes, name, out_cfg),
         };
         if let Some(per_file) = fan_out_writers {
             emit_fan_out(&mut fan_ctx, &unbuffered, per_file, scan_timer);
@@ -669,8 +672,16 @@ fn dispatch_output_envelope(
             return Ok(());
         }
         let projected = {
+            // Disjoint field borrows: the projection timer and the probe map are
+            // separate context fields, so the stage timing survives the probe.
             let _guard = ctx.projection_timer.guard();
-            project_output_from_record(&record, &out_cfg, cxl_emit_names_opt)
+            let probe = mapping_probe(&mut ctx.mapping_probes, name, &out_cfg);
+            crate::projection::project_output_probed(
+                &record,
+                &out_cfg,
+                cxl_emit_names_opt,
+                Some(probe),
+            )
         };
         {
             let _guard = ctx.write_timer.guard();
@@ -916,6 +927,9 @@ struct FanOutContext<'a> {
     write_timer: &'a mut crate::executor::stage_metrics::CumulativeTimer,
     projection_timer: &'a mut crate::executor::stage_metrics::CumulativeTimer,
     collector: &'a mut crate::executor::stage_metrics::StageCollector,
+    /// This Output's `mapping:` resolution evidence, carried in so the per-record
+    /// projections below feed the same probe the rest of the run's arms do.
+    mapping_probe: &'a mut crate::projection::MappingProbe,
     /// The run's error strategy, so a `join_values` `on_conflict: error`
     /// collision dead-letters under `Continue` but still aborts under
     /// `FailFast` — the same disposition every other per-record failure gets.
@@ -955,7 +969,12 @@ fn emit_single_writer(
             for (record, rn) in unbuffered {
                 let projected = {
                     let _guard = fan_ctx.projection_timer.guard();
-                    project_output_from_record(record, fan_ctx.out_cfg, fan_ctx.cxl_emit_names_opt)
+                    crate::projection::project_output_probed(
+                        record,
+                        fan_ctx.out_cfg,
+                        fan_ctx.cxl_emit_names_opt,
+                        Some(fan_ctx.mapping_probe),
+                    )
                 };
                 let write_result = {
                     let _guard = fan_ctx.write_timer.guard();
@@ -1052,7 +1071,12 @@ fn emit_fan_out(
         };
         let projected = {
             let _guard = fan_ctx.projection_timer.guard();
-            project_output_from_record(record, fan_ctx.out_cfg, fan_ctx.cxl_emit_names_opt)
+            crate::projection::project_output_probed(
+                record,
+                fan_ctx.out_cfg,
+                fan_ctx.cxl_emit_names_opt,
+                Some(fan_ctx.mapping_probe),
+            )
         };
         let write_result = {
             let _guard = fan_ctx.write_timer.guard();

--- a/crates/clinker-exec/src/executor/params.rs
+++ b/crates/clinker-exec/src/executor/params.rs
@@ -177,6 +177,16 @@ pub struct ExecutionReport {
     /// [`crate::pipeline::shutdown::ShutdownToken`]. The CLI maps this to
     /// the interrupted exit code (130). A clean run leaves it `false`.
     pub interrupted: bool,
+    /// Advisory end-of-run findings, already rendered, in Output declaration
+    /// order. Today: the per-Output `mapping:` report — **W365** for an entry
+    /// whose column no record carried, **W366** for an upstream column a mapped
+    /// output name displaced.
+    ///
+    /// Never fatal. Both describe a file that was written and is readable; by
+    /// the time a stream ends its sibling Outputs have flushed, so aborting
+    /// would leave a half-written run behind for a fault visible in the output
+    /// itself. Empty on a clean run.
+    pub advisories: Vec<String>,
 }
 
 /// Sum per-stage CPU and I/O deltas into run-level totals. Stages with `None`

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -425,6 +425,15 @@ pub(crate) fn build_format_writer(
     raw_writer: Box<dyn Write + Send>,
     schema: Arc<Schema>,
 ) -> Result<Box<dyn FormatWriter>, PipelineError> {
+    // Write-boundary E365. Every arm that opens a writer — records-only,
+    // fan-out, envelope, document-DLQ, streaming, correlation — passes through
+    // here with the schema it established from the stream's own records, so
+    // this is the one place that sees every established output schema. A
+    // `mapping:` entry whose column the stream never supplied would otherwise
+    // drop that column from the file silently; under selection semantics that
+    // is data loss, so it is refused before the first byte.
+    crate::projection::check_mapping_against_schema(&schema, output, &output.name)?;
+
     // Extract field definitions for fixed-width output (requires explicit schema).
     let field_defs = if matches!(output.format, OutputFormat::FixedWidth(_)) {
         Some(extract_output_field_defs(output)?)

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -425,15 +425,6 @@ pub(crate) fn build_format_writer(
     raw_writer: Box<dyn Write + Send>,
     schema: Arc<Schema>,
 ) -> Result<Box<dyn FormatWriter>, PipelineError> {
-    // Write-boundary E365. Every arm that opens a writer — records-only,
-    // fan-out, envelope, document-DLQ, streaming, correlation — passes through
-    // here with the schema it established from the stream's own records, so
-    // this is the one place that sees every established output schema. A
-    // `mapping:` entry whose column the stream never supplied would otherwise
-    // drop that column from the file silently; under selection semantics that
-    // is data loss, so it is refused before the first byte.
-    crate::projection::check_mapping_against_schema(&schema, output, &output.name)?;
-
     // Extract field definitions for fixed-width output (requires explicit schema).
     let field_defs = if matches!(output.format, OutputFormat::FixedWidth(_)) {
         Some(extract_output_field_defs(output)?)

--- a/crates/clinker-exec/src/executor/streaming.rs
+++ b/crates/clinker-exec/src/executor/streaming.rs
@@ -194,6 +194,19 @@ pub(crate) struct StreamingOutputTaskOutput {
     /// live `ctx`), drained through `push_dlq` in [`Self::fold_into`] once the
     /// thread is joined and the dispatcher's `ctx` is available again.
     pub(crate) dlq_pending: Vec<DlqEntry>,
+    /// This Output's `mapping:` resolution evidence, accumulated on the
+    /// streaming thread and merged into the run-wide map in [`Self::fold_into`].
+    /// Merged rather than replaced: an Output can also receive records through
+    /// the dispatcher's arms, and only the union answers "did any record carry
+    /// this column".
+    pub(crate) mapping_probe: crate::projection::MappingProbe,
+    /// The Output this task wrote, so the fold can key the probe without
+    /// reaching back into the consumer's `spec`.
+    pub(crate) output_name: String,
+    /// This Output's config, so the fold can size a probe entry the dispatcher
+    /// arms never created. Owned for the same reason the rest of
+    /// [`StreamingOutputSpec`] is: the thread outlives the borrow.
+    pub(crate) out_cfg: OutputConfig,
 }
 
 impl StreamingOutputTaskOutput {
@@ -230,6 +243,7 @@ impl StreamingOutputTaskOutput {
         for sm in self.stage_metrics {
             ctx.collector.record(sm);
         }
+        ctx.merge_mapping_probe(&self.output_name, &self.out_cfg, &self.mapping_probe);
     }
 }
 
@@ -356,6 +370,9 @@ struct OutputStreamConsumer {
 impl OutputStreamConsumer {
     fn new(raw_writer: Box<dyn Write + Send>, spec: StreamingOutputSpec) -> Self {
         let structured_guard = StructuredOutputDocumentGuard::new(&spec.out_cfg.format);
+        let mapping_probe = crate::projection::MappingProbe::for_config(&spec.out_cfg);
+        let output_name = spec.output_name.clone();
+        let out_cfg = spec.out_cfg.clone();
         Self {
             spec,
             out: StreamingOutputTaskOutput {
@@ -367,6 +384,9 @@ impl OutputStreamConsumer {
                 errors: Vec::new(),
                 stage_metrics: Vec::new(),
                 dlq_pending: Vec::new(),
+                mapping_probe,
+                output_name,
+                out_cfg,
             },
             scan_timer_slot: Some(stage_metrics::StageTimer::new(
                 stage_metrics::StageName::SchemaScan,
@@ -380,8 +400,6 @@ impl OutputStreamConsumer {
 
 impl StreamingConsumer for OutputStreamConsumer {
     fn on_record(&mut self, record: Record, row_num: u64) -> ControlFlow<()> {
-        use crate::projection::project_output_from_record;
-
         let cxl_emit_names_opt: Option<&[String]> = if self.spec.cxl_emit_names.is_empty() {
             None
         } else {
@@ -411,7 +429,12 @@ impl StreamingConsumer for OutputStreamConsumer {
 
         let projected = {
             let _guard = self.out.projection_timer.guard();
-            project_output_from_record(&record, &self.spec.out_cfg, cxl_emit_names_opt)
+            crate::projection::project_output_probed(
+                &record,
+                &self.spec.out_cfg,
+                cxl_emit_names_opt,
+                Some(&mut self.out.mapping_probe),
+            )
         };
 
         // Lazy writer construction: defer until we have the first record's

--- a/crates/clinker-exec/src/executor/streaming.rs
+++ b/crates/clinker-exec/src/executor/streaming.rs
@@ -429,12 +429,20 @@ impl StreamingConsumer for OutputStreamConsumer {
 
         let projected = {
             let _guard = self.out.projection_timer.guard();
-            crate::projection::project_output_probed(
-                &record,
-                &self.spec.out_cfg,
-                cxl_emit_names_opt,
-                Some(&mut self.out.mapping_probe),
-            )
+            if self.spec.out_cfg.mapping.is_some() {
+                crate::projection::project_output_staged(
+                    &record,
+                    &self.spec.out_cfg,
+                    cxl_emit_names_opt,
+                    &mut self.out.mapping_probe,
+                )
+            } else {
+                crate::projection::project_output_from_record(
+                    &record,
+                    &self.spec.out_cfg,
+                    cxl_emit_names_opt,
+                )
+            }
         };
 
         // Lazy writer construction: defer until we have the first record's
@@ -456,6 +464,9 @@ impl StreamingConsumer for OutputStreamConsumer {
                     }
                 }
                 Err(e) => {
+                    if self.spec.out_cfg.mapping.is_some() {
+                        self.out.mapping_probe.discard_staged_record();
+                    }
                     self.out.errors.push(e);
                     if let Some(timer) = self.scan_timer_slot.take() {
                         self.out.stage_metrics.push(timer.finish(0, 0));
@@ -474,12 +485,18 @@ impl StreamingConsumer for OutputStreamConsumer {
         };
         match write_result {
             Ok(()) => {
+                if self.spec.out_cfg.mapping.is_some() {
+                    self.out.mapping_probe.commit_staged_record();
+                }
                 self.out.records_written += 1;
                 self.out.records_emitted += 1;
                 self.out.seen_row_nums.insert(row_num);
                 ControlFlow::Continue(())
             }
             Err(e) => {
+                if self.spec.out_cfg.mapping.is_some() {
+                    self.out.mapping_probe.discard_staged_record();
+                }
                 // A `join_values` `on_conflict: error` collision dead-letters the
                 // one offending record and keeps streaming (unless FailFast); the
                 // entry is drained to the DLQ when the thread is joined. Any other

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -551,6 +551,141 @@ nodes:
         );
     }
 
+    /// A record in a correlation group is not part of the delivered stream
+    /// when any peer in that group fails. Its fields therefore must not count
+    /// as evidence that a mapped column was populated in the written file.
+    #[test]
+    fn a_rejected_correlation_group_cannot_suppress_an_empty_column_report() {
+        let yaml = r#"
+pipeline:
+  name: mapping_correlation_report
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: people
+  config:
+    name: people
+    type: json
+    path: test.json
+    correlation_key: employee_id
+    schema:
+    - { name: employee_id, type: string }
+    - { name: value, type: string }
+- type: transform
+  name: parse_value
+  input: people
+  config:
+    cxl: |
+      emit employee_id = employee_id
+      emit parsed_value = value.to_int()
+- type: output
+  name: out
+  input: parse_value
+  config:
+    name: out
+    type: csv
+    path: output.csv
+    include_unmapped: true
+    mapping:
+    - employee_id
+    - optional_copy: optional
+    - displaced: employee_id
+"#;
+        let input = r#"[
+          {"employee_id":"A","value":"100","optional":"present-only-in-rejected-group","displaced":"rejected-only"},
+          {"employee_id":"A","value":"bad"},
+          {"employee_id":"B","value":"200"}
+        ]"#;
+
+        let run = run_pipeline_reporting(yaml, input).expect("the run completes");
+        assert_eq!(run.counters.records_written, 1);
+        assert!(run.output.contains("B,"), "{}", run.output);
+        assert!(!run.output.contains("A,"), "{}", run.output);
+        assert_eq!(run.advisories.len(), 1, "{:?}", run.advisories);
+        assert!(run.advisories[0].contains("W365"), "{}", run.advisories[0]);
+        assert!(
+            run.advisories[0].contains("'optional'"),
+            "the only record carrying `optional` was rejected with its group: {}",
+            run.advisories[0]
+        );
+        assert!(
+            !run.advisories
+                .iter()
+                .any(|warning| warning.contains("W366")),
+            "the only colliding passthrough was rejected with its group: {:?}",
+            run.advisories
+        );
+    }
+
+    /// An oversized correlation group is rejected before commit just like a
+    /// dirty group. Its fields cannot resolve or collide in the written file's
+    /// mapping report.
+    #[test]
+    fn an_overflowed_correlation_group_cannot_affect_mapping_advisories() {
+        let yaml = r#"
+pipeline:
+  name: mapping_correlation_overflow_report
+error_handling:
+  strategy: continue
+  max_group_buffer: 1
+nodes:
+- type: source
+  name: people
+  config:
+    name: people
+    type: json
+    path: test.json
+    correlation_key: employee_id
+    schema:
+    - { name: employee_id, type: string }
+    - { name: value, type: string }
+- type: transform
+  name: passthrough
+  input: people
+  config:
+    cxl: |
+      emit employee_id = employee_id
+      emit value = value
+- type: output
+  name: out
+  input: passthrough
+  config:
+    name: out
+    type: csv
+    path: output.csv
+    include_unmapped: true
+    mapping:
+    - employee_id
+    - optional_copy: optional
+    - displaced: employee_id
+"#;
+        let input = r#"[
+          {"employee_id":"A","value":"one","optional":"overflow-only","displaced":"overflow-only"},
+          {"employee_id":"A","value":"two"},
+          {"employee_id":"B","value":"clean"}
+        ]"#;
+
+        let run = run_pipeline_reporting(yaml, input).expect("the run completes");
+        assert_eq!(run.counters.records_written, 1);
+        assert!(run.output.contains("B,"), "{}", run.output);
+        assert!(!run.output.contains("A,"), "{}", run.output);
+        assert_eq!(run.advisories.len(), 1, "{:?}", run.advisories);
+        assert!(run.advisories[0].contains("W365"), "{}", run.advisories[0]);
+        assert!(
+            run.advisories[0].contains("'optional'"),
+            "the only record carrying `optional` was rejected on overflow: {}",
+            run.advisories[0]
+        );
+        assert!(
+            !run.advisories
+                .iter()
+                .any(|warning| warning.contains("W366")),
+            "the only colliding passthrough was rejected on overflow: {:?}",
+            run.advisories
+        );
+    }
+
     /// A genuinely heterogeneous stream, and the property the whole redesign
     /// exists for: the file's column set follows the `mapping:` block, not
     /// whichever record happened to arrive first.

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -261,7 +261,7 @@ nodes:
     exclude:
     - internal_id
     mapping:
-      full_name: employee_name
+    - employee_name: full_name
 "#;
         let csv = "first_name,last_name,department,internal_id\n\
                     Alice,Smith,Engineering,12345\n\
@@ -322,6 +322,158 @@ nodes:
 
         let records: Vec<csv::StringRecord> = reader.records().map(|r| r.unwrap()).collect();
         assert_eq!(records.len(), 3);
+    }
+
+    /// The written header line for a `mapping:` block, asserted as a whole
+    /// rather than by `contains`. Column order is the block's declaration
+    /// order, deliberately different from the upstream column order, and the
+    /// one rename is spelled `output_name: source_column`.
+    fn mapping_header(mapping_block: &str, include_unmapped: bool) -> String {
+        let yaml = format!(
+            r#"
+pipeline:
+  name: mapping_header
+nodes:
+- type: source
+  name: employees
+  config:
+    name: employees
+    type: csv
+    path: test.csv
+    options:
+      has_header: true
+    schema:
+    - {{ name: first_name, type: string }}
+    - {{ name: last_name, type: string }}
+    - {{ name: department, type: string }}
+- type: output
+  name: out
+  input: employees
+  config:
+    name: out
+    type: csv
+    path: output.csv
+    include_unmapped: {include_unmapped}
+    mapping:
+{mapping_block}
+"#
+        );
+        let csv = "first_name,last_name,department\nAlice,Smith,Engineering\n";
+        let (_, _, output) = run_pipeline(&yaml, csv).expect("pipeline must run");
+        output
+            .lines()
+            .next()
+            .expect("output must carry a header")
+            .to_string()
+    }
+
+    /// Declaration order is the output column order — including when it
+    /// disagrees with the order the columns arrive in.
+    #[test]
+    fn mapping_declaration_order_is_the_output_column_order() {
+        let header = mapping_header(
+            "    - department\n    - surname: last_name\n    - first_name\n",
+            false,
+        );
+        assert_eq!(header, "department,surname,first_name");
+    }
+
+    /// `include_unmapped: false` against a partial mapping: only the listed
+    /// columns are written.
+    #[test]
+    fn mapping_without_include_unmapped_writes_only_the_listed_columns() {
+        let header = mapping_header("    - surname: last_name\n", false);
+        assert_eq!(header, "surname");
+    }
+
+    /// `include_unmapped: true` against the same partial mapping: the listed
+    /// column comes first, then everything the block did not claim, in its
+    /// existing relative order.
+    #[test]
+    fn mapping_with_include_unmapped_appends_the_unlisted_columns() {
+        let header = mapping_header("    - surname: last_name\n", true);
+        assert_eq!(header, "surname,first_name,department");
+    }
+
+    /// One upstream column may feed two output columns. Uniqueness is required
+    /// on the output side, which the map form could not express in this
+    /// direction at all.
+    #[test]
+    fn one_source_column_may_be_written_twice_under_two_names() {
+        let header = mapping_header("    - department\n    - dept: department\n", false);
+        assert_eq!(header, "department,dept");
+    }
+
+    /// The shape the sequence form exists for: a wide output that renames one
+    /// column. Twelve bare scalars and one pair, and the rename is the only
+    /// item carrying a colon.
+    #[test]
+    fn a_wide_mapping_renaming_one_column_writes_the_declared_header() {
+        let columns = [
+            "order_id",
+            "order_date",
+            "customer_id",
+            "channel",
+            "sku",
+            "quantity",
+            "unit_price",
+            "discount_pct",
+            "gross_amount",
+            "line_total",
+            "ship_country",
+            "status",
+        ];
+        let schema: String = columns
+            .iter()
+            .map(|c| format!("    - {{ name: {c}, type: string }}\n"))
+            .collect();
+        // Identity for every column but `customer_id`, which is written as
+        // `sold_to`. Declared in upstream order so the assertion isolates the
+        // rename rather than re-testing reordering.
+        let mapping: String = columns
+            .iter()
+            .map(|c| {
+                if *c == "customer_id" {
+                    "    - sold_to: customer_id\n".to_string()
+                } else {
+                    format!("    - {c}\n")
+                }
+            })
+            .collect();
+        let yaml = format!(
+            r#"
+pipeline:
+  name: wide_mapping
+nodes:
+- type: source
+  name: orders
+  config:
+    name: orders
+    type: csv
+    path: test.csv
+    options:
+      has_header: true
+    schema:
+{schema}- type: output
+  name: out
+  input: orders
+  config:
+    name: out
+    type: csv
+    path: output.csv
+    include_unmapped: false
+    mapping:
+{mapping}"#
+        );
+        let header_row = columns.join(",");
+        let csv = format!("{header_row}\n{}\n", vec!["x"; columns.len()].join(","));
+
+        let (_, _, output) = run_pipeline(&yaml, &csv).expect("pipeline must run");
+        assert_eq!(
+            output.lines().next().expect("header"),
+            "order_id,order_date,sold_to,channel,sku,quantity,unit_price,discount_pct,\
+             gross_amount,line_total,ship_country,status"
+        );
     }
 
     // ── Phase 8 Task 8.4 exit code gate tests ─────────────────

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -77,7 +77,8 @@ mod tests {
                 | PipelineError::CombineOutputCapExceeded { .. }
                 | PipelineError::EnvelopeMultiHeaderConflict { .. }
                 | PipelineError::EnvelopeHeaderGrainUnmatched { .. }
-                | PipelineError::EnvelopeHeaderMultipleForGrain { .. },
+                | PipelineError::EnvelopeHeaderMultipleForGrain { .. }
+                | PipelineError::OutputMappingColumnMissing { .. },
             ) => 1,
             Err(
                 PipelineError::Eval(_)
@@ -474,6 +475,67 @@ nodes:
             "order_id,order_date,sold_to,channel,sku,quantity,unit_price,discount_pct,\
              gross_amount,line_total,ship_country,status"
         );
+    }
+
+    /// The write-boundary half of E365, end to end. The plan-time gate stands
+    /// down here on purpose: the source reserves the `auto_widen` sidecar and
+    /// `include_unmapped: true` expands it, so at compile time `nickname` might
+    /// genuinely arrive. It does not — and because `mapping:` SELECTS, a silent
+    /// skip would write a file missing the column the block declared. The run
+    /// must fail instead.
+    ///
+    /// This is the same guard that covers a mapping inside a composition body,
+    /// whose rows are open by construction and which the plan gate therefore
+    /// also cannot check: both reach the writer through the one dispatch arm.
+    #[test]
+    fn a_mapping_column_the_stream_never_supplies_fails_the_run() {
+        let yaml = r#"
+pipeline:
+  name: mapping_runtime_gate
+nodes:
+- type: source
+  name: people
+  config:
+    name: people
+    type: csv
+    path: test.csv
+    options:
+      has_header: true
+    schema:
+    - { name: first_name, type: string }
+- type: output
+  name: out
+  input: people
+  config:
+    name: out
+    type: csv
+    path: output.csv
+    include_unmapped: true
+    mapping:
+    - first_name
+    - nickname: goes_by
+"#;
+        let csv = "first_name\nAlice\n";
+        let err = run_pipeline(yaml, csv).expect_err("an unresolved mapping entry must fail");
+        let rendered = err.to_string();
+        assert!(rendered.contains("E365"), "{rendered}");
+        assert!(
+            rendered.contains("'goes_by'"),
+            "the message names the source column the author must correct: {rendered}"
+        );
+        assert!(
+            rendered.contains("'first_name'"),
+            "the message lists the columns that are present: {rendered}"
+        );
+        assert_eq!(exit_code(&Err(err)), 1);
+    }
+
+    /// Over-rejection guard for the same gate: a mapping every record can
+    /// satisfy runs clean and writes the declared header.
+    #[test]
+    fn a_mapping_the_stream_satisfies_runs_clean() {
+        let header = mapping_header("    - surname: last_name\n    - first_name\n", false);
+        assert_eq!(header, "surname,first_name");
     }
 
     // ── Phase 8 Task 8.4 exit code gate tests ─────────────────

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -12,6 +12,22 @@ mod tests {
         yaml: &str,
         csv_input: &str,
     ) -> Result<(clinker_record::PipelineCounters, Vec<DlqEntry>, String), PipelineError> {
+        let run = run_pipeline_reporting(yaml, csv_input)?;
+        Ok((run.counters, run.dlq, run.output))
+    }
+
+    /// What one in-memory run produced.
+    struct RunOutcome {
+        counters: clinker_record::PipelineCounters,
+        dlq: Vec<DlqEntry>,
+        output: String,
+        /// The run's advisory end-of-stream findings — the `mapping:` report.
+        advisories: Vec<String>,
+    }
+
+    /// [`run_pipeline`] plus the run's advisory findings, for the tests that
+    /// assert on the end-of-run `mapping:` report.
+    fn run_pipeline_reporting(yaml: &str, csv_input: &str) -> Result<RunOutcome, PipelineError> {
         let config = config::parse_config(yaml).unwrap();
         let output_buf = SharedBuffer::new();
 
@@ -41,8 +57,12 @@ mod tests {
         let report =
             PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
 
-        let output = output_buf.as_string();
-        Ok((report.counters, report.dlq_entries, output))
+        Ok(RunOutcome {
+            counters: report.counters,
+            dlq: report.dlq_entries,
+            output: output_buf.as_string(),
+            advisories: report.advisories,
+        })
     }
 
     /// Determine exit code from pipeline result (mirrors main.rs logic).
@@ -77,8 +97,7 @@ mod tests {
                 | PipelineError::CombineOutputCapExceeded { .. }
                 | PipelineError::EnvelopeMultiHeaderConflict { .. }
                 | PipelineError::EnvelopeHeaderGrainUnmatched { .. }
-                | PipelineError::EnvelopeHeaderMultipleForGrain { .. }
-                | PipelineError::OutputMappingColumnMissing { .. },
+                | PipelineError::EnvelopeHeaderMultipleForGrain { .. },
             ) => 1,
             Err(
                 PipelineError::Eval(_)
@@ -477,21 +496,19 @@ nodes:
         );
     }
 
-    /// The write-boundary half of E365, end to end. The plan-time gate stands
-    /// down here on purpose: the source reserves the `auto_widen` sidecar and
-    /// `include_unmapped: true` expands it, so at compile time `nickname` might
-    /// genuinely arrive. It does not — and because `mapping:` SELECTS, a silent
-    /// skip would write a file missing the column the block declared. The run
-    /// must fail instead.
+    /// A mapping entry no record resolves, end to end. The compile gate stands
+    /// down on purpose — the source reserves the `auto_widen` sidecar and
+    /// `include_unmapped: true` expands it, so `goes_by` might genuinely arrive,
+    /// and `goes_by` is not a near-miss of any declared column.
     ///
-    /// This is the same guard that covers a mapping inside a composition body,
-    /// whose rows are open by construction and which the plan gate therefore
-    /// also cannot check: both reach the writer through the one dispatch arm.
+    /// The run completes and writes the declared column, empty; the end-of-run
+    /// report names the entry. Aborting instead would kill a run whose sibling
+    /// Outputs have already flushed, over a fault that is visible in the file.
     #[test]
-    fn a_mapping_column_the_stream_never_supplies_fails_the_run() {
+    fn a_mapping_column_no_record_supplies_writes_empty_and_is_reported() {
         let yaml = r#"
 pipeline:
-  name: mapping_runtime_gate
+  name: mapping_runtime_report
 nodes:
 - type: source
   name: people
@@ -516,18 +533,190 @@ nodes:
     - nickname: goes_by
 "#;
         let csv = "first_name\nAlice\n";
-        let err = run_pipeline(yaml, csv).expect_err("an unresolved mapping entry must fail");
-        let rendered = err.to_string();
-        assert!(rendered.contains("E365"), "{rendered}");
+        let run = run_pipeline_reporting(yaml, csv).expect("the run completes");
+        let advisories = &run.advisories;
+
+        assert_eq!(run.counters.records_written, 1);
+        assert_eq!(
+            run.output, "first_name,nickname\nAlice,\n",
+            "the declared column is written, empty — the file's shape follows the block, \
+             not the data"
+        );
+        assert_eq!(advisories.len(), 1, "{advisories:?}");
+        assert!(advisories[0].contains("W365"), "{}", advisories[0]);
         assert!(
-            rendered.contains("'goes_by'"),
-            "the message names the source column the author must correct: {rendered}"
+            advisories[0].contains("'goes_by'"),
+            "the report names the source column the author must correct: {}",
+            advisories[0]
+        );
+    }
+
+    /// A genuinely heterogeneous stream, and the property the whole redesign
+    /// exists for: the file's column set follows the `mapping:` block, not
+    /// whichever record happened to arrive first.
+    ///
+    /// A JSON source because a CSV file's header fixes every record's column
+    /// set, so it cannot express a record that lacks a column. `goes_by` is
+    /// undeclared, so it reaches the sink through the `auto_widen` sidecar — on
+    /// one record and not the other. A CSV sink because its header IS the
+    /// projected column set, so the assertion reads it directly.
+    ///
+    /// Run twice, once in each record order. Under the previous skip-the-column
+    /// behaviour the sparse-first order lost `nickname` for every record, since
+    /// the header is derived from the first record's projection. The two runs
+    /// must now agree.
+    #[test]
+    fn a_heterogeneous_stream_null_fills_whatever_order_records_arrive_in() {
+        let yaml = r#"
+pipeline:
+  name: mapping_heterogeneous
+nodes:
+- type: source
+  name: people
+  config:
+    name: people
+    type: json
+    path: test.json
+    schema:
+    - { name: first_name, type: string }
+- type: output
+  name: out
+  input: people
+  config:
+    name: out
+    type: csv
+    path: output.csv
+    include_unmapped: true
+    mapping:
+    - first_name
+    - nickname: goes_by
+"#;
+
+        let dense_first = run_pipeline_reporting(
+            yaml,
+            r#"[{"first_name":"Alice","goes_by":"Al"},{"first_name":"Bob"}]"#,
+        )
+        .expect("the run completes");
+        assert_eq!(dense_first.counters.records_written, 2);
+        assert_eq!(
+            dense_first.output, "first_name,nickname\nAlice,Al\nBob,\n",
+            "the record without the column still carries it, empty"
         );
         assert!(
-            rendered.contains("'first_name'"),
-            "the message lists the columns that are present: {rendered}"
+            dense_first.advisories.is_empty(),
+            "a column some record carried is sparse, not a typo: {:?}",
+            dense_first.advisories
         );
-        assert_eq!(exit_code(&Err(err)), 1);
+
+        let sparse_first = run_pipeline_reporting(
+            yaml,
+            r#"[{"first_name":"Bob"},{"first_name":"Alice","goes_by":"Al"}]"#,
+        )
+        .expect("the run completes");
+        assert_eq!(
+            sparse_first.output, "first_name,nickname\nBob,\nAlice,Al\n",
+            "the declared column survives a first record that does not carry it"
+        );
+        assert!(
+            sparse_first.advisories.is_empty(),
+            "{:?}",
+            sparse_first.advisories
+        );
+    }
+
+    /// W366 end to end. `sold_to` is not in the source's `schema:`, so it
+    /// reaches the sink through the `auto_widen` sidecar and the plan gate
+    /// cannot see the collision with the mapping's output name. The mapped value
+    /// wins — that is deterministic and documented — and the displaced upstream
+    /// column is named rather than dropped in silence.
+    #[test]
+    fn a_passthrough_a_mapping_output_name_displaced_is_reported() {
+        let yaml = r#"
+pipeline:
+  name: mapping_collision_report
+nodes:
+- type: source
+  name: orders
+  config:
+    name: orders
+    type: csv
+    path: test.csv
+    options:
+      has_header: true
+    schema:
+    - { name: order_id, type: string }
+    - { name: customer_id, type: string }
+- type: output
+  name: out
+  input: orders
+  config:
+    name: out
+    type: csv
+    path: output.csv
+    include_unmapped: true
+    mapping:
+    - order_id
+    - sold_to: customer_id
+"#;
+        let csv = "order_id,customer_id,sold_to\nA-1,C-9,stale\n";
+        let run = run_pipeline_reporting(yaml, csv).expect("the run completes");
+        let advisories = &run.advisories;
+
+        assert_eq!(
+            run.output, "order_id,sold_to\nA-1,C-9\n",
+            "one `sold_to` column, carrying the MAPPED value"
+        );
+        assert_eq!(advisories.len(), 1, "{advisories:?}");
+        assert!(advisories[0].contains("W366"), "{}", advisories[0]);
+        assert!(
+            advisories[0].contains("'sold_to'"),
+            "the report names the displaced upstream column: {}",
+            advisories[0]
+        );
+    }
+
+    /// The narrower contrast, on the CSV path where every record shares one
+    /// column set: a column present but EMPTY on a record still resolves. An
+    /// empty value is not an absent column, so the report stays quiet.
+    #[test]
+    fn a_column_some_record_supplies_is_not_reported() {
+        let yaml = r#"
+pipeline:
+  name: mapping_sparse
+nodes:
+- type: source
+  name: people
+  config:
+    name: people
+    type: csv
+    path: test.csv
+    options:
+      has_header: true
+    on_unmapped:
+      mode: drop
+    schema:
+    - { name: first_name, type: string }
+    - { name: nickname, type: string }
+- type: output
+  name: out
+  input: people
+  config:
+    name: out
+    type: csv
+    path: output.csv
+    include_unmapped: false
+    mapping:
+    - first_name
+    - goes_by: nickname
+"#;
+        let csv = "first_name,nickname\nAlice,Al\nBob,\n";
+        let run = run_pipeline_reporting(yaml, csv).expect("the run completes");
+        assert_eq!(run.output, "first_name,goes_by\nAlice,Al\nBob,\n");
+        assert!(
+            run.advisories.is_empty(),
+            "an empty value is not an absent column: {:?}",
+            run.advisories
+        );
     }
 
     /// Over-rejection guard for the same gate: a mapping every record can

--- a/crates/clinker-exec/src/projection.rs
+++ b/crates/clinker-exec/src/projection.rs
@@ -28,7 +28,9 @@ pub fn apply_aliases(emitted: &mut IndexMap<String, Value>, aliases: &HashMap<St
 ///    add all input record fields not already emitted (the path that
 ///    surfaces `OnUnmapped::AutoWiden`-discovered columns at the sink).
 /// 2. **Exclude**: Remove any field in `exclude` list (by current name).
-/// 3. **Mapping**: Rename surviving fields per `mapping` table.
+/// 3. **Mapping**: Emit the columns `mapping` lists, in declaration
+///    order, under their declared output names; append whatever the
+///    block did not list when `include_unmapped` is set.
 pub fn project_output(
     input_record: &Record,
     emitted: &IndexMap<String, Value>,
@@ -68,12 +70,19 @@ pub fn project_output_with_meta(
 /// Output projection semantic. When `cxl_emit_names` is `None` (caller
 /// has no upstream PlanNode handle), all upstream columns survive — the
 /// permissive fallback used by tests and ad-hoc projections.
+///
+/// A declared `mapping:` overrides the `cxl_emit_names` restriction for
+/// the columns it lists: the block is the author's own statement of
+/// which columns the file carries, so a listed column is emitted whether
+/// or not the upstream transform named it in an `emit`. `include_unmapped`
+/// still governs everything the block does not list.
 pub fn project_output_from_record(
     input_record: &Record,
     config: &OutputConfig,
     cxl_emit_names: Option<&[String]>,
 ) -> Record {
-    let drop_unmapped = !config.include_unmapped && cxl_emit_names.is_some();
+    let drop_unmapped =
+        !config.include_unmapped && cxl_emit_names.is_some() && config.mapping.is_none();
     let needs_rewrite = config.exclude.is_some()
         || config.mapping.is_some()
         || config.include_unmapped
@@ -175,21 +184,68 @@ pub fn project_output_from_record(
         }
     }
 
-    if let Some(ref mapping) = config.mapping {
-        let mut renamed = IndexMap::with_capacity(fields.len());
-        for (name, value) in fields {
-            let output_name = mapping.get(&name).cloned().unwrap_or(name);
-            renamed.insert(output_name, value);
+    // `mapping:` is the ordered declaration of the columns this output
+    // carries: listed columns first, in declaration order, under their
+    // declared names, then — when `include_unmapped` is set — everything
+    // the block did not claim, in its existing relative order.
+    //
+    // Per-record cost: one probe per listed column plus one
+    // `claims_source` probe per surviving column. The claimed-source set
+    // is resolved once when the config is parsed, so nothing here
+    // allocates per record beyond the output record itself; the previous
+    // rename pass allocated a whole second `IndexMap` on every record.
+    let (names, values): (Vec<Box<str>>, Vec<Value>) = match config.mapping.as_ref() {
+        Some(mapping) => {
+            let mut names: Vec<Box<str>> = Vec::with_capacity(mapping.entries().len());
+            let mut values: Vec<Value> = Vec::with_capacity(mapping.entries().len());
+            for entry in mapping.entries() {
+                // A listed column absent from this record is skipped rather
+                // than emitted empty. The plan-time E365 gate rejects a name
+                // the graph cannot supply, so what reaches here is a column
+                // that exists in the schema but not on this row.
+                if let Some(value) = fields.get(entry.source.as_str()) {
+                    names.push(Box::<str>::from(entry.output.as_str()));
+                    values.push(value.clone());
+                }
+            }
+            if config.include_unmapped {
+                for (name, value) in fields {
+                    if !mapping.claims_source(name.as_str()) {
+                        names.push(Box::<str>::from(name.as_str()));
+                        values.push(value);
+                    }
+                }
+            } else {
+                // `include_unmapped: false` drops the unlisted USER columns.
+                // The engine-stamped correlation shadows are governed by their
+                // own flag, so a mapping must not silently defeat an explicit
+                // `include_correlation_keys: true` — they are appended after
+                // the declared columns instead. A `$`-prefixed key can only be
+                // in `fields` because that flag admitted it: `$` is a reserved
+                // engine namespace no source column may claim, the `$widened`
+                // slot was removed above, and sidecar expansion (the other
+                // source of extra keys) runs only on the branch above.
+                for (name, value) in fields {
+                    if name.starts_with('$') && !mapping.claims_source(name.as_str()) {
+                        names.push(Box::<str>::from(name.as_str()));
+                        values.push(value);
+                    }
+                }
+            }
+            (names, values)
         }
-        fields = renamed;
-    }
+        None => {
+            let mut names: Vec<Box<str>> = Vec::with_capacity(fields.len());
+            let mut values: Vec<Value> = Vec::with_capacity(fields.len());
+            for (name, value) in fields {
+                names.push(Box::<str>::from(name.as_str()));
+                values.push(value);
+            }
+            (names, values)
+        }
+    };
 
-    let schema = fields
-        .keys()
-        .map(|k| Box::<str>::from(k.as_str()))
-        .collect::<SchemaBuilder>()
-        .build();
-    let values: Vec<Value> = fields.into_values().collect();
+    let schema = names.into_iter().collect::<SchemaBuilder>().build();
     let mut out = Record::new(schema, values);
     // Same document's row after the rename/exclude rewrite — carry the
     // envelope context forward so document-reconstructing writers still
@@ -259,6 +315,7 @@ fn round_declared_output_decimals(record: &mut Record, config: &OutputConfig) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clinker_plan::config::{MappingEntry, OutputMapping};
     use clinker_record::Schema;
 
     fn make_input() -> Record {
@@ -361,13 +418,14 @@ mod tests {
         assert!(result.get("first_name").is_some());
     }
 
+    /// The direction contract: the pair is `output_name: source_column`, so
+    /// `given_name: first_name` reads `first_name` and writes `given_name`.
     #[test]
     fn test_mapping_renames() {
         let input = make_input();
         let emitted = IndexMap::new();
 
-        let mut mapping = IndexMap::new();
-        mapping.insert("first_name".to_string(), "given_name".to_string());
+        let mapping = OutputMapping::new(vec![MappingEntry::rename("given_name", "first_name")]);
 
         let config = OutputConfig {
             name: "out".into(),
@@ -512,19 +570,19 @@ mod tests {
             "sidecar payload must not be expanded — that is the include_unmapped flag"
         );
 
-        // Slow path: same flags, but force rewrite via mapping.
+        // Slow path: same flags, but force the rewrite with an `exclude:` of a
+        // column this record does not carry. A `mapping:` would force it too,
+        // but a mapping under `include_unmapped: false` emits only what it
+        // lists, which would conflate this test with the selection semantic it
+        // is not about.
         let config_slow = OutputConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),
             include_unmapped: false,
             include_header: None,
-            mapping: Some({
-                let mut m = IndexMap::new();
-                m.insert("name".into(), "person".into());
-                m
-            }),
-            exclude: None,
+            mapping: None,
+            exclude: Some(vec!["not_on_this_record".to_string()]),
             sort_order: None,
             preserve_nulls: None,
             include_correlation_keys: true,
@@ -547,13 +605,37 @@ mod tests {
             .collect();
         assert_eq!(
             cols_slow,
-            vec!["id", "person", "$ck.id"],
+            vec!["id", "name", "$ck.id"],
             "slow path: include_correlation_keys must surface $ck.* but never $widened"
         );
         assert!(
             result_slow.get("$widened").is_none(),
             "slow path: $widened must not appear on the output schema"
         );
+
+        // A `mapping:` under `include_unmapped: false` selects the USER
+        // columns; it must not silently defeat an explicit
+        // `include_correlation_keys: true`. The shadows are appended after the
+        // declared columns, and `$widened` still never appears.
+        let mut config_mapped = config_slow.clone();
+        config_mapped.exclude = None;
+        config_mapped.mapping = Some(OutputMapping::new(vec![MappingEntry::rename(
+            "person", "name",
+        )]));
+        let result_mapped = project_output_from_record(&input, &config_mapped, None);
+        let cols_mapped: Vec<&str> = result_mapped
+            .schema()
+            .columns()
+            .iter()
+            .map(|c| &**c)
+            .collect();
+        assert_eq!(
+            cols_mapped,
+            vec!["person", "$ck.id"],
+            "a mapping selects the user columns; include_correlation_keys still governs \
+             the correlation shadows"
+        );
+        assert!(result_mapped.get("$widened").is_none());
     }
 
     /// `include_unmapped: true` expands the sidecar map even when
@@ -854,13 +936,13 @@ mod tests {
             .checked_div(Decimal::from(3))
             .expect("4 / 3");
         let input = one_field_record("raw_avg", Value::Decimal(quotient));
-        let mut mapping = IndexMap::new();
-        mapping.insert("raw_avg".to_string(), "average".to_string());
         let mut config = scale_config(Some(SourceSchema::Columns(vec![decimal_col(
             "average",
             Some(2),
         )])));
-        config.mapping = Some(mapping);
+        config.mapping = Some(OutputMapping::new(vec![MappingEntry::rename(
+            "average", "raw_avg",
+        )]));
         let out = project_output_from_record(&input, &config, None);
         assert!(out.get("raw_avg").is_none(), "field was renamed");
         assert_eq!(

--- a/crates/clinker-exec/src/projection.rs
+++ b/crates/clinker-exec/src/projection.rs
@@ -81,6 +81,25 @@ pub fn project_output_from_record(
     config: &OutputConfig,
     cxl_emit_names: Option<&[String]>,
 ) -> Record {
+    project_output_probed(input_record, config, cxl_emit_names, None)
+}
+
+/// [`project_output_from_record`] with the per-Output [`MappingProbe`] the
+/// end-of-stream report is built from.
+///
+/// Every per-record projection for one Output must feed the SAME probe, or an
+/// entry that resolved only on the records routed elsewhere reads as never
+/// resolved. Callers with no stream-scoped home for one pass `None`; those are
+/// the ad-hoc and test projections, which produce no report.
+pub fn project_output_probed(
+    input_record: &Record,
+    config: &OutputConfig,
+    cxl_emit_names: Option<&[String]>,
+    mut probe: Option<&mut MappingProbe>,
+) -> Record {
+    if let Some(probe) = probe.as_deref_mut() {
+        probe.note_record();
+    }
     let drop_unmapped =
         !config.include_unmapped && cxl_emit_names.is_some() && config.mapping.is_none();
     let needs_rewrite = config.exclude.is_some()
@@ -180,88 +199,126 @@ pub fn project_output_from_record(
 
     if let Some(ref exclude_list) = config.exclude {
         for name in exclude_list {
-            fields.swap_remove(name.as_str());
+            // Order-preserving. `swap_remove` moves the map's last entry into
+            // the hole, so `a,b,c,d` minus `b` would emit `a,d,c` and break the
+            // relative order the passthrough columns are documented to keep.
+            // `exclude:` lists are author-sized, so the shift is cheap.
+            fields.shift_remove(name.as_str());
         }
     }
 
     // `mapping:` is the ordered declaration of the columns this output
-    // carries: listed columns first, in declaration order, under their
-    // declared names, then — when `include_unmapped` is set — everything
+    // carries: every listed column, in declaration order, under its
+    // declared name, then — when `include_unmapped` is set — everything
     // the block did not claim, in its existing relative order.
     //
-    // Per-record cost: one probe per listed column plus one
-    // `claims_source` probe per surviving column. Every index the loop
-    // consults is resolved once when the config is parsed, and a listed
-    // column's value is MOVED out of `fields` rather than copied — the
-    // slot is left holding a `Null` placeholder that the append loop
-    // below never reaches, because it skips claimed sources. Only a
-    // source feeding two output columns is cloned, and only for the
-    // readers before the last. So this allocates nothing per record
-    // beyond the output record itself; the previous rename pass
-    // allocated a whole second `IndexMap` on every record.
+    // A listed column absent from THIS record is written as `Value::Null`,
+    // not skipped. That is what makes the output schema a function of the
+    // config alone rather than of whichever record happened to arrive
+    // first: `mapping:` states which columns the file carries and in what
+    // order, and a column that vanishes on some rows contradicts both.
+    // Heterogeneous streams — an `auto_widen` sidecar, a multi-record-type
+    // source, a composition body's open row — are exactly the shapes where
+    // a per-record column set would otherwise leak into the file's shape.
+    //
+    // Per-record cost: one lookup per listed column plus one `claims_*`
+    // lookup per surviving column. Every index the loop consults is
+    // resolved once when the config is parsed, and a listed column's value
+    // is MOVED out of `fields` rather than copied — the slot is left
+    // holding a `Null` placeholder that the append loop below never
+    // reaches, because it skips claimed sources. Only a source feeding two
+    // output columns is cloned, and only for the readers before the last.
+    // So this allocates nothing per record beyond the output record itself.
     //
     // The placeholder trick is what keeps the append order intact:
-    // removing the slot outright would need `swap_remove` (which
-    // reorders the passthrough columns) or `shift_remove` (which is
-    // O(n) per listed column).
+    // removing the slot outright would need `swap_remove` (which reorders
+    // the passthrough columns) or a shift per listed column.
     let (names, values): (Vec<Box<str>>, Vec<Value>) = match config.mapping.as_ref() {
         Some(mapping) => {
             let mut names: Vec<Box<str>> = Vec::with_capacity(mapping.entries().len());
             let mut values: Vec<Value> = Vec::with_capacity(mapping.entries().len());
             for (index, entry) in mapping.entries().iter().enumerate() {
-                // A listed column absent from this record is skipped rather
-                // than emitted empty. The plan-time E365 gate rejects a name
-                // the graph cannot supply where it can see the column set, and
-                // the write boundary rejects one it cannot, so what reaches
-                // here is a column that exists in the schema but not on this
-                // row.
-                let Some(slot) = fields.get_mut(entry.source.as_str()) else {
-                    continue;
-                };
-                let value = if mapping.is_last_reader(index) {
-                    std::mem::replace(slot, Value::Null)
-                } else {
-                    slot.clone()
+                let value = match fields.get_mut(entry.source.as_str()) {
+                    Some(slot) => {
+                        if let Some(probe) = probe.as_deref_mut() {
+                            probe.note_resolved(index);
+                        }
+                        if mapping.is_last_reader(index) {
+                            std::mem::replace(slot, Value::Null)
+                        } else {
+                            slot.clone()
+                        }
+                    }
+                    // Absent on this row. The column is still written, empty,
+                    // so the file's shape does not depend on the data. An entry
+                    // that resolves on NO record is a typo rather than a sparse
+                    // column, and the probe's end-of-stream report says so.
+                    None => Value::Null,
                 };
                 names.push(Box::<str>::from(entry.output.as_str()));
                 values.push(value);
             }
             if config.include_unmapped {
                 for (name, value) in fields {
-                    // `claims_output` is the collision guard: a passthrough
-                    // column whose name the block already writes must not be
-                    // appended beside it. `SchemaBuilder` does not dedupe and
-                    // the schema's name index is last-write-wins, so the
-                    // appended column would answer `Record::get` for the
-                    // mapped one and serve its value under the mapped header.
-                    // The plan gate catches this where it can enumerate the
-                    // upstream columns; open rows and sidecar-expanded columns
-                    // reach here unchecked, so this guard is not redundant.
-                    if !mapping.claims_source(name.as_str())
-                        && !mapping.claims_output(name.as_str())
-                    {
-                        names.push(Box::<str>::from(name.as_str()));
-                        values.push(value);
+                    if mapping.claims_source(name.as_str()) {
+                        continue;
                     }
+                    // Collision guard: a passthrough column whose name the block
+                    // already writes must not be appended beside it.
+                    // `SchemaBuilder` does not dedupe and the schema's name
+                    // index is last-write-wins, so the appended column would
+                    // answer `Record::get` for the mapped one and serve its
+                    // value under the mapped header. The mapping is the author's
+                    // explicit statement, so the mapped column wins — but the
+                    // displaced one is recorded, because dropping real upstream
+                    // data silently is the thing this must not do. The plan gate
+                    // catches this where it can enumerate the upstream columns;
+                    // open rows and sidecar-expanded columns reach here
+                    // unchecked, so the guard is not redundant.
+                    if mapping.claims_output(name.as_str()) {
+                        if let Some(probe) = probe.as_deref_mut() {
+                            probe.note_shadowed(name.as_str());
+                        }
+                        continue;
+                    }
+                    names.push(Box::<str>::from(name.as_str()));
+                    values.push(value);
                 }
             } else {
                 // `include_unmapped: false` drops the unlisted USER columns.
                 // The engine-stamped correlation shadows are governed by their
                 // own flag, so a mapping must not silently defeat an explicit
-                // `include_correlation_keys: true` — they are appended after
-                // the declared columns instead. A `$`-prefixed key can only be
-                // in `fields` because that flag admitted it: `$` is a reserved
-                // engine namespace no source column may claim, the `$widened`
-                // slot was removed above, and sidecar expansion (the other
-                // source of extra keys) runs only on the branch above.
-                for (name, value) in fields {
-                    if name.starts_with('$')
-                        && !mapping.claims_source(name.as_str())
-                        && !mapping.claims_output(name.as_str())
-                    {
-                        names.push(Box::<str>::from(name.as_str()));
-                        values.push(value);
+                // `include_correlation_keys: true` — they are appended after the
+                // declared columns instead.
+                //
+                // Selected by FieldMetadata, never by a name prefix: `$` is not
+                // reserved on the input side, so a source column named `$id` or
+                // `$schema` (ordinary in JSON-Schema and MongoDB-shaped
+                // payloads) is a user column and must stay dropped here. The
+                // record's correlation fields sit after its user fields in
+                // schema order, which is the order `fields` was gathered in, so
+                // walking them directly preserves the append order.
+                for (name, _) in input_record.iter_correlation_fields() {
+                    if mapping.claims_source(name) {
+                        continue;
                     }
+                    if mapping.claims_output(name) {
+                        if let Some(probe) = probe.as_deref_mut() {
+                            probe.note_shadowed(name);
+                        }
+                        continue;
+                    }
+                    // `exclude:` may have removed it, and a CK column is present
+                    // in `fields` only when `include_correlation_keys` admitted
+                    // it in the first place. `swap_remove` is safe here where it
+                    // was not above: the append order comes from the record's
+                    // schema walk, not from `fields`, and `fields` is dead after
+                    // this loop.
+                    let Some(value) = fields.swap_remove(name) else {
+                        continue;
+                    };
+                    names.push(Box::<str>::from(name));
+                    values.push(value);
                 }
             }
             (names, values)
@@ -287,70 +344,144 @@ pub fn project_output_from_record(
     out
 }
 
-/// Every `mapping:` output name absent from an established output schema.
+/// Per-Output evidence about how a `mapping:` block resolved over a whole
+/// stream, and the source of its end-of-stream report.
 ///
-/// Empty for a well-formed stream. A name is missing exactly when the entry's
-/// source column was not on the records the schema was derived from, so this
-/// is the write-boundary half of **E365**: the plan-time gate answers the
-/// question wherever it can enumerate the upstream columns, and this answers it
-/// where it cannot — inside a composition body (whose rows are open by
-/// construction, and where an open tail may legitimately supply anything) and
-/// for columns that arrive only through the `auto_widen` sidecar.
+/// Exists because absence is a property of the *stream*, not of the output
+/// schema. Every record now carries every declared column (an unresolved entry
+/// writes `Value::Null`), so the schema can no longer answer "did this entry
+/// ever find its column" — and the schema was the wrong place to ask anyway: it
+/// is derived from the first record on every arm except the buffered CSV union,
+/// and a first-record-derived answer is either too strict (a legitimately sparse
+/// column aborts the run) or too loose (a column absent from every LATER record
+/// goes unreported).
 ///
-/// Checked against the SCHEMA, once per output stream, not per record: whether
-/// a column exists is a property of the stream. Under selection semantics a
-/// mapping entry that resolves to nothing deletes a column from the file, and
-/// with `include_unmapped: false` a wholly unresolvable block writes an empty
-/// header and blank rows — so silence here is data loss, not a no-op.
-pub fn missing_mapping_outputs(
-    schema: &clinker_record::Schema,
-    config: &OutputConfig,
-) -> Vec<String> {
-    let Some(mapping) = config.mapping.as_ref() else {
-        return Vec::new();
-    };
-    let present: std::collections::HashSet<&str> = schema.columns().iter().map(|c| &**c).collect();
-    let mut missing: Vec<String> = Vec::new();
-    for entry in mapping.entries() {
-        if !present.contains(entry.output.as_str()) && !missing.contains(&entry.output) {
-            missing.push(entry.output.clone());
-        }
-    }
-    missing
+/// Asking over the whole stream is precise instead. A typo is supplied by no
+/// record, so it reports; a sparse column in a heterogeneous stream is supplied
+/// by some record, so it does not.
+///
+/// Bounded: three vectors sized by the author's column count, allocated once
+/// per Output. Nothing here grows with input cardinality, and the per-record
+/// path only sets a flag.
+///
+/// Self-describing on purpose: it carries the source names it was built from
+/// rather than re-reading them out of an [`OutputConfig`] at report time. The
+/// report is produced after the dispatch walk, where the only handle left is
+/// the Output's name, and matching that name back to a config is a lookup that
+/// can miss — a miss would report one Output's entries under another's name.
+#[derive(Debug, Clone)]
+pub struct MappingProbe {
+    /// The source column each mapping entry reads, in declaration order, and
+    /// whether that source resolved on some record. Empty for an Output with
+    /// no `mapping:` block.
+    sources: Vec<Box<str>>,
+    resolved: Vec<bool>,
+    /// Passthrough column names the mapping displaced, first-seen order.
+    shadowed: Vec<Box<str>>,
+    /// Records projected through this Output. Zero means the stream was empty,
+    /// which is not evidence of anything.
+    records: u64,
 }
 
-/// Raise the write-boundary **E365** for an established output schema that the
-/// `mapping:` block does not fully cover, or `Ok(())` when it does.
-pub fn check_mapping_against_schema(
-    schema: &clinker_record::Schema,
-    config: &OutputConfig,
-    output_name: &str,
-) -> Result<(), clinker_plan::error::PipelineError> {
-    let missing = missing_mapping_outputs(schema, config);
-    if missing.is_empty() {
-        return Ok(());
-    }
-    let mapping = config
-        .mapping
-        .as_ref()
-        .expect("missing_mapping_outputs only reports names when a mapping is declared");
-    let sources: Vec<String> = missing
-        .iter()
-        .filter_map(|out| {
-            mapping
-                .entries()
+impl MappingProbe {
+    /// A probe sized for `config`'s mapping block. Cheap for an Output with no
+    /// `mapping:` — it allocates nothing and reports nothing.
+    pub fn for_config(config: &OutputConfig) -> Self {
+        let sources: Vec<Box<str>> = config.mapping.as_ref().map_or_else(Vec::new, |m| {
+            m.entries()
                 .iter()
-                .find(|e| &e.output == out)
-                .map(|e| e.source.clone())
-        })
-        .collect();
-    Err(
-        clinker_plan::error::PipelineError::OutputMappingColumnMissing {
-            output: output_name.to_string(),
-            columns: sources,
-            available: schema.columns().iter().map(|c| c.to_string()).collect(),
-        },
-    )
+                .map(|e| Box::<str>::from(e.source.as_str()))
+                .collect()
+        });
+        Self {
+            resolved: vec![false; sources.len()],
+            sources,
+            shadowed: Vec::new(),
+            records: 0,
+        }
+    }
+
+    fn note_record(&mut self) {
+        self.records = self.records.saturating_add(1);
+    }
+
+    fn note_resolved(&mut self, index: usize) {
+        if let Some(slot) = self.resolved.get_mut(index) {
+            *slot = true;
+        }
+    }
+
+    fn note_shadowed(&mut self, column: &str) {
+        if !self.shadowed.iter().any(|c| &**c == column) {
+            self.shadowed.push(Box::from(column));
+        }
+    }
+
+    /// Fold another probe for the same Output into this one. Used where an
+    /// Output's records are projected off the dispatcher's thread — the
+    /// streaming arm accumulates locally and folds back once joined.
+    ///
+    /// Both sides are built from the same Output's block, so their entry
+    /// vectors agree; `zip` stopping at the shorter one is the safe reading of
+    /// a disagreement, not a silent truncation of a real signal.
+    pub fn merge(&mut self, other: &MappingProbe) {
+        self.records = self.records.saturating_add(other.records);
+        for (slot, hit) in self.resolved.iter_mut().zip(other.resolved.iter()) {
+            *slot |= *hit;
+        }
+        for column in &other.shadowed {
+            self.note_shadowed(column);
+        }
+    }
+
+    /// The advisory findings for one Output, empty when the block resolved
+    /// cleanly.
+    ///
+    /// Advisory, never fatal: by the time a stream ends its sibling Outputs have
+    /// written, so aborting here would leave a half-written run behind for a
+    /// fault that is visible in the file itself.
+    pub fn findings(&self, output_name: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        // An empty stream resolves nothing and proves nothing.
+        if self.records == 0 {
+            return out;
+        }
+        // Duplicated source names collapse: two entries reading the same missing
+        // column are one thing for the author to fix.
+        let mut unresolved: Vec<&str> = Vec::new();
+        for (index, source) in self.sources.iter().enumerate() {
+            if !self.resolved[index] && !unresolved.contains(&&**source) {
+                unresolved.push(source);
+            }
+        }
+        if !unresolved.is_empty() {
+            let listed = unresolved
+                .iter()
+                .map(|c| format!("'{c}'"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            out.push(format!(
+                "W365 output '{output_name}': `mapping:` reads column(s) {listed}, which no \
+                 record carried — those output columns are empty in every row. Check the \
+                 spelling, or remove the item if the column is gone from upstream"
+            ));
+        }
+        if !self.shadowed.is_empty() {
+            let listed = self
+                .shadowed
+                .iter()
+                .map(|c| format!("'{c}'"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            out.push(format!(
+                "W366 output '{output_name}': upstream column(s) {listed} were dropped because \
+                 `mapping:` writes an output column of the same name; the mapped value is what \
+                 the file carries. Rename the mapped column, or add the upstream name to this \
+                 output's `exclude:` to state the intent"
+            ));
+        }
+        out
+    }
 }
 
 /// Enforce a declared output-column `scale` at the write boundary: each
@@ -811,6 +942,18 @@ mod tests {
         assert_eq!(out.get("bee"), Some(&Value::Integer(2)));
         assert_eq!(out.get("c"), Some(&Value::Integer(3)));
         assert_eq!(out.get("d"), Some(&Value::Integer(4)));
+
+        // `exclude:` removes from the same map and must preserve order too. A
+        // `swap_remove` here would pull `d` into `b`'s slot and emit `x,d,c`.
+        let mut excluding = fast_path_output_config(false);
+        excluding.include_unmapped = true;
+        excluding.exclude = Some(vec!["b".to_string()]);
+        excluding.mapping = Some(OutputMapping::new(vec![MappingEntry::rename("x", "a")]));
+        let out = project_output_from_record(&input, &excluding, None);
+        let cols: Vec<&str> = out.schema().columns().iter().map(|c| &**c).collect();
+        assert_eq!(cols, vec!["x", "c", "d"]);
+        assert_eq!(out.get("c"), Some(&Value::Integer(3)));
+        assert_eq!(out.get("d"), Some(&Value::Integer(4)));
     }
 
     /// One source column feeding two output columns: the earlier reader copies,
@@ -873,44 +1016,152 @@ mod tests {
         );
     }
 
-    /// The write-boundary half of E365: a mapping entry whose column the stream
-    /// never supplied leaves its output name off the established schema, and
-    /// that is refused rather than written as a file missing a column.
+    fn one_field(name: &str, value: Value) -> Record {
+        Record::new(SchemaBuilder::new().with_field(name).build(), vec![value])
+    }
+
+    /// The core of the redesign: a record missing a mapped source still carries
+    /// the declared column, empty. The output schema is a function of the
+    /// config, not of whichever record arrived first.
     #[test]
-    fn missing_mapping_output_is_reported_against_an_established_schema() {
+    fn an_absent_mapping_source_yields_a_null_column_not_a_missing_one() {
         let mut config = fast_path_output_config(false);
         config.include_unmapped = false;
         config.mapping = Some(OutputMapping::new(vec![
             MappingEntry::passthrough("id"),
-            MappingEntry::rename("given_name", "firstname"),
+            MappingEntry::rename("given_name", "first_name"),
         ]));
-        let established = Schema::new(vec!["id".into()]);
 
-        assert_eq!(
-            missing_mapping_outputs(&established, &config),
-            vec!["given_name".to_string()]
+        // A record carrying both, and a record carrying only `id` — the shape a
+        // heterogeneous stream produces.
+        let full = Record::new(
+            SchemaBuilder::new()
+                .with_field("id")
+                .with_field("first_name")
+                .build(),
+            vec![Value::Integer(1), Value::String("Alice".into())],
         );
-        let err = check_mapping_against_schema(&established, &config, "out")
-            .expect_err("an unresolved entry must be refused");
-        let rendered = err.to_string();
-        assert!(rendered.contains("E365"), "{rendered}");
+        let sparse = one_field("id", Value::Integer(2));
+
+        let a = project_output_from_record(&full, &config, None);
+        let b = project_output_from_record(&sparse, &config, None);
+
+        let cols = |r: &Record| -> Vec<String> {
+            r.schema().columns().iter().map(|c| c.to_string()).collect()
+        };
+        assert_eq!(cols(&a), vec!["id", "given_name"]);
+        assert_eq!(
+            cols(&b),
+            cols(&a),
+            "every record must project the same declared column set, whatever it carries"
+        );
+        assert_eq!(b.get("given_name"), Some(&Value::Null));
+    }
+
+    /// The probe distinguishes a typo from a sparse column. `first_name`
+    /// resolved on one of the two records, so it is not reported; `nickname`
+    /// resolved on neither, so it is.
+    #[test]
+    fn the_probe_reports_only_entries_no_record_resolved() {
+        let mut config = fast_path_output_config(false);
+        config.include_unmapped = false;
+        config.mapping = Some(OutputMapping::new(vec![
+            MappingEntry::passthrough("first_name"),
+            MappingEntry::rename("goes_by", "nickname"),
+        ]));
+
+        let mut probe = MappingProbe::for_config(&config);
+        let with_name = one_field("first_name", Value::String("Alice".into()));
+        let without = one_field("other", Value::Integer(1));
+        project_output_probed(&without, &config, None, Some(&mut probe));
+        project_output_probed(&with_name, &config, None, Some(&mut probe));
+
+        let findings = probe.findings("out");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert!(findings[0].contains("W365"), "{}", findings[0]);
         assert!(
-            rendered.contains("'firstname'"),
-            "the message names the SOURCE column the author has to correct: {rendered}"
+            findings[0].contains("'nickname'"),
+            "names the unresolved source column: {}",
+            findings[0]
+        );
+        assert!(
+            !findings[0].contains("'first_name'"),
+            "a column some record carried is sparse, not a typo: {}",
+            findings[0]
         );
     }
 
-    /// Over-rejection guard for the same check: a fully covered schema passes.
+    /// An empty stream resolves nothing and proves nothing — it must not warn.
     #[test]
-    fn a_fully_resolved_mapping_passes_the_write_boundary_check() {
+    fn the_probe_stays_silent_on_an_empty_stream() {
         let mut config = fast_path_output_config(false);
         config.mapping = Some(OutputMapping::new(vec![MappingEntry::rename(
-            "given_name",
-            "first_name",
+            "goes_by", "nickname",
         )]));
-        let established = Schema::new(vec!["given_name".into(), "id".into()]);
-        assert!(missing_mapping_outputs(&established, &config).is_empty());
-        assert!(check_mapping_against_schema(&established, &config, "out").is_ok());
+        let probe = MappingProbe::for_config(&config);
+        assert!(probe.findings("out").is_empty());
+    }
+
+    /// The displaced passthrough is reported rather than dropped in silence.
+    #[test]
+    fn the_probe_reports_a_passthrough_the_mapping_displaced() {
+        let mut config = fast_path_output_config(false);
+        config.include_unmapped = true;
+        config.mapping = Some(OutputMapping::new(vec![MappingEntry::rename(
+            "sold_to", "customer",
+        )]));
+        let input = Record::new(
+            SchemaBuilder::new()
+                .with_field("customer")
+                .with_field("sold_to")
+                .build(),
+            vec![Value::String("right".into()), Value::String("stale".into())],
+        );
+
+        let mut probe = MappingProbe::for_config(&config);
+        let out = project_output_probed(&input, &config, None, Some(&mut probe));
+        assert_eq!(out.get("sold_to"), Some(&Value::String("right".into())));
+
+        let findings = probe.findings("out");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert!(findings[0].contains("W366"), "{}", findings[0]);
+        assert!(findings[0].contains("'sold_to'"), "{}", findings[0]);
+    }
+
+    /// A user column named `$id` — ordinary in JSON-Schema and MongoDB-shaped
+    /// payloads — is a user column, not an engine one, so `include_unmapped:
+    /// false` drops it like any other unlisted column. Engine-stamped fields
+    /// are selected by metadata; a `$` prefix proves nothing.
+    #[test]
+    fn a_dollar_prefixed_user_column_is_not_treated_as_engine_stamped() {
+        use clinker_record::FieldMetadata;
+        let schema = SchemaBuilder::new()
+            .with_field("$id")
+            .with_field("name")
+            .with_field_meta("$ck.name", FieldMetadata::source_correlation("name"))
+            .build();
+        let input = Record::new(
+            schema,
+            vec![
+                Value::String("doc-1".into()),
+                Value::String("Alice".into()),
+                Value::String("Alice".into()),
+            ],
+        );
+        let mut config = fast_path_output_config(true);
+        config.include_unmapped = false;
+        config.mapping = Some(OutputMapping::new(vec![MappingEntry::rename(
+            "person", "name",
+        )]));
+
+        let out = project_output_from_record(&input, &config, None);
+        let cols: Vec<&str> = out.schema().columns().iter().map(|c| &**c).collect();
+        assert_eq!(
+            cols,
+            vec!["person", "$ck.name"],
+            "`$id` is a user column and stays dropped; only the metadata-stamped \
+             correlation shadow rides the include_correlation_keys flag"
+        );
     }
 
     /// `include_unmapped: true` expands the sidecar map even when

--- a/crates/clinker-exec/src/projection.rs
+++ b/crates/clinker-exec/src/projection.rs
@@ -190,27 +190,56 @@ pub fn project_output_from_record(
     // the block did not claim, in its existing relative order.
     //
     // Per-record cost: one probe per listed column plus one
-    // `claims_source` probe per surviving column. The claimed-source set
-    // is resolved once when the config is parsed, so nothing here
-    // allocates per record beyond the output record itself; the previous
-    // rename pass allocated a whole second `IndexMap` on every record.
+    // `claims_source` probe per surviving column. Every index the loop
+    // consults is resolved once when the config is parsed, and a listed
+    // column's value is MOVED out of `fields` rather than copied — the
+    // slot is left holding a `Null` placeholder that the append loop
+    // below never reaches, because it skips claimed sources. Only a
+    // source feeding two output columns is cloned, and only for the
+    // readers before the last. So this allocates nothing per record
+    // beyond the output record itself; the previous rename pass
+    // allocated a whole second `IndexMap` on every record.
+    //
+    // The placeholder trick is what keeps the append order intact:
+    // removing the slot outright would need `swap_remove` (which
+    // reorders the passthrough columns) or `shift_remove` (which is
+    // O(n) per listed column).
     let (names, values): (Vec<Box<str>>, Vec<Value>) = match config.mapping.as_ref() {
         Some(mapping) => {
             let mut names: Vec<Box<str>> = Vec::with_capacity(mapping.entries().len());
             let mut values: Vec<Value> = Vec::with_capacity(mapping.entries().len());
-            for entry in mapping.entries() {
+            for (index, entry) in mapping.entries().iter().enumerate() {
                 // A listed column absent from this record is skipped rather
                 // than emitted empty. The plan-time E365 gate rejects a name
-                // the graph cannot supply, so what reaches here is a column
-                // that exists in the schema but not on this row.
-                if let Some(value) = fields.get(entry.source.as_str()) {
-                    names.push(Box::<str>::from(entry.output.as_str()));
-                    values.push(value.clone());
-                }
+                // the graph cannot supply where it can see the column set, and
+                // the write boundary rejects one it cannot, so what reaches
+                // here is a column that exists in the schema but not on this
+                // row.
+                let Some(slot) = fields.get_mut(entry.source.as_str()) else {
+                    continue;
+                };
+                let value = if mapping.is_last_reader(index) {
+                    std::mem::replace(slot, Value::Null)
+                } else {
+                    slot.clone()
+                };
+                names.push(Box::<str>::from(entry.output.as_str()));
+                values.push(value);
             }
             if config.include_unmapped {
                 for (name, value) in fields {
-                    if !mapping.claims_source(name.as_str()) {
+                    // `claims_output` is the collision guard: a passthrough
+                    // column whose name the block already writes must not be
+                    // appended beside it. `SchemaBuilder` does not dedupe and
+                    // the schema's name index is last-write-wins, so the
+                    // appended column would answer `Record::get` for the
+                    // mapped one and serve its value under the mapped header.
+                    // The plan gate catches this where it can enumerate the
+                    // upstream columns; open rows and sidecar-expanded columns
+                    // reach here unchecked, so this guard is not redundant.
+                    if !mapping.claims_source(name.as_str())
+                        && !mapping.claims_output(name.as_str())
+                    {
                         names.push(Box::<str>::from(name.as_str()));
                         values.push(value);
                     }
@@ -226,7 +255,10 @@ pub fn project_output_from_record(
                 // slot was removed above, and sidecar expansion (the other
                 // source of extra keys) runs only on the branch above.
                 for (name, value) in fields {
-                    if name.starts_with('$') && !mapping.claims_source(name.as_str()) {
+                    if name.starts_with('$')
+                        && !mapping.claims_source(name.as_str())
+                        && !mapping.claims_output(name.as_str())
+                    {
                         names.push(Box::<str>::from(name.as_str()));
                         values.push(value);
                     }
@@ -253,6 +285,72 @@ pub fn project_output_from_record(
     out.set_doc_ctx(Arc::clone(input_record.doc_ctx()));
     round_declared_output_decimals(&mut out, config);
     out
+}
+
+/// Every `mapping:` output name absent from an established output schema.
+///
+/// Empty for a well-formed stream. A name is missing exactly when the entry's
+/// source column was not on the records the schema was derived from, so this
+/// is the write-boundary half of **E365**: the plan-time gate answers the
+/// question wherever it can enumerate the upstream columns, and this answers it
+/// where it cannot — inside a composition body (whose rows are open by
+/// construction, and where an open tail may legitimately supply anything) and
+/// for columns that arrive only through the `auto_widen` sidecar.
+///
+/// Checked against the SCHEMA, once per output stream, not per record: whether
+/// a column exists is a property of the stream. Under selection semantics a
+/// mapping entry that resolves to nothing deletes a column from the file, and
+/// with `include_unmapped: false` a wholly unresolvable block writes an empty
+/// header and blank rows — so silence here is data loss, not a no-op.
+pub fn missing_mapping_outputs(
+    schema: &clinker_record::Schema,
+    config: &OutputConfig,
+) -> Vec<String> {
+    let Some(mapping) = config.mapping.as_ref() else {
+        return Vec::new();
+    };
+    let present: std::collections::HashSet<&str> = schema.columns().iter().map(|c| &**c).collect();
+    let mut missing: Vec<String> = Vec::new();
+    for entry in mapping.entries() {
+        if !present.contains(entry.output.as_str()) && !missing.contains(&entry.output) {
+            missing.push(entry.output.clone());
+        }
+    }
+    missing
+}
+
+/// Raise the write-boundary **E365** for an established output schema that the
+/// `mapping:` block does not fully cover, or `Ok(())` when it does.
+pub fn check_mapping_against_schema(
+    schema: &clinker_record::Schema,
+    config: &OutputConfig,
+    output_name: &str,
+) -> Result<(), clinker_plan::error::PipelineError> {
+    let missing = missing_mapping_outputs(schema, config);
+    if missing.is_empty() {
+        return Ok(());
+    }
+    let mapping = config
+        .mapping
+        .as_ref()
+        .expect("missing_mapping_outputs only reports names when a mapping is declared");
+    let sources: Vec<String> = missing
+        .iter()
+        .filter_map(|out| {
+            mapping
+                .entries()
+                .iter()
+                .find(|e| &e.output == out)
+                .map(|e| e.source.clone())
+        })
+        .collect();
+    Err(
+        clinker_plan::error::PipelineError::OutputMappingColumnMissing {
+            output: output_name.to_string(),
+            columns: sources,
+            available: schema.columns().iter().map(|c| c.to_string()).collect(),
+        },
+    )
 }
 
 /// Enforce a declared output-column `scale` at the write boundary: each
@@ -636,6 +734,183 @@ mod tests {
              the correlation shadows"
         );
         assert!(result_mapped.get("$widened").is_none());
+
+        // Same combination with a `cxl_emit_names` list supplied — the term
+        // `drop_unmapped` gained when a declared mapping started overriding the
+        // emit-name restriction. Without a mapping the restriction would cut
+        // this to the emitted names alone; with one, the mapping decides the
+        // user columns and the CK shadow still rides the `include_correlation_keys`
+        // flag. A regression here silently adds or removes an engine-namespaced
+        // column from a delivered file.
+        let emit_names = vec!["id".to_string()];
+        let result_emit =
+            project_output_from_record(&input, &config_mapped, Some(emit_names.as_slice()));
+        let cols_emit: Vec<&str> = result_emit
+            .schema()
+            .columns()
+            .iter()
+            .map(|c| &**c)
+            .collect();
+        assert_eq!(
+            cols_emit,
+            vec!["person", "$ck.id"],
+            "a declared mapping overrides the cxl-emit-name restriction for the columns it \
+             lists, and include_correlation_keys still governs the shadows"
+        );
+
+        // The contrast case that makes the clause load-bearing: drop the
+        // mapping and the same emit-name list DOES restrict the output.
+        let mut config_no_mapping = config_mapped.clone();
+        config_no_mapping.mapping = None;
+        let result_no_mapping =
+            project_output_from_record(&input, &config_no_mapping, Some(emit_names.as_slice()));
+        let cols_no_mapping: Vec<&str> = result_no_mapping
+            .schema()
+            .columns()
+            .iter()
+            .map(|c| &**c)
+            .collect();
+        assert_eq!(
+            cols_no_mapping,
+            vec!["id"],
+            "without a mapping, `include_unmapped: false` restricts to the emitted names"
+        );
+    }
+
+    /// Column ORDER of the appended passthrough columns, pinned against the
+    /// value-move optimisation. Taking a mapped value out of the gathered map
+    /// leaves a placeholder rather than removing the slot, precisely so the
+    /// remaining columns keep their relative order — `IndexMap::swap_remove`
+    /// would move the last column into the hole and reorder the file's header.
+    #[test]
+    fn passthrough_columns_keep_their_relative_order_around_a_mapped_column() {
+        let schema = SchemaBuilder::new()
+            .with_field("a")
+            .with_field("b")
+            .with_field("c")
+            .with_field("d")
+            .build();
+        let input = Record::new(
+            schema,
+            vec![
+                Value::Integer(1),
+                Value::Integer(2),
+                Value::Integer(3),
+                Value::Integer(4),
+            ],
+        );
+        let mut config = fast_path_output_config(false);
+        config.include_unmapped = true;
+        // Claim a column from the MIDDLE: a swap-remove would pull `d` into
+        // `b`'s slot and emit `a, d, c` instead of `a, c, d`.
+        config.mapping = Some(OutputMapping::new(vec![MappingEntry::rename("bee", "b")]));
+
+        let out = project_output_from_record(&input, &config, None);
+        let cols: Vec<&str> = out.schema().columns().iter().map(|c| &**c).collect();
+        assert_eq!(cols, vec!["bee", "a", "c", "d"]);
+        assert_eq!(out.get("bee"), Some(&Value::Integer(2)));
+        assert_eq!(out.get("c"), Some(&Value::Integer(3)));
+        assert_eq!(out.get("d"), Some(&Value::Integer(4)));
+    }
+
+    /// One source column feeding two output columns: the earlier reader copies,
+    /// the last reader takes. Both must carry the real value — a take-then-read
+    /// ordering bug would serve the second column a `Null`.
+    #[test]
+    fn a_source_read_twice_delivers_its_value_to_both_output_columns() {
+        let schema = SchemaBuilder::new().with_field("sku").build();
+        let input = Record::new(schema, vec![Value::String("A-1".into())]);
+        let mut config = fast_path_output_config(false);
+        config.include_unmapped = false;
+        config.mapping = Some(OutputMapping::new(vec![
+            MappingEntry::passthrough("sku"),
+            MappingEntry::rename("item_code", "sku"),
+        ]));
+
+        let out = project_output_from_record(&input, &config, None);
+        let cols: Vec<&str> = out.schema().columns().iter().map(|c| &**c).collect();
+        assert_eq!(cols, vec!["sku", "item_code"]);
+        assert_eq!(out.get("sku"), Some(&Value::String("A-1".into())));
+        assert_eq!(out.get("item_code"), Some(&Value::String("A-1".into())));
+    }
+
+    /// An output name that an appended passthrough column would duplicate: the
+    /// mapped column wins and the passthrough is dropped. Two same-named columns
+    /// on one schema resolve last-write-wins through `Record::get`, so appending
+    /// it would serve the passthrough's value under the mapped header.
+    #[test]
+    fn a_passthrough_column_never_shadows_a_mapped_output_name() {
+        let schema = SchemaBuilder::new()
+            .with_field("order_id")
+            .with_field("customer")
+            .with_field("sold_to")
+            .build();
+        let input = Record::new(
+            schema,
+            vec![
+                Value::Integer(7),
+                Value::String("the-right-value".into()),
+                Value::String("the-stale-value".into()),
+            ],
+        );
+        let mut config = fast_path_output_config(false);
+        config.include_unmapped = true;
+        config.mapping = Some(OutputMapping::new(vec![MappingEntry::rename(
+            "sold_to", "customer",
+        )]));
+
+        let out = project_output_from_record(&input, &config, None);
+        let cols: Vec<&str> = out.schema().columns().iter().map(|c| &**c).collect();
+        assert_eq!(
+            cols,
+            vec!["sold_to", "order_id"],
+            "the upstream `sold_to` must not be appended beside the mapped one"
+        );
+        assert_eq!(
+            out.get("sold_to"),
+            Some(&Value::String("the-right-value".into())),
+            "the mapped value must be what the column resolves to"
+        );
+    }
+
+    /// The write-boundary half of E365: a mapping entry whose column the stream
+    /// never supplied leaves its output name off the established schema, and
+    /// that is refused rather than written as a file missing a column.
+    #[test]
+    fn missing_mapping_output_is_reported_against_an_established_schema() {
+        let mut config = fast_path_output_config(false);
+        config.include_unmapped = false;
+        config.mapping = Some(OutputMapping::new(vec![
+            MappingEntry::passthrough("id"),
+            MappingEntry::rename("given_name", "firstname"),
+        ]));
+        let established = Schema::new(vec!["id".into()]);
+
+        assert_eq!(
+            missing_mapping_outputs(&established, &config),
+            vec!["given_name".to_string()]
+        );
+        let err = check_mapping_against_schema(&established, &config, "out")
+            .expect_err("an unresolved entry must be refused");
+        let rendered = err.to_string();
+        assert!(rendered.contains("E365"), "{rendered}");
+        assert!(
+            rendered.contains("'firstname'"),
+            "the message names the SOURCE column the author has to correct: {rendered}"
+        );
+    }
+
+    /// Over-rejection guard for the same check: a fully covered schema passes.
+    #[test]
+    fn a_fully_resolved_mapping_passes_the_write_boundary_check() {
+        let mut config = fast_path_output_config(false);
+        config.mapping = Some(OutputMapping::new(vec![MappingEntry::rename(
+            "given_name",
+            "first_name",
+        )]));
+        let established = Schema::new(vec!["given_name".into(), "id".into()]);
+        assert!(missing_mapping_outputs(&established, &config).is_empty());
+        assert!(check_mapping_against_schema(&established, &config, "out").is_ok());
     }
 
     /// `include_unmapped: true` expands the sidecar map even when

--- a/crates/clinker-exec/src/projection.rs
+++ b/crates/clinker-exec/src/projection.rs
@@ -344,6 +344,24 @@ pub fn project_output_probed(
     out
 }
 
+/// Project one record while staging its mapping evidence until the caller
+/// knows whether the writer accepted it.
+///
+/// The scratch flags live on `probe` and are reused for every record, so this
+/// adds no record-rate allocation and does not repeat the mapping lookups the
+/// projection already performs. Call exactly one of
+/// [`MappingProbe::commit_staged_record`] or
+/// [`MappingProbe::discard_staged_record`] before staging another record.
+pub(crate) fn project_output_staged(
+    input_record: &Record,
+    config: &OutputConfig,
+    cxl_emit_names: Option<&[String]>,
+    probe: &mut MappingProbe,
+) -> Record {
+    probe.begin_staged_record();
+    project_output_probed(input_record, config, cxl_emit_names, Some(probe))
+}
+
 /// Per-Output evidence about how a `mapping:` block resolved over a whole
 /// stream, and the source of its end-of-stream report.
 ///
@@ -360,9 +378,9 @@ pub fn project_output_probed(
 /// record, so it reports; a sparse column in a heterogeneous stream is supplied
 /// by some record, so it does not.
 ///
-/// Bounded: three vectors sized by the author's column count, allocated once
+/// Bounded: fixed vectors sized by the author's column count, allocated once
 /// per Output. Nothing here grows with input cardinality, and the per-record
-/// path only sets a flag.
+/// path only clears and sets reusable flags.
 ///
 /// Self-describing on purpose: it carries the source names it was built from
 /// rather than re-reading them out of an [`OutputConfig`] at report time. The
@@ -375,45 +393,151 @@ pub struct MappingProbe {
     /// whether that source resolved on some record. Empty for an Output with
     /// no `mapping:` block.
     sources: Vec<Box<str>>,
+    outputs: Vec<Box<str>>,
     resolved: Vec<bool>,
-    /// Passthrough column names the mapping displaced, first-seen order.
-    shadowed: Vec<Box<str>>,
+    /// Whether each mapping output name displaced an upstream passthrough.
+    /// Parallel to `outputs`; findings preserve mapping declaration order.
+    shadowed: Vec<bool>,
     /// Records projected through this Output. Zero means the stream was empty,
     /// which is not evidence of anything.
     records: u64,
+    /// Fixed per-Output scratch used when projection precedes a fallible write.
+    /// These vectors are allocated with the probe, then cleared and reused for
+    /// every record; they never grow with input cardinality.
+    staged_resolved: Vec<bool>,
+    staged_shadowed: Vec<bool>,
+    staging: bool,
 }
 
 impl MappingProbe {
     /// A probe sized for `config`'s mapping block. Cheap for an Output with no
     /// `mapping:` — it allocates nothing and reports nothing.
     pub fn for_config(config: &OutputConfig) -> Self {
-        let sources: Vec<Box<str>> = config.mapping.as_ref().map_or_else(Vec::new, |m| {
-            m.entries()
-                .iter()
-                .map(|e| Box::<str>::from(e.source.as_str()))
-                .collect()
-        });
+        let (sources, outputs): (Vec<Box<str>>, Vec<Box<str>>) =
+            config.mapping.as_ref().map_or_else(
+                || (Vec::new(), Vec::new()),
+                |m| {
+                    m.entries()
+                        .iter()
+                        .map(|e| {
+                            (
+                                Box::<str>::from(e.source.as_str()),
+                                Box::<str>::from(e.output.as_str()),
+                            )
+                        })
+                        .unzip()
+                },
+            );
         Self {
             resolved: vec![false; sources.len()],
+            shadowed: vec![false; outputs.len()],
+            staged_resolved: vec![false; sources.len()],
+            staged_shadowed: vec![false; outputs.len()],
             sources,
-            shadowed: Vec::new(),
+            outputs,
             records: 0,
+            staging: false,
         }
     }
 
     fn note_record(&mut self) {
-        self.records = self.records.saturating_add(1);
+        if !self.staging {
+            self.records = self.records.saturating_add(1);
+        }
     }
 
     fn note_resolved(&mut self, index: usize) {
-        if let Some(slot) = self.resolved.get_mut(index) {
+        let slots = if self.staging {
+            &mut self.staged_resolved
+        } else {
+            &mut self.resolved
+        };
+        if let Some(slot) = slots.get_mut(index) {
             *slot = true;
         }
     }
 
     fn note_shadowed(&mut self, column: &str) {
-        if !self.shadowed.iter().any(|c| &**c == column) {
-            self.shadowed.push(Box::from(column));
+        let Some(index) = self.outputs.iter().position(|name| &**name == column) else {
+            return;
+        };
+        let slots = if self.staging {
+            &mut self.staged_shadowed
+        } else {
+            &mut self.shadowed
+        };
+        if let Some(slot) = slots.get_mut(index) {
+            *slot = true;
+        }
+    }
+
+    fn begin_staged_record(&mut self) {
+        debug_assert!(
+            !self.staging,
+            "previous mapping observation was not finished"
+        );
+        self.staged_resolved.fill(false);
+        self.staged_shadowed.fill(false);
+        self.staging = true;
+    }
+
+    /// Commit the evidence staged by [`project_output_staged`] after a
+    /// successful write.
+    pub(crate) fn commit_staged_record(&mut self) {
+        debug_assert!(self.staging, "no mapping observation is staged");
+        if !self.staging {
+            return;
+        }
+        self.records = self.records.saturating_add(1);
+        for (resolved, staged) in self.resolved.iter_mut().zip(&self.staged_resolved) {
+            *resolved |= *staged;
+        }
+        for (shadowed, staged) in self.shadowed.iter_mut().zip(&self.staged_shadowed) {
+            *shadowed |= *staged;
+        }
+        self.staging = false;
+    }
+
+    /// Drop the evidence staged by [`project_output_staged`] after a rejected
+    /// or dead-lettered write.
+    pub(crate) fn discard_staged_record(&mut self) {
+        debug_assert!(self.staging, "no mapping observation is staged");
+        self.staging = false;
+    }
+
+    /// Observe one record without rebuilding its projected output.
+    ///
+    /// The correlation-buffer path projects before it knows whether the group
+    /// will commit. It calls this only for clean groups at commit time so a
+    /// record later rejected to the DLQ cannot make an all-empty written
+    /// column look populated. The checks mirror the gather/exclude/mapping
+    /// visibility rules in [`project_output_probed`] and allocate no
+    /// per-record state.
+    pub(crate) fn observe_committed_record(&mut self, record: &Record, config: &OutputConfig) {
+        self.note_record();
+        let Some(mapping) = config.mapping.as_ref() else {
+            return;
+        };
+
+        for (index, entry) in mapping.entries().iter().enumerate() {
+            if projection_field_is_present(record, config, &entry.source) {
+                self.note_resolved(index);
+            }
+        }
+
+        for entry in mapping.entries() {
+            let name = entry.output.as_str();
+            if mapping.claims_source(name) {
+                continue;
+            }
+            let would_be_appended = if config.include_unmapped {
+                projection_field_is_present(record, config, name)
+            } else {
+                correlation_field_is_present(record, config, name)
+            };
+            if would_be_appended {
+                self.note_shadowed(name);
+            }
         }
     }
 
@@ -429,8 +553,8 @@ impl MappingProbe {
         for (slot, hit) in self.resolved.iter_mut().zip(other.resolved.iter()) {
             *slot |= *hit;
         }
-        for column in &other.shadowed {
-            self.note_shadowed(column);
+        for (slot, hit) in self.shadowed.iter_mut().zip(other.shadowed.iter()) {
+            *slot |= *hit;
         }
     }
 
@@ -466,9 +590,14 @@ impl MappingProbe {
                  spelling, or remove the item if the column is gone from upstream"
             ));
         }
-        if !self.shadowed.is_empty() {
-            let listed = self
-                .shadowed
+        let shadowed: Vec<&str> = self
+            .outputs
+            .iter()
+            .zip(&self.shadowed)
+            .filter_map(|(name, hit)| hit.then_some(&**name))
+            .collect();
+        if !shadowed.is_empty() {
+            let listed = shadowed
                 .iter()
                 .map(|c| format!("'{c}'"))
                 .collect::<Vec<_>>()
@@ -482,6 +611,61 @@ impl MappingProbe {
         }
         out
     }
+}
+
+/// Whether `name` is present in the temporary field map built by the output
+/// projection after its visibility and `exclude:` rules run.
+fn projection_field_is_present(record: &Record, config: &OutputConfig, name: &str) -> bool {
+    if config
+        .exclude
+        .as_ref()
+        .is_some_and(|excluded| excluded.iter().any(|column| column == name))
+    {
+        return false;
+    }
+
+    if let Some(index) = record.schema().index(name) {
+        use clinker_record::FieldMetadata;
+        match record.schema().field_metadata(index) {
+            None => return true,
+            Some(
+                FieldMetadata::SourceCorrelation { .. } | FieldMetadata::AggregateGroupIndex { .. },
+            ) => return config.include_correlation_keys,
+            Some(_) => {}
+        }
+    }
+
+    if config.include_unmapped
+        && let Some(Value::Map(sidecar)) =
+            record.get(clinker_plan::config::pipeline_node::WIDENED_SIDECAR_COLUMN)
+    {
+        return sidecar.contains_key(name);
+    }
+
+    false
+}
+
+/// Under `include_unmapped: false`, only correlation columns can be appended
+/// after the declared mapping, and only when the author explicitly opts in.
+fn correlation_field_is_present(record: &Record, config: &OutputConfig, name: &str) -> bool {
+    if !config.include_correlation_keys
+        || config
+            .exclude
+            .as_ref()
+            .is_some_and(|excluded| excluded.iter().any(|column| column == name))
+    {
+        return false;
+    }
+    let Some(index) = record.schema().index(name) else {
+        return false;
+    };
+    matches!(
+        record.schema().field_metadata(index),
+        Some(
+            clinker_record::FieldMetadata::SourceCorrelation { .. }
+                | clinker_record::FieldMetadata::AggregateGroupIndex { .. }
+        )
+    )
 }
 
 /// Enforce a declared output-column `scale` at the write boundary: each

--- a/crates/clinker-exec/tests/csv_join_values_e2e.rs
+++ b/crates/clinker-exec/tests/csv_join_values_e2e.rs
@@ -30,8 +30,10 @@ fn params() -> PipelineRunParams {
 
 /// A JSON source (native arrays) feeding a CSV sink. Row 1's `tags` array holds
 /// a value containing the join delimiter `;`; row 2 is clean.
-const JSON_INPUT: &str =
-    r#"[{"order_id":"1","tags":["a;b","c"]},{"order_id":"2","tags":["x","y"]}]"#;
+const JSON_INPUT: &str = r#"[
+  {"order_id":"1","tags":["a;b","c"],"optional":"rejected-only","displaced":"rejected-only"},
+  {"order_id":"2","tags":["x","y"]}
+]"#;
 
 fn json_reader() -> SourceReaders {
     HashMap::from([(
@@ -70,6 +72,11 @@ nodes:
       name: out
       type: csv
       path: ./out.csv
+      mapping:
+        - order_id
+        - tags
+        - optional_copy: optional
+        - displaced: order_id
 "#;
     let config = clinker_plan::config::parse_config(PIPELINE).expect("pipeline parses");
     let buf = SharedBuffer::new();
@@ -83,9 +90,13 @@ nodes:
 
     // Only the clean record reached the CSV; the colliding record did not.
     let output = String::from_utf8(buf.contents()).expect("utf-8 output");
-    assert_eq!(output, "order_id,tags\n2,x;y\n", "got: {output}");
+    assert_eq!(
+        output, "order_id,tags,optional_copy,displaced\n2,x;y,,2\n",
+        "got: {output}"
+    );
 
     assert_join_collision_entry(&report.dlq_entries);
+    assert_rejected_row_did_not_affect_mapping_advisories(&report.advisories);
     // The colliding record is counted once (as DLQ), not as both written and
     // dead-lettered: one row written/ok (row 2), one row dead-lettered (row 1).
     assert_eq!(report.counters.records_written, 1, "only row 2 was written");
@@ -127,6 +138,11 @@ nodes:
       name: out
       type: csv
       path: ./out.csv
+      mapping:
+        - order_id
+        - tags
+        - optional_copy: optional
+        - displaced: order_id
 "#;
     let config = clinker_plan::config::parse_config(PIPELINE).expect("pipeline parses");
     let buf = SharedBuffer::new();
@@ -139,12 +155,30 @@ nodes:
         .expect("run succeeds — the streaming collision dead-letters, it does not abort");
 
     let output = String::from_utf8(buf.contents()).expect("utf-8 output");
-    assert_eq!(output, "order_id,tags\n2,x;y\n", "got: {output}");
+    assert_eq!(
+        output, "order_id,tags,optional_copy,displaced\n2,x;y,,2\n",
+        "got: {output}"
+    );
 
     assert_join_collision_entry(&report.dlq_entries);
+    assert_rejected_row_did_not_affect_mapping_advisories(&report.advisories);
     assert_eq!(report.counters.records_written, 1, "only row 2 was written");
     assert_eq!(report.counters.ok_count, 1, "only row 2 is ok");
     assert_eq!(report.counters.dlq_count, 1, "row 1 collided");
+}
+
+/// The colliding row is the only one carrying `optional` and the passthrough
+/// `displaced`. Because it was dead-lettered, it neither resolves the empty
+/// mapped column nor creates a displaced-column warning for the written file.
+fn assert_rejected_row_did_not_affect_mapping_advisories(advisories: &[String]) {
+    assert_eq!(advisories.len(), 1, "{advisories:?}");
+    assert!(advisories[0].contains("W365"), "{}", advisories[0]);
+    assert!(advisories[0].contains("'optional'"), "{}", advisories[0]);
+    assert!(
+        !advisories.iter().any(|advisory| advisory.contains("W366")),
+        "a passthrough present only on the rejected row was not displaced in the file: \
+         {advisories:?}"
+    );
 }
 
 /// Exactly one `MultiValueJoinCollision` entry, naming the `tags` field and the

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -9,6 +9,7 @@ pub mod fs_type;
 pub mod multi_value;
 pub mod node_header;
 pub mod output;
+pub mod output_mapping;
 pub mod patch;
 pub mod path_template;
 pub mod pipeline;
@@ -41,6 +42,7 @@ pub use format::*;
 pub use fs_type::{FsKind, case_sensitive_dir, classify, collision_key, same_device};
 pub use node_header::{MergeHeader, NodeHeader, NodeInput, SourceHeader};
 pub use output::*;
+pub use output_mapping::{MappingEntry, OutputMapping};
 pub use patch::{
     BodySourcePatchMap, ColumnPatch, DiscriminatorPatch, EnvelopeFieldOp, NestedSectionOp,
     RecordTypeAdd, RecordTypeOp, RecordTypePatch, SchemaColumnOp, SourceConfigPatch, SplitFieldOp,

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -3,7 +3,6 @@
 use super::*;
 use clinker_format::JoinValues;
 use clinker_record::schema_def::LineSeparator;
-use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 /// Output destination configuration.
@@ -21,8 +20,14 @@ pub struct OutputConfig {
     pub include_unmapped: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_header: Option<bool>,
+    /// Ordered declaration of the columns this output writes: which columns,
+    /// under which names, in which order. Each item is a bare column name
+    /// (carried through unchanged) or a single `output_name: source_column`
+    /// pair. Declaration order is output column order; columns the block does
+    /// not list are appended after it when `include_unmapped` is `true` and
+    /// dropped when it is `false`. See [`OutputMapping`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mapping: Option<IndexMap<String, String>>,
+    pub mapping: Option<OutputMapping>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclude: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/clinker-plan/src/config/output_mapping.rs
+++ b/crates/clinker-plan/src/config/output_mapping.rs
@@ -72,8 +72,8 @@ impl MappingEntry {
 
 /// An Output node's ordered `mapping:` declaration.
 ///
-/// Construct from an entry list with [`OutputMapping::new`]; the claimed-source
-/// index is derived once there and kept in step with `entries` because both
+/// Construct from an entry list with [`OutputMapping::new`]; every derived
+/// index is computed once there and kept in step with `entries` because all
 /// fields are private.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputMapping {
@@ -83,6 +83,19 @@ pub struct OutputMapping {
     /// per-record allocation, which is what keeps the unlisted-column append
     /// off the record-rate allocation path.
     claimed: HashSet<Box<str>>,
+    /// Every name some entry writes. The unlisted-column append consults it so
+    /// a passthrough column cannot land under a name the block already
+    /// declared — two same-named columns on one schema resolve last-write-wins
+    /// through `Record::get`, which would serve the passthrough's value under
+    /// the renamed column's header.
+    claimed_outputs: HashSet<Box<str>>,
+    /// Per entry, whether it is the LAST one reading its source column. The
+    /// projection pass moves the value out of the gathered field map for a last
+    /// reader and clones only for the rare source feeding two output columns,
+    /// so the common path copies no `Value` per record.
+    ///
+    /// Parallel to `entries`; indexed by entry position.
+    last_reader: Vec<bool>,
     /// Capture slot for the superseded map form, read by the **E364** gate and
     /// by nothing else — the same device the retired `array_paths:` key uses.
     ///
@@ -92,31 +105,57 @@ pub struct OutputMapping {
     /// and the author's own pairs echoed back in the sequence form, rather than
     /// a bare YAML type error.
     legacy_map: Vec<(String, String)>,
+    /// Whether the block was written as a YAML map. Tracked separately from
+    /// `legacy_map` being non-empty so an EMPTY map (`mapping: {}`) is still
+    /// recognised as the superseded form rather than slipping through as a
+    /// well-formed block that happens to declare nothing.
+    map_form: bool,
 }
 
 impl OutputMapping {
-    /// Build from an ordered entry list, deriving the claimed-source index.
+    /// Build from an ordered entry list, deriving the claimed-source,
+    /// claimed-output, and last-reader indexes.
     ///
-    /// Accepts duplicate output names: rejecting them is a plan-time
-    /// diagnostic (**E364**) that carries the offending node's span, and a
-    /// `Deserialize` impl has no span to attach.
+    /// Accepts duplicate output names and an empty list: rejecting either is a
+    /// plan-time diagnostic (**E364**) that carries the offending node's span,
+    /// and a `Deserialize` impl has no span to attach.
     pub fn new(entries: Vec<MappingEntry>) -> Self {
-        let claimed = entries
+        let claimed: HashSet<Box<str>> = entries
             .iter()
             .map(|e| Box::<str>::from(e.source.as_str()))
             .collect();
+        let claimed_outputs: HashSet<Box<str>> = entries
+            .iter()
+            .map(|e| Box::<str>::from(e.output.as_str()))
+            .collect();
+        // Walk backwards so the FIRST time a source is seen from the end is its
+        // last reader in declaration order.
+        let mut seen: HashSet<&str> = HashSet::with_capacity(entries.len());
+        let mut last_reader = vec![false; entries.len()];
+        for (i, entry) in entries.iter().enumerate().rev() {
+            last_reader[i] = seen.insert(entry.source.as_str());
+        }
         Self {
             entries,
             claimed,
+            claimed_outputs,
+            last_reader,
             legacy_map: Vec::new(),
+            map_form: false,
         }
     }
 
     /// The superseded map form's pairs, when the block was written as a map.
-    /// Empty for every well-formed block. Drives the **E364** migration
-    /// diagnostic.
+    /// Empty for every well-formed block, and also for an empty map — use
+    /// [`OutputMapping::is_map_form`] to detect the shape itself.
     pub fn legacy_map_form(&self) -> &[(String, String)] {
         &self.legacy_map
+    }
+
+    /// Whether the block was written as a YAML map rather than a sequence.
+    /// True for `mapping: {}` as well as for a populated map.
+    pub fn is_map_form(&self) -> bool {
+        self.map_form
     }
 
     /// The declared entries, in declaration order — which is output order.
@@ -128,6 +167,18 @@ impl OutputMapping {
     /// pass has already placed it and must not append it a second time.
     pub fn claims_source(&self, column: &str) -> bool {
         self.claimed.contains(column)
+    }
+
+    /// True when some entry writes `column`, so an unlisted upstream column of
+    /// that name must not be appended alongside it.
+    pub fn claims_output(&self, column: &str) -> bool {
+        self.claimed_outputs.contains(column)
+    }
+
+    /// Whether the entry at `index` is the last one reading its source column,
+    /// and may therefore take the value rather than copy it.
+    pub fn is_last_reader(&self, index: usize) -> bool {
+        self.last_reader.get(index).copied().unwrap_or(true)
     }
 
     /// Output names that appear more than once, in first-duplicate order.
@@ -211,9 +262,9 @@ impl<'de> Deserialize<'de> for OutputMapping {
                     legacy_map.push(pair);
                 }
                 Ok(OutputMapping {
-                    entries: Vec::new(),
-                    claimed: HashSet::new(),
+                    map_form: true,
                     legacy_map,
+                    ..OutputMapping::new(Vec::new())
                 })
             }
         }
@@ -285,21 +336,34 @@ impl<'de> Deserialize<'de> for MappingEntry {
     }
 }
 
+/// Render a `'a', 'b'` list for a diagnostic.
+fn quoted(names: &[&str]) -> String {
+    names
+        .iter()
+        .map(|n| format!("'{n}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Every Output whose `mapping:` block is malformed or contradicts itself
 /// (**E364**).
 ///
-/// Three faults, all decidable from the Output node alone — no upstream schema
+/// Four faults, all decidable from the Output node alone — no upstream schema
 /// needed, which is why they live here rather than in the bind walk:
 ///
 /// * the superseded map form. `mapping:` was a YAML map of column name to
-///   column name; it is a sequence now. The rejection echoes the author's own
-///   pairs back in the sequence form so the fix is a paste.
+///   column name; it is a sequence now. The rejection rewrites the author's own
+///   pairs into the sequence form so the fix is a paste.
+/// * a block that declares no columns — an empty sequence or an empty map.
+///   Under `include_unmapped: false` that is a file with no columns at all, so
+///   it is malformed rather than a valid request for an empty file.
 /// * a repeated output name. A YAML map gave key uniqueness for free; a
 ///   sequence has to enforce it, and a writer cannot emit two columns under one
 ///   header.
-/// * a listed column this same output's `exclude:` removes. `exclude:` runs
-///   against the incoming column names before `mapping:` reads them, so the
-///   entry could only ever produce nothing.
+/// * a column this same output's `exclude:` removes, named on either side of an
+///   entry. `exclude:` runs against the incoming column names before `mapping:`
+///   reads them, so the entry could only ever produce nothing (source side) or
+///   the exclusion could never take effect (output side).
 ///
 /// Takes a node LIST rather than the pipeline, for the same reason the
 /// multi-value gates do: a composition body's nodes need the identical check
@@ -325,24 +389,47 @@ pub fn output_mapping_faults(
         };
         let out_name = header.name.as_str();
 
-        let legacy = mapping.legacy_map_form();
-        if !legacy.is_empty() {
-            // Echo the author's own pairs, unswapped. Under the contract the
-            // key is already the output name, so a block written against the
-            // documented direction lifts straight into the sequence; a block
-            // written against the old executor behaviour needs the sides
-            // swapped, which is why the help states the direction outright.
+        // Keyed off the SHAPE, not off the capture having content, so an empty
+        // map (`mapping: {}`) is recognised as the superseded form too instead
+        // of reading as a well-formed block that happens to declare nothing.
+        if mapping.is_map_form() {
+            let legacy = mapping.legacy_map_form();
+            // The pairs are SWAPPED into the new direction. The old executor
+            // looked entries up by the incoming field name, so the map's key
+            // was the SOURCE column — every block that actually renamed
+            // anything was source-on-left, and lifting it verbatim would invert
+            // it. The help names the one block this is wrong for: one written
+            // to the old documentation, which renamed nothing at all.
             let rewritten = legacy
                 .iter()
                 .map(|(k, v)| {
                     if k == v {
                         format!("    - {k}")
                     } else {
-                        format!("    - {k}: {v}")
+                        format!("    - {v}: {k}")
                     }
                 })
                 .collect::<Vec<_>>()
                 .join("\n");
+            let help = if legacy.is_empty() {
+                "each item is a bare column name (carried through under its own name) or a \
+                 single `output_name: source_column` pair — the OUTPUT name is on the left, \
+                 and declaration order is the output column order. This block also names no \
+                 column at all; list the columns the file should carry:\n  mapping:\n    \
+                 - order_id\n    - sold_to: customer_id"
+                    .to_string()
+            } else {
+                format!(
+                    "each item is a bare column name (carried through under its own name) or a \
+                     single `output_name: source_column` pair — the OUTPUT name is on the left, \
+                     and declaration order is the output column order. Rewrite the block as:\n  \
+                     mapping:\n{rewritten}\n\nThe two sides of each pair are SWAPPED above, \
+                     deliberately: the engine read the map's key as the SOURCE column, so this \
+                     preserves what the pipeline actually wrote. If instead the block was \
+                     written to follow the old documentation — which described the opposite \
+                     direction and therefore renamed nothing — swap them back."
+                )
+            };
             faults.push(NodeFault {
                 node_index,
                 code: "E364",
@@ -350,31 +437,39 @@ pub fn output_mapping_faults(
                     "output '{out_name}': `mapping:` is a sequence of output columns, not a map \
                      of column name to column name"
                 ),
-                help: format!(
-                    "each item is a bare column name (carried through under its own name) or a \
-                     single `output_name: source_column` pair — the OUTPUT name is on the left, \
-                     and declaration order is the output column order. Rewrite the block as:\n  \
-                     mapping:\n{rewritten}"
-                ),
+                help,
             });
             // Every other check reads `entries`, which a captured map form
             // leaves empty; there is nothing further to say about this block.
             continue;
         }
 
+        if mapping.entries().is_empty() {
+            faults.push(NodeFault {
+                node_index,
+                code: "E364",
+                message: format!(
+                    "output '{out_name}': `mapping:` declares no columns, so it states that the \
+                     file carries none"
+                ),
+                help: "list the columns the file should carry, one item each — a bare column \
+                       name to carry it through, or an `output_name: source_column` pair to \
+                       rename it. To write every upstream column, remove the `mapping:` block \
+                       entirely rather than leaving it empty."
+                    .to_string(),
+            });
+            continue;
+        }
+
         let dups = mapping.duplicate_output_names();
         if !dups.is_empty() {
-            let listed = dups
-                .iter()
-                .map(|d| format!("'{d}'"))
-                .collect::<Vec<_>>()
-                .join(", ");
             faults.push(NodeFault {
                 node_index,
                 code: "E364",
                 message: format!(
                     "output '{out_name}': `mapping:` declares the output column(s) {listed} \
-                     more than once; a written file cannot carry two columns under one name"
+                     more than once; a written file cannot carry two columns under one name",
+                    listed = quoted(&dups),
                 ),
                 help: format!(
                     "keep one item per output column and delete the rest. To write one upstream \
@@ -386,30 +481,61 @@ pub fn output_mapping_faults(
         }
 
         if let Some(exclude) = output.exclude.as_ref() {
-            let clashes: Vec<&str> = mapping
+            let excluded = |n: &str| exclude.iter().any(|x| x == n);
+            let read_clashes: Vec<&str> = mapping
                 .entries()
                 .iter()
-                .filter(|e| exclude.iter().any(|x| x == &e.source))
                 .map(|e| e.source.as_str())
+                .filter(|s| excluded(s))
                 .collect();
-            if !clashes.is_empty() {
-                let listed = clashes
-                    .iter()
-                    .map(|c| format!("'{c}'"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
+            if !read_clashes.is_empty() {
                 faults.push(NodeFault {
                     node_index,
                     code: "E364",
                     message: format!(
                         "output '{out_name}': `mapping:` reads the column(s) {listed}, which this \
                          output's own `exclude:` removes first — the entries can never produce a \
-                         column"
+                         column",
+                        listed = quoted(&read_clashes),
                     ),
                     help: format!(
                         "drop {listed} from `exclude:` if the mapping should write it, or drop \
                          the mapping item if the column should not be written. `exclude:` names \
-                         incoming columns and runs before `mapping:` reads them"
+                         incoming columns and runs before `mapping:` reads them",
+                        listed = quoted(&read_clashes),
+                    ),
+                });
+            }
+            // The output side is the subtler half: `exclude: [sold_to]` against
+            // `- sold_to: customer_id` looks like it suppresses the column, but
+            // `exclude:` matches INCOMING names and runs before the rename, so
+            // `sold_to` does not exist yet when it is consulted and the column
+            // is written anyway. Report the name the author actually has to act
+            // on rather than letting the exclusion silently do nothing.
+            let write_clashes: Vec<&str> = mapping
+                .entries()
+                .iter()
+                .filter(|e| !e.is_passthrough())
+                .map(|e| e.output.as_str())
+                .filter(|o| excluded(o))
+                .collect();
+            if !write_clashes.is_empty() {
+                faults.push(NodeFault {
+                    node_index,
+                    code: "E364",
+                    message: format!(
+                        "output '{out_name}': `exclude:` names {listed}, which `mapping:` \
+                         produces as an OUTPUT column name — `exclude:` matches incoming column \
+                         names and runs before the rename, so it would not suppress it and the \
+                         column would be written anyway",
+                        listed = quoted(&write_clashes),
+                    ),
+                    help: format!(
+                        "to drop the column, delete its `mapping:` item instead. To exclude the \
+                         column it is renamed FROM, name the source column in `exclude:` — but \
+                         then the mapping item cannot resolve either, so delete it as well. \
+                         Remove {listed} from `exclude:` to keep writing it.",
+                        listed = quoted(&write_clashes),
                     ),
                 });
             }
@@ -532,24 +658,38 @@ mod tests {
                 .collect()
         }
 
-        fn output_with(mapping_block: &str, extra: &str) -> String {
+        /// `mapping_value` is spliced in directly after `mapping:`, so a caller
+        /// can write an inline `{}` / `[]` as well as an indented block.
+        fn output_with(mapping_value: &str, extra: &str) -> String {
             format!(
                 "  - type: source\n    name: src\n    config:\n      name: src\n      \
                  type: csv\n      path: in.csv\n      schema:\n        - {{ name: sku, \
                  type: string }}\n        - {{ name: qty, type: int }}\n  - type: output\n    \
                  name: out\n    input: src\n    config:\n      name: out\n      type: csv\n      \
-                 path: out.csv\n{extra}      mapping:\n{mapping_block}"
+                 path: out.csv\n{extra}      mapping:{mapping_value}"
             )
+        }
+
+        /// An indented block value, the ordinary shape.
+        fn block(lines: &str) -> String {
+            format!("\n{lines}")
         }
 
         #[test]
         fn map_form_is_rejected_with_the_sequence_form_spelled_out() {
-            let f = faults(&output_with("        sku: sku\n        item: qty\n", ""));
+            let f = faults(&output_with(
+                &block("        sku: sku\n        item: qty\n"),
+                "",
+            ));
             assert_eq!(f.len(), 1, "{f:?}");
             assert!(f[0].0.contains("not a map"), "{}", f[0].0);
+            // `item: qty` meant "rename the source column `item` to `qty`" — the
+            // engine looked entries up by the incoming field name. The sequence
+            // spelling of that is `- qty: item`; emitting `- item: qty` would
+            // hand back a block that inverts the rename.
             assert!(
-                f[0].1.contains("- sku\n") && f[0].1.contains("- item: qty"),
-                "help must echo the author's pairs in the sequence form, identity entries \
+                f[0].1.contains("- sku\n") && f[0].1.contains("- qty: item"),
+                "help must rewrite the pairs into the new direction, identity entries \
                  collapsed to a bare name: {}",
                 f[0].1
             );
@@ -560,9 +700,36 @@ mod tests {
             );
         }
 
+        /// An empty map is still the superseded shape — the gate keys off the
+        /// form, not off the capture having content, so it cannot slip through
+        /// as a well-formed block that happens to declare nothing.
+        #[test]
+        fn an_empty_map_is_rejected_as_the_map_form() {
+            let f = faults(&output_with(" {}\n", ""));
+            assert_eq!(f.len(), 1, "{f:?}");
+            assert!(f[0].0.contains("not a map"), "{}", f[0].0);
+            assert!(
+                f[0].1.contains("names no column"),
+                "help must also say the block declares nothing: {}",
+                f[0].1
+            );
+        }
+
+        /// An empty sequence declares no columns, which under
+        /// `include_unmapped: false` is a file with no columns at all.
+        #[test]
+        fn an_empty_sequence_is_rejected() {
+            let f = faults(&output_with(" []\n", ""));
+            assert_eq!(f.len(), 1, "{f:?}");
+            assert!(f[0].0.contains("declares no columns"), "{}", f[0].0);
+        }
+
         #[test]
         fn duplicate_output_name_is_rejected() {
-            let f = faults(&output_with("        - sku\n        - sku: qty\n", ""));
+            let f = faults(&output_with(
+                &block("        - sku\n        - sku: qty\n"),
+                "",
+            ));
             assert_eq!(f.len(), 1, "{f:?}");
             assert!(f[0].0.contains("'sku'"), "{}", f[0].0);
             assert!(f[0].0.contains("more than once"), "{}", f[0].0);
@@ -571,7 +738,7 @@ mod tests {
         #[test]
         fn a_mapping_item_excluded_by_the_same_output_is_rejected() {
             let f = faults(&output_with(
-                "        - sku\n        - amount: qty\n",
+                &block("        - sku\n        - amount: qty\n"),
                 "      exclude: [qty]\n",
             ));
             assert_eq!(f.len(), 1, "{f:?}");
@@ -579,9 +746,38 @@ mod tests {
             assert!(f[0].0.contains("exclude"), "{}", f[0].0);
         }
 
+        /// The output side of the same clash: `exclude:` matches incoming names
+        /// and runs before the rename, so excluding a produced name suppresses
+        /// nothing and the column is written regardless.
+        #[test]
+        fn excluding_a_mapping_output_name_is_rejected() {
+            let f = faults(&output_with(
+                &block("        - sku\n        - amount: qty\n"),
+                "      exclude: [amount]\n",
+            ));
+            assert_eq!(f.len(), 1, "{f:?}");
+            assert!(f[0].0.contains("'amount'"), "{}", f[0].0);
+            assert!(f[0].0.contains("before the rename"), "{}", f[0].0);
+        }
+
+        /// A passthrough entry names one column on both sides, so excluding it
+        /// is the source-side clash and must be reported once, not twice.
+        #[test]
+        fn excluding_a_passthrough_entry_reports_the_source_side_only() {
+            let f = faults(&output_with(
+                &block("        - sku\n        - amount: qty\n"),
+                "      exclude: [sku]\n",
+            ));
+            assert_eq!(f.len(), 1, "{f:?}");
+            assert!(f[0].0.contains("removes first"), "{}", f[0].0);
+        }
+
         #[test]
         fn a_well_formed_sequence_produces_no_fault() {
-            let f = faults(&output_with("        - sku\n        - amount: qty\n", ""));
+            let f = faults(&output_with(
+                &block("        - sku\n        - amount: qty\n"),
+                "",
+            ));
             assert!(f.is_empty(), "{f:?}");
         }
     }

--- a/crates/clinker-plan/src/config/output_mapping.rs
+++ b/crates/clinker-plan/src/config/output_mapping.rs
@@ -75,9 +75,14 @@ impl MappingEntry {
 /// Construct from an entry list with [`OutputMapping::new`]; every derived
 /// index is computed once there and kept in step with `entries` because all
 /// fields are private.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct OutputMapping {
     entries: Vec<MappingEntry>,
+    /// One-based source line for each authored sequence item. Programmatic
+    /// construction uses `0` (unknown). Kept parallel to `entries` so plan
+    /// diagnostics can point at the offending item without putting parser
+    /// metadata on the public [`MappingEntry`] API or the runtime plan.
+    entry_lines: Vec<u32>,
     /// Every source column some entry reads. Lets the projection pass answer
     /// "has this column already been placed?" in O(1) per column with no
     /// per-record allocation, which is what keeps the unlisted-column append
@@ -117,8 +122,9 @@ impl OutputMapping {
     /// claimed-output, and last-reader indexes.
     ///
     /// Accepts duplicate output names and an empty list: rejecting either is a
-    /// plan-time diagnostic (**E364**) that carries the offending node's span,
-    /// and a `Deserialize` impl has no span to attach.
+    /// plan-time diagnostic (**E364**). Programmatic construction has no source
+    /// line to attach; YAML deserialization records sequence-item lines
+    /// separately without changing this API.
     pub fn new(entries: Vec<MappingEntry>) -> Self {
         let claimed: HashSet<Box<str>> = entries
             .iter()
@@ -136,6 +142,7 @@ impl OutputMapping {
             last_reader[i] = seen.insert(entry.source.as_str());
         }
         Self {
+            entry_lines: vec![0; entries.len()],
             entries,
             claimed,
             claimed_outputs,
@@ -163,6 +170,15 @@ impl OutputMapping {
         &self.entries
     }
 
+    /// One-based YAML line for the entry at `index`, when the mapping came
+    /// from source text and the parser retained the item location.
+    pub(crate) fn entry_line(&self, index: usize) -> Option<u32> {
+        self.entry_lines
+            .get(index)
+            .copied()
+            .filter(|line| *line > 0)
+    }
+
     /// True when some entry reads `column` from upstream, so the projection
     /// pass has already placed it and must not append it a second time.
     pub fn claims_source(&self, column: &str) -> bool {
@@ -185,16 +201,39 @@ impl OutputMapping {
     /// Drives the **E364** plan-time gate; a writer cannot emit two columns
     /// under one header.
     pub fn duplicate_output_names(&self) -> Vec<&str> {
+        self.duplicate_output_entries()
+            .into_iter()
+            .map(|(_, name)| name)
+            .collect()
+    }
+
+    /// Repeated output names paired with the first offending entry index.
+    pub(crate) fn duplicate_output_entries(&self) -> Vec<(usize, &str)> {
         let mut seen: HashSet<&str> = HashSet::with_capacity(self.entries.len());
-        let mut dups: Vec<&str> = Vec::new();
-        for entry in &self.entries {
-            if !seen.insert(entry.output.as_str()) && !dups.contains(&entry.output.as_str()) {
-                dups.push(entry.output.as_str());
+        let mut dups: Vec<(usize, &str)> = Vec::new();
+        for (index, entry) in self.entries.iter().enumerate() {
+            if !seen.insert(entry.output.as_str())
+                && !dups.iter().any(|(_, name)| *name == entry.output)
+            {
+                dups.push((index, entry.output.as_str()));
             }
         }
         dups
     }
 }
+
+impl PartialEq for OutputMapping {
+    fn eq(&self, other: &Self) -> bool {
+        // Source locations are parser metadata, not part of the authored
+        // mapping value. A parsed block and the equivalent programmatically
+        // constructed block compare equal.
+        self.entries == other.entries
+            && self.legacy_map == other.legacy_map
+            && self.map_form == other.map_form
+    }
+}
+
+impl Eq for OutputMapping {}
 
 impl Serialize for OutputMapping {
     /// Round-trips to the authored shape: a bare scalar per passthrough entry,
@@ -231,6 +270,140 @@ const MAPPING_SHAPE_HELP: &str = "`mapping:` is a sequence, one item per output 
      `output_name: source_column` pair to rename it:\n  \
      mapping:\n    - order_id\n    - sold_to: customer_id";
 
+/// A mapping entry plus its YAML line when the active deserializer supports
+/// serde-saphyr's `__yaml_spanned` protocol. Other serde formats fall back to
+/// an ordinary unspanned entry, preserving `OutputMapping`'s format-neutral
+/// `Deserialize` implementation.
+struct LocatedMappingEntry {
+    value: MappingEntry,
+    line: u32,
+}
+
+impl<'de> Deserialize<'de> for LocatedMappingEntry {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct LocatedVisitor;
+
+        impl<'de> Visitor<'de> for LocatedVisitor {
+            type Value = LocatedMappingEntry;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a mapping entry with optional source location")
+            }
+
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct EntryOrSpanVisitor;
+
+                impl<'de> Visitor<'de> for EntryOrSpanVisitor {
+                    type Value = LocatedMappingEntry;
+
+                    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                        f.write_str("a mapping entry or serde-saphyr spanned entry")
+                    }
+
+                    fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                        if value.is_empty() {
+                            return Err(de::Error::custom(format!(
+                                "a `mapping:` item may not be an empty column name. \
+                                 {MAPPING_SHAPE_HELP}"
+                            )));
+                        }
+                        Ok(LocatedMappingEntry {
+                            value: MappingEntry::passthrough(value),
+                            line: 0,
+                        })
+                    }
+
+                    fn visit_string<E: de::Error>(self, value: String) -> Result<Self::Value, E> {
+                        if value.is_empty() {
+                            return Err(de::Error::custom(format!(
+                                "a `mapping:` item may not be an empty column name. \
+                                 {MAPPING_SHAPE_HELP}"
+                            )));
+                        }
+                        Ok(LocatedMappingEntry {
+                            value: MappingEntry::passthrough(value),
+                            line: 0,
+                        })
+                    }
+
+                    fn visit_map<A: MapAccess<'de>>(
+                        self,
+                        mut map: A,
+                    ) -> Result<Self::Value, A::Error> {
+                        let Some(first_key) = map.next_key::<String>()? else {
+                            return Err(de::Error::custom(
+                                "an empty `mapping:` item names no column",
+                            ));
+                        };
+                        if first_key != "value" {
+                            let source = map.next_value::<String>()?;
+                            if map.next_key::<de::IgnoredAny>()?.is_some() {
+                                return Err(de::Error::custom(
+                                    "a `mapping:` rename item carries exactly one pair",
+                                ));
+                            }
+                            if first_key.is_empty() || source.is_empty() {
+                                return Err(de::Error::custom(format!(
+                                    "a `mapping:` rename item needs a non-empty output name and \
+                                     source column. {MAPPING_SHAPE_HELP}"
+                                )));
+                            }
+                            return Ok(LocatedMappingEntry {
+                                value: MappingEntry::rename(first_key, source),
+                                line: 0,
+                            });
+                        }
+
+                        // serde-saphyr's internal wrapper yields the fixed map
+                        // `{value, referenced, defined}` in this order. A plain
+                        // serde format may instead be deserializing the valid
+                        // rename `{value: source}`; no second key distinguishes
+                        // that case without relying on the concrete format.
+                        let value = map.next_value::<MappingEntry>()?;
+                        let Some(second_key) = map.next_key::<String>()? else {
+                            return Ok(LocatedMappingEntry {
+                                value: MappingEntry::rename("value", value.source),
+                                line: 0,
+                            });
+                        };
+                        if second_key != "referenced" {
+                            return Err(de::Error::custom(format!(
+                                "unexpected spanned mapping field `{second_key}`"
+                            )));
+                        }
+                        let referenced = map.next_value::<crate::yaml::Location>()?;
+                        let defined_key = map.next_key::<String>()?.ok_or_else(|| {
+                            de::Error::custom("spanned mapping entry is missing `defined`")
+                        })?;
+                        if defined_key != "defined" {
+                            return Err(de::Error::custom(format!(
+                                "unexpected spanned mapping field `{defined_key}`"
+                            )));
+                        }
+                        let _defined = map.next_value::<crate::yaml::Location>()?;
+                        if map.next_key::<de::IgnoredAny>()?.is_some() {
+                            return Err(de::Error::custom(
+                                "spanned mapping entry carries an unexpected field",
+                            ));
+                        }
+                        Ok(LocatedMappingEntry {
+                            value,
+                            line: referenced.line() as u32,
+                        })
+                    }
+                }
+
+                deserializer.deserialize_any(EntryOrSpanVisitor)
+            }
+        }
+
+        deserializer.deserialize_newtype_struct("__yaml_spanned", LocatedVisitor)
+    }
+}
+
 impl<'de> Deserialize<'de> for OutputMapping {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct MappingVisitor;
@@ -246,10 +419,14 @@ impl<'de> Deserialize<'de> for OutputMapping {
 
             fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
                 let mut entries = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-                while let Some(entry) = seq.next_element::<MappingEntry>()? {
-                    entries.push(entry);
+                let mut entry_lines = Vec::with_capacity(entries.capacity());
+                while let Some(entry) = seq.next_element::<LocatedMappingEntry>()? {
+                    entry_lines.push(entry.line);
+                    entries.push(entry.value);
                 }
-                Ok(OutputMapping::new(entries))
+                let mut mapping = OutputMapping::new(entries);
+                mapping.entry_lines = entry_lines;
+                Ok(mapping)
             }
 
             /// Capture the superseded map form rather than failing here, so the
@@ -345,8 +522,8 @@ fn quoted(names: &[&str]) -> String {
         .join(", ")
 }
 
-/// Every Output whose `mapping:` block is malformed or contradicts itself
-/// (**E364**).
+/// Detailed finding for an Output whose `mapping:` block is malformed or
+/// contradicts itself (**E364**), including an internal item-line anchor.
 ///
 /// Four faults, all decidable from the Output node alone — no upstream schema
 /// needed, which is why they live here rather than in the bind walk:
@@ -360,18 +537,45 @@ fn quoted(names: &[&str]) -> String {
 /// * a repeated output name. A YAML map gave key uniqueness for free; a
 ///   sequence has to enforce it, and a writer cannot emit two columns under one
 ///   header.
-/// * a column this same output's `exclude:` removes, named on either side of an
-///   entry. `exclude:` runs against the incoming column names before `mapping:`
-///   reads them, so the entry could only ever produce nothing (source side) or
-///   the exclusion could never take effect (output side).
+/// * a source column this same output's `exclude:` removes. `exclude:` runs
+///   against incoming column names before `mapping:` reads them, so the entry
+///   could only ever produce nothing. An output-side name is allowed because
+///   excluding the incoming namesake is how authors resolve a passthrough
+///   collision.
 ///
 /// Takes a node LIST rather than the pipeline, for the same reason the
 /// multi-value gates do: a composition body's nodes need the identical check
 /// and never appear in the call-site pipeline's `nodes:`.
+pub(crate) struct OutputMappingFault {
+    pub(crate) node_index: usize,
+    /// One-based YAML line for the precise offending mapping item. `None` for
+    /// block-level faults and programmatically constructed configurations.
+    pub(crate) item_line: Option<u32>,
+    pub(crate) code: &'static str,
+    pub(crate) message: String,
+    pub(crate) help: String,
+}
+
+/// Every Output whose `mapping:` block is malformed or contradicts itself
+/// (**E364**), in the shared node-fault form used by public validation helpers.
 pub fn output_mapping_faults(
     nodes: &[crate::yaml::Spanned<crate::config::pipeline_node::PipelineNode>],
 ) -> Vec<crate::config::multi_value::NodeFault> {
-    use crate::config::multi_value::NodeFault;
+    output_mapping_faults_spanned(nodes)
+        .into_iter()
+        .map(|fault| crate::config::multi_value::NodeFault {
+            node_index: fault.node_index,
+            code: fault.code,
+            message: fault.message,
+            help: fault.help,
+        })
+        .collect()
+}
+
+/// Internal item-spanned form used when constructing plan diagnostics.
+pub(crate) fn output_mapping_faults_spanned(
+    nodes: &[crate::yaml::Spanned<crate::config::pipeline_node::PipelineNode>],
+) -> Vec<OutputMappingFault> {
     use crate::config::pipeline_node::PipelineNode;
 
     let mut faults = Vec::new();
@@ -430,8 +634,9 @@ pub fn output_mapping_faults(
                      direction and therefore renamed nothing — swap them back."
                 )
             };
-            faults.push(NodeFault {
+            faults.push(OutputMappingFault {
                 node_index,
+                item_line: None,
                 code: "E364",
                 message: format!(
                     "output '{out_name}': `mapping:` is a sequence of output columns, not a map \
@@ -445,8 +650,9 @@ pub fn output_mapping_faults(
         }
 
         if mapping.entries().is_empty() {
-            faults.push(NodeFault {
+            faults.push(OutputMappingFault {
                 node_index,
+                item_line: None,
                 code: "E364",
                 message: format!(
                     "output '{out_name}': `mapping:` declares no columns, so it states that the \
@@ -461,10 +667,12 @@ pub fn output_mapping_faults(
             continue;
         }
 
-        let dups = mapping.duplicate_output_names();
+        let duplicate_entries = mapping.duplicate_output_entries();
+        let dups: Vec<&str> = duplicate_entries.iter().map(|(_, name)| *name).collect();
         if !dups.is_empty() {
-            faults.push(NodeFault {
+            faults.push(OutputMappingFault {
                 node_index,
+                item_line: mapping.entry_line(duplicate_entries[0].0),
                 code: "E364",
                 message: format!(
                     "output '{out_name}': `mapping:` declares the output column(s) {listed} \
@@ -482,27 +690,31 @@ pub fn output_mapping_faults(
 
         if let Some(exclude) = output.exclude.as_ref() {
             let excluded = |n: &str| exclude.iter().any(|x| x == n);
-            let read_clashes: Vec<&str> = mapping
+            let read_clashes: Vec<(usize, &str)> = mapping
                 .entries()
                 .iter()
-                .map(|e| e.source.as_str())
-                .filter(|s| excluded(s))
+                .enumerate()
+                .filter_map(|(index, entry)| {
+                    excluded(&entry.source).then_some((index, entry.source.as_str()))
+                })
                 .collect();
             if !read_clashes.is_empty() {
-                faults.push(NodeFault {
+                let listed_names: Vec<&str> = read_clashes.iter().map(|(_, name)| *name).collect();
+                faults.push(OutputMappingFault {
                     node_index,
+                    item_line: mapping.entry_line(read_clashes[0].0),
                     code: "E364",
                     message: format!(
                         "output '{out_name}': `mapping:` reads the column(s) {listed}, which this \
                          output's own `exclude:` removes first — the entries can never produce a \
                          column",
-                        listed = quoted(&read_clashes),
+                        listed = quoted(&listed_names),
                     ),
                     help: format!(
                         "drop {listed} from `exclude:` if the mapping should write it, or drop \
                          the mapping item if the column should not be written. `exclude:` names \
                          incoming columns and runs before `mapping:` reads them",
-                        listed = quoted(&read_clashes),
+                        listed = quoted(&listed_names),
                     ),
                 });
             }
@@ -559,6 +771,25 @@ mod tests {
         assert!(m.entries()[0].is_passthrough());
         assert!(!m.entries()[1].is_passthrough());
         assert!(m.entries()[2].is_passthrough());
+    }
+
+    #[test]
+    fn serde_json_deserialization_remains_unspanned_and_format_neutral() {
+        let mapping: OutputMapping = serde_json::from_str(
+            r#"["order_id", {"sold_to": "customer_id"}, {"value": "source_value"}]"#,
+        )
+        .expect("JSON deserialization");
+        assert_eq!(
+            mapping.entries(),
+            &[
+                MappingEntry::passthrough("order_id"),
+                MappingEntry::rename("sold_to", "customer_id"),
+                MappingEntry::rename("value", "source_value"),
+            ]
+        );
+        assert_eq!(mapping.entry_line(0), None);
+        assert_eq!(mapping.entry_line(1), None);
+        assert_eq!(mapping.entry_line(2), None);
     }
 
     /// The superseded map form parses into the capture slot and declares no

--- a/crates/clinker-plan/src/config/output_mapping.rs
+++ b/crates/clinker-plan/src/config/output_mapping.rs
@@ -506,39 +506,12 @@ pub fn output_mapping_faults(
                     ),
                 });
             }
-            // The output side is the subtler half: `exclude: [sold_to]` against
-            // `- sold_to: customer_id` looks like it suppresses the column, but
-            // `exclude:` matches INCOMING names and runs before the rename, so
-            // `sold_to` does not exist yet when it is consulted and the column
-            // is written anyway. Report the name the author actually has to act
-            // on rather than letting the exclusion silently do nothing.
-            let write_clashes: Vec<&str> = mapping
-                .entries()
-                .iter()
-                .filter(|e| !e.is_passthrough())
-                .map(|e| e.output.as_str())
-                .filter(|o| excluded(o))
-                .collect();
-            if !write_clashes.is_empty() {
-                faults.push(NodeFault {
-                    node_index,
-                    code: "E364",
-                    message: format!(
-                        "output '{out_name}': `exclude:` names {listed}, which `mapping:` \
-                         produces as an OUTPUT column name — `exclude:` matches incoming column \
-                         names and runs before the rename, so it would not suppress it and the \
-                         column would be written anyway",
-                        listed = quoted(&write_clashes),
-                    ),
-                    help: format!(
-                        "to drop the column, delete its `mapping:` item instead. To exclude the \
-                         column it is renamed FROM, name the source column in `exclude:` — but \
-                         then the mapping item cannot resolve either, so delete it as well. \
-                         Remove {listed} from `exclude:` to keep writing it.",
-                        listed = quoted(&write_clashes),
-                    ),
-                });
-            }
+            // Only the SOURCE side is a fault. `exclude:` operates on incoming
+            // column names, full stop, and naming one that the mapping also
+            // produces as an output name is not a mistake — it is the documented
+            // resolution for a collision between a mapped column and a
+            // passthrough of the same name, which the collision diagnostic's own
+            // help tells the author to write.
         }
     }
     faults
@@ -746,18 +719,18 @@ mod tests {
             assert!(f[0].0.contains("exclude"), "{}", f[0].0);
         }
 
-        /// The output side of the same clash: `exclude:` matches incoming names
-        /// and runs before the rename, so excluding a produced name suppresses
-        /// nothing and the column is written regardless.
+        /// `exclude:` naming a column the mapping also PRODUCES is not a fault.
+        /// `exclude:` operates on incoming names, so it removes the upstream
+        /// column of that name and leaves the mapped one — which is exactly the
+        /// resolution the collision diagnostic tells the author to write. A gate
+        /// here would reject the fix another diagnostic hands out.
         #[test]
-        fn excluding_a_mapping_output_name_is_rejected() {
+        fn excluding_a_mapping_output_name_is_not_a_fault() {
             let f = faults(&output_with(
                 &block("        - sku\n        - amount: qty\n"),
                 "      exclude: [amount]\n",
             ));
-            assert_eq!(f.len(), 1, "{f:?}");
-            assert!(f[0].0.contains("'amount'"), "{}", f[0].0);
-            assert!(f[0].0.contains("before the rename"), "{}", f[0].0);
+            assert!(f.is_empty(), "{f:?}");
         }
 
         /// A passthrough entry names one column on both sides, so excluding it

--- a/crates/clinker-plan/src/config/output_mapping.rs
+++ b/crates/clinker-plan/src/config/output_mapping.rs
@@ -270,6 +270,53 @@ const MAPPING_SHAPE_HELP: &str = "`mapping:` is a sequence, one item per output 
      `output_name: source_column` pair to rename it:\n  \
      mapping:\n    - order_id\n    - sold_to: customer_id";
 
+/// Render one pasteable `mapping:` sequence item.
+///
+/// Ordinary identifier-shaped names stay bare. Everything else uses a JSON
+/// string literal, which is also a valid one-line YAML double-quoted scalar;
+/// this keeps colons, whitespace, control characters, and YAML 1.1 boolean or
+/// null spellings from changing the suggested block's meaning.
+pub(crate) fn render_mapping_item(output: &str, source: &str) -> String {
+    fn scalar(name: &str) -> String {
+        let lower = name.to_ascii_lowercase();
+        let ambiguous_word = matches!(
+            lower.as_str(),
+            "y" | "yes"
+                | "true"
+                | "on"
+                | "n"
+                | "no"
+                | "false"
+                | "off"
+                | "null"
+                | "~"
+                | "nan"
+                | "inf"
+                | "-inf"
+                | "+inf"
+        );
+        let plain_identifier = !ambiguous_word
+            && name
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+            && name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'));
+        if plain_identifier {
+            name.to_string()
+        } else {
+            serde_json::to_string(name).expect("serializing a string cannot fail")
+        }
+    }
+
+    if output == source {
+        format!("- {}", scalar(output))
+    } else {
+        format!("- {}: {}", scalar(output), scalar(source))
+    }
+}
+
 /// A mapping entry plus its YAML line when the active deserializer supports
 /// serde-saphyr's `__yaml_spanned` protocol. Other serde formats fall back to
 /// an ordinary unspanned entry, preserving `OutputMapping`'s format-neutral
@@ -606,13 +653,7 @@ pub(crate) fn output_mapping_faults_spanned(
             // to the old documentation, which renamed nothing at all.
             let rewritten = legacy
                 .iter()
-                .map(|(k, v)| {
-                    if k == v {
-                        format!("    - {k}")
-                    } else {
-                        format!("    - {v}: {k}")
-                    }
-                })
+                .map(|(k, v)| format!("    {}", render_mapping_item(v, k)))
                 .collect::<Vec<_>>()
                 .join("\n");
             let help = if legacy.is_empty() {
@@ -790,6 +831,30 @@ mod tests {
         assert_eq!(mapping.entry_line(0), None);
         assert_eq!(mapping.entry_line(1), None);
         assert_eq!(mapping.entry_line(2), None);
+    }
+
+    #[test]
+    fn diagnostic_mapping_items_are_yaml_safe_and_keep_identifiers_short() {
+        assert_eq!(
+            render_mapping_item("sold to", "customer: id"),
+            r#"- "sold to": "customer: id""#
+        );
+        assert_eq!(
+            render_mapping_item("yes", "line\nitem"),
+            r#"- "yes": "line\nitem""#
+        );
+        assert_eq!(
+            render_mapping_item("given_name", "first_name"),
+            "- given_name: first_name"
+        );
+
+        let rendered = render_mapping_item("sold to", "customer: id");
+        let parsed: OutputMapping =
+            crate::yaml::from_str(&rendered).expect("diagnostic item parses as YAML");
+        assert_eq!(
+            parsed.entries(),
+            &[MappingEntry::rename("sold to", "customer: id")]
+        );
     }
 
     /// The superseded map form parses into the capture slot and declares no

--- a/crates/clinker-plan/src/config/output_mapping.rs
+++ b/crates/clinker-plan/src/config/output_mapping.rs
@@ -1,0 +1,588 @@
+//! An Output node's `mapping:` block: the ordered declaration of which
+//! columns the file carries, in which order, under which names.
+//!
+//! ```yaml
+//! mapping:
+//!   - order_id                # emitted under its own name
+//!   - sold_to: customer_id    # output column `sold_to` reads `customer_id`
+//!   - contact_email: customer_email
+//! ```
+//!
+//! Two item shapes, one concept. A bare scalar is a passthrough column; a
+//! single-key pair renames. The pair reads **output name on the left, source
+//! column on the right**, so the first token of an item names the output column
+//! in both shapes. Identity-by-omission — a bare name means "unchanged" and no
+//! placeholder token is spent on it — is the settled convention in query and
+//! object-construction languages, and a sequence of bare scalars mixed with
+//! single-key maps is the same shorthand the Source node's `split_values:` /
+//! `join_values:` blocks and this crate's [`SortFieldSpec`](crate::config::SortFieldSpec)
+//! already accept.
+//!
+//! Declaration order is the output column order. Columns the block does not
+//! list are appended after the listed ones when `include_unmapped: true` (the
+//! default) and dropped when it is `false`.
+//!
+//! Bounded memory: the block is per-schema config, sized by the author's column
+//! count and never by input cardinality. [`OutputMapping`] resolves the
+//! claimed-source lookup once, at parse time, so the per-record projection pass
+//! adds no allocation and no per-column hashing beyond the one map probe the
+//! rename already performed.
+
+use std::collections::HashSet;
+
+use serde::de::{self, MapAccess, SeqAccess, Visitor};
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// One item of an Output node's `mapping:` sequence.
+///
+/// `output` is the column name the writer emits; `source` is the column read
+/// from upstream. A bare-name item sets both to the same string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MappingEntry {
+    /// Column name in the written output.
+    pub output: String,
+    /// Column name read from the record arriving at this Output.
+    pub source: String,
+}
+
+impl MappingEntry {
+    /// A passthrough entry — the column keeps its upstream name.
+    pub fn passthrough(name: impl Into<String>) -> Self {
+        let name = name.into();
+        Self {
+            output: name.clone(),
+            source: name,
+        }
+    }
+
+    /// A rename entry — `output` is written, `source` is read.
+    pub fn rename(output: impl Into<String>, source: impl Into<String>) -> Self {
+        Self {
+            output: output.into(),
+            source: source.into(),
+        }
+    }
+
+    /// True when this entry carries the column through unrenamed.
+    pub fn is_passthrough(&self) -> bool {
+        self.output == self.source
+    }
+}
+
+/// An Output node's ordered `mapping:` declaration.
+///
+/// Construct from an entry list with [`OutputMapping::new`]; the claimed-source
+/// index is derived once there and kept in step with `entries` because both
+/// fields are private.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputMapping {
+    entries: Vec<MappingEntry>,
+    /// Every source column some entry reads. Lets the projection pass answer
+    /// "has this column already been placed?" in O(1) per column with no
+    /// per-record allocation, which is what keeps the unlisted-column append
+    /// off the record-rate allocation path.
+    claimed: HashSet<Box<str>>,
+    /// Capture slot for the superseded map form, read by the **E364** gate and
+    /// by nothing else — the same device the retired `array_paths:` key uses.
+    ///
+    /// The map form is never honoured: a captured block declares no entries, so
+    /// it renames nothing even if the gate were bypassed. It is parsed at all
+    /// so the rejection can be a coded diagnostic with the node's source span
+    /// and the author's own pairs echoed back in the sequence form, rather than
+    /// a bare YAML type error.
+    legacy_map: Vec<(String, String)>,
+}
+
+impl OutputMapping {
+    /// Build from an ordered entry list, deriving the claimed-source index.
+    ///
+    /// Accepts duplicate output names: rejecting them is a plan-time
+    /// diagnostic (**E364**) that carries the offending node's span, and a
+    /// `Deserialize` impl has no span to attach.
+    pub fn new(entries: Vec<MappingEntry>) -> Self {
+        let claimed = entries
+            .iter()
+            .map(|e| Box::<str>::from(e.source.as_str()))
+            .collect();
+        Self {
+            entries,
+            claimed,
+            legacy_map: Vec::new(),
+        }
+    }
+
+    /// The superseded map form's pairs, when the block was written as a map.
+    /// Empty for every well-formed block. Drives the **E364** migration
+    /// diagnostic.
+    pub fn legacy_map_form(&self) -> &[(String, String)] {
+        &self.legacy_map
+    }
+
+    /// The declared entries, in declaration order — which is output order.
+    pub fn entries(&self) -> &[MappingEntry] {
+        &self.entries
+    }
+
+    /// True when some entry reads `column` from upstream, so the projection
+    /// pass has already placed it and must not append it a second time.
+    pub fn claims_source(&self, column: &str) -> bool {
+        self.claimed.contains(column)
+    }
+
+    /// Output names that appear more than once, in first-duplicate order.
+    /// Drives the **E364** plan-time gate; a writer cannot emit two columns
+    /// under one header.
+    pub fn duplicate_output_names(&self) -> Vec<&str> {
+        let mut seen: HashSet<&str> = HashSet::with_capacity(self.entries.len());
+        let mut dups: Vec<&str> = Vec::new();
+        for entry in &self.entries {
+            if !seen.insert(entry.output.as_str()) && !dups.contains(&entry.output.as_str()) {
+                dups.push(entry.output.as_str());
+            }
+        }
+        dups
+    }
+}
+
+impl Serialize for OutputMapping {
+    /// Round-trips to the authored shape: a bare scalar per passthrough entry,
+    /// a single-key map per rename. `clinker config --resolved` prints this.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.entries.len()))?;
+        for entry in &self.entries {
+            if entry.is_passthrough() {
+                seq.serialize_element(&entry.output)?;
+            } else {
+                seq.serialize_element(&RenamePair(entry))?;
+            }
+        }
+        seq.end()
+    }
+}
+
+/// Serializes one rename entry as the single-key map `{output: source}`.
+struct RenamePair<'a>(&'a MappingEntry);
+
+impl Serialize for RenamePair<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry(&self.0.output, &self.0.source)?;
+        map.end()
+    }
+}
+
+/// The corrected form every `mapping:` diagnostic points at, so the message
+/// carries something the author can paste.
+const MAPPING_SHAPE_HELP: &str = "`mapping:` is a sequence, one item per output column. \
+     Write a bare column name to carry a column through unchanged, or a single \
+     `output_name: source_column` pair to rename it:\n  \
+     mapping:\n    - order_id\n    - sold_to: customer_id";
+
+impl<'de> Deserialize<'de> for OutputMapping {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct MappingVisitor;
+
+        impl<'de> Visitor<'de> for MappingVisitor {
+            type Value = OutputMapping;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str(
+                    "a sequence of column names and single `output_name: source_column` pairs",
+                )
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut entries = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(entry) = seq.next_element::<MappingEntry>()? {
+                    entries.push(entry);
+                }
+                Ok(OutputMapping::new(entries))
+            }
+
+            /// Capture the superseded map form rather than failing here, so the
+            /// **E364** gate can reject it with a source span and the author's
+            /// own pairs rewritten into the sequence form. Nothing else reads
+            /// the capture; a block that reaches this arm declares no entries.
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let mut legacy_map = Vec::new();
+                while let Some(pair) = map.next_entry::<String, String>()? {
+                    legacy_map.push(pair);
+                }
+                Ok(OutputMapping {
+                    entries: Vec::new(),
+                    claimed: HashSet::new(),
+                    legacy_map,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(MappingVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for MappingEntry {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct EntryVisitor;
+
+        impl<'de> Visitor<'de> for EntryVisitor {
+            type Value = MappingEntry;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a column name, or a single `output_name: source_column` pair")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                if v.is_empty() {
+                    return Err(de::Error::custom(format!(
+                        "a `mapping:` item may not be an empty column name. {MAPPING_SHAPE_HELP}"
+                    )));
+                }
+                Ok(MappingEntry::passthrough(v))
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let Some((output, source)) = map.next_entry::<String, String>()? else {
+                    return Err(de::Error::custom(format!(
+                        "an empty `mapping:` item names no column. {MAPPING_SHAPE_HELP}"
+                    )));
+                };
+                // A multi-key item is the map form leaking in one level down —
+                // `- {a: x, b: y}` instead of two items. Name every key so the
+                // author can see which ones to split out.
+                let mut extra: Vec<String> = Vec::new();
+                while let Some((k, _)) = map.next_entry::<String, de::IgnoredAny>()? {
+                    extra.push(k);
+                }
+                if !extra.is_empty() {
+                    let mut names = vec![output.clone()];
+                    names.extend(extra);
+                    let rewritten = names
+                        .iter()
+                        .map(|n| format!("    - {n}: <source_column>"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    return Err(de::Error::custom(format!(
+                        "a `mapping:` rename item carries exactly one \
+                         `output_name: source_column` pair; this one carries {} ({}). \
+                         Give each output column its own item:\n  mapping:\n{rewritten}",
+                        names.len(),
+                        names.join(", "),
+                    )));
+                }
+                if output.is_empty() || source.is_empty() {
+                    return Err(de::Error::custom(format!(
+                        "a `mapping:` rename item needs a non-empty output name and \
+                         source column; got `{output}: {source}`. {MAPPING_SHAPE_HELP}"
+                    )));
+                }
+                Ok(MappingEntry { output, source })
+            }
+        }
+
+        deserializer.deserialize_any(EntryVisitor)
+    }
+}
+
+/// Every Output whose `mapping:` block is malformed or contradicts itself
+/// (**E364**).
+///
+/// Three faults, all decidable from the Output node alone — no upstream schema
+/// needed, which is why they live here rather than in the bind walk:
+///
+/// * the superseded map form. `mapping:` was a YAML map of column name to
+///   column name; it is a sequence now. The rejection echoes the author's own
+///   pairs back in the sequence form so the fix is a paste.
+/// * a repeated output name. A YAML map gave key uniqueness for free; a
+///   sequence has to enforce it, and a writer cannot emit two columns under one
+///   header.
+/// * a listed column this same output's `exclude:` removes. `exclude:` runs
+///   against the incoming column names before `mapping:` reads them, so the
+///   entry could only ever produce nothing.
+///
+/// Takes a node LIST rather than the pipeline, for the same reason the
+/// multi-value gates do: a composition body's nodes need the identical check
+/// and never appear in the call-site pipeline's `nodes:`.
+pub fn output_mapping_faults(
+    nodes: &[crate::yaml::Spanned<crate::config::pipeline_node::PipelineNode>],
+) -> Vec<crate::config::multi_value::NodeFault> {
+    use crate::config::multi_value::NodeFault;
+    use crate::config::pipeline_node::PipelineNode;
+
+    let mut faults = Vec::new();
+    for (node_index, spanned) in nodes.iter().enumerate() {
+        let PipelineNode::Output {
+            header,
+            config: body,
+        } = &spanned.value
+        else {
+            continue;
+        };
+        let output = &body.output;
+        let Some(mapping) = output.mapping.as_ref() else {
+            continue;
+        };
+        let out_name = header.name.as_str();
+
+        let legacy = mapping.legacy_map_form();
+        if !legacy.is_empty() {
+            // Echo the author's own pairs, unswapped. Under the contract the
+            // key is already the output name, so a block written against the
+            // documented direction lifts straight into the sequence; a block
+            // written against the old executor behaviour needs the sides
+            // swapped, which is why the help states the direction outright.
+            let rewritten = legacy
+                .iter()
+                .map(|(k, v)| {
+                    if k == v {
+                        format!("    - {k}")
+                    } else {
+                        format!("    - {k}: {v}")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            faults.push(NodeFault {
+                node_index,
+                code: "E364",
+                message: format!(
+                    "output '{out_name}': `mapping:` is a sequence of output columns, not a map \
+                     of column name to column name"
+                ),
+                help: format!(
+                    "each item is a bare column name (carried through under its own name) or a \
+                     single `output_name: source_column` pair — the OUTPUT name is on the left, \
+                     and declaration order is the output column order. Rewrite the block as:\n  \
+                     mapping:\n{rewritten}"
+                ),
+            });
+            // Every other check reads `entries`, which a captured map form
+            // leaves empty; there is nothing further to say about this block.
+            continue;
+        }
+
+        let dups = mapping.duplicate_output_names();
+        if !dups.is_empty() {
+            let listed = dups
+                .iter()
+                .map(|d| format!("'{d}'"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            faults.push(NodeFault {
+                node_index,
+                code: "E364",
+                message: format!(
+                    "output '{out_name}': `mapping:` declares the output column(s) {listed} \
+                     more than once; a written file cannot carry two columns under one name"
+                ),
+                help: format!(
+                    "keep one item per output column and delete the rest. To write one upstream \
+                     column into two output columns, give each its own name — \
+                     `- {first}: <source_column>` and `- {first}_copy: <source_column>`",
+                    first = dups[0],
+                ),
+            });
+        }
+
+        if let Some(exclude) = output.exclude.as_ref() {
+            let clashes: Vec<&str> = mapping
+                .entries()
+                .iter()
+                .filter(|e| exclude.iter().any(|x| x == &e.source))
+                .map(|e| e.source.as_str())
+                .collect();
+            if !clashes.is_empty() {
+                let listed = clashes
+                    .iter()
+                    .map(|c| format!("'{c}'"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                faults.push(NodeFault {
+                    node_index,
+                    code: "E364",
+                    message: format!(
+                        "output '{out_name}': `mapping:` reads the column(s) {listed}, which this \
+                         output's own `exclude:` removes first — the entries can never produce a \
+                         column"
+                    ),
+                    help: format!(
+                        "drop {listed} from `exclude:` if the mapping should write it, or drop \
+                         the mapping item if the column should not be written. `exclude:` names \
+                         incoming columns and runs before `mapping:` reads them"
+                    ),
+                });
+            }
+        }
+    }
+    faults
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(yaml: &str) -> Result<OutputMapping, String> {
+        crate::yaml::from_str::<OutputMapping>(yaml).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn bare_names_are_passthrough_entries() {
+        let m = parse("- order_id\n- order_date\n").expect("parse");
+        assert_eq!(
+            m.entries(),
+            &[
+                MappingEntry::passthrough("order_id"),
+                MappingEntry::passthrough("order_date"),
+            ]
+        );
+        assert!(m.claims_source("order_id"));
+        assert!(!m.claims_source("sku"));
+    }
+
+    #[test]
+    fn pair_reads_output_name_on_the_left() {
+        let m = parse("- sold_to: customer_id\n").expect("parse");
+        assert_eq!(
+            m.entries(),
+            &[MappingEntry::rename("sold_to", "customer_id")]
+        );
+        // The direction contract, asserted rather than implied: the source
+        // column is what the projection reads, the output name is what it writes.
+        assert!(m.claims_source("customer_id"));
+        assert!(!m.claims_source("sold_to"));
+    }
+
+    #[test]
+    fn bare_and_pair_items_mix_in_one_sequence() {
+        let m = parse("- order_id\n- sold_to: customer_id\n- sku\n").expect("parse");
+        assert_eq!(m.entries().len(), 3);
+        assert!(m.entries()[0].is_passthrough());
+        assert!(!m.entries()[1].is_passthrough());
+        assert!(m.entries()[2].is_passthrough());
+    }
+
+    /// The superseded map form parses into the capture slot and declares no
+    /// entries, so it renames nothing even if the E364 gate were bypassed. The
+    /// gate's message is asserted where the gate lives.
+    #[test]
+    fn map_form_is_captured_not_honoured() {
+        let m = parse("sold_to: customer_id\nchannel: channel\n").expect("captured");
+        assert!(m.entries().is_empty(), "a captured map declares no entries");
+        assert_eq!(
+            m.legacy_map_form(),
+            &[
+                ("sold_to".to_string(), "customer_id".to_string()),
+                ("channel".to_string(), "channel".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn multi_key_item_is_rejected_and_names_every_key() {
+        let err = parse("- { a: x, b: y }\n").expect_err("multi-key item must fail");
+        assert!(err.contains("exactly one"), "{err}");
+        assert!(err.contains('a') && err.contains('b'), "{err}");
+    }
+
+    #[test]
+    fn duplicate_output_names_are_reported() {
+        let m = parse("- sku\n- sku: legacy_sku\n- qty\n").expect("parse");
+        assert_eq!(m.duplicate_output_names(), vec!["sku"]);
+    }
+
+    #[test]
+    fn one_source_column_may_feed_two_output_columns() {
+        let m = parse("- sku\n- item_code: sku\n").expect("parse");
+        assert!(m.duplicate_output_names().is_empty());
+        assert_eq!(m.entries().len(), 2);
+    }
+
+    #[test]
+    fn round_trips_through_yaml() {
+        let original = parse("- order_id\n- sold_to: customer_id\n").expect("parse");
+        let yaml = crate::yaml::to_string(&original).expect("serialize");
+        let reparsed = parse(&yaml).unwrap_or_else(|e| panic!("reparse {yaml:?}: {e}"));
+        assert_eq!(original, reparsed);
+        assert!(
+            !yaml.contains("order_id: order_id"),
+            "a passthrough entry must serialize back to a bare name, got {yaml:?}"
+        );
+    }
+
+    #[test]
+    fn empty_item_is_rejected() {
+        assert!(parse("- \"\"\n").is_err());
+        assert!(parse("- {}\n").is_err());
+    }
+
+    /// The E364 gate's three faults, each with the corrected form the author
+    /// can paste. Asserted against the message text because the message *is*
+    /// the surface here.
+    mod gate {
+        use crate::config::pipeline::PipelineConfig;
+
+        fn faults(nodes_yaml: &str) -> Vec<(String, String)> {
+            let yaml = format!("pipeline:\n  name: t\nnodes:\n{nodes_yaml}");
+            let config: PipelineConfig = crate::yaml::from_str(&yaml)
+                .unwrap_or_else(|e| panic!("fixture must parse: {e}\n{yaml}"));
+            super::super::output_mapping_faults(&config.nodes)
+                .into_iter()
+                .map(|f| (f.message, f.help))
+                .collect()
+        }
+
+        fn output_with(mapping_block: &str, extra: &str) -> String {
+            format!(
+                "  - type: source\n    name: src\n    config:\n      name: src\n      \
+                 type: csv\n      path: in.csv\n      schema:\n        - {{ name: sku, \
+                 type: string }}\n        - {{ name: qty, type: int }}\n  - type: output\n    \
+                 name: out\n    input: src\n    config:\n      name: out\n      type: csv\n      \
+                 path: out.csv\n{extra}      mapping:\n{mapping_block}"
+            )
+        }
+
+        #[test]
+        fn map_form_is_rejected_with_the_sequence_form_spelled_out() {
+            let f = faults(&output_with("        sku: sku\n        item: qty\n", ""));
+            assert_eq!(f.len(), 1, "{f:?}");
+            assert!(f[0].0.contains("not a map"), "{}", f[0].0);
+            assert!(
+                f[0].1.contains("- sku\n") && f[0].1.contains("- item: qty"),
+                "help must echo the author's pairs in the sequence form, identity entries \
+                 collapsed to a bare name: {}",
+                f[0].1
+            );
+            assert!(
+                f[0].1.contains("OUTPUT name is on the left"),
+                "help must state the pair direction: {}",
+                f[0].1
+            );
+        }
+
+        #[test]
+        fn duplicate_output_name_is_rejected() {
+            let f = faults(&output_with("        - sku\n        - sku: qty\n", ""));
+            assert_eq!(f.len(), 1, "{f:?}");
+            assert!(f[0].0.contains("'sku'"), "{}", f[0].0);
+            assert!(f[0].0.contains("more than once"), "{}", f[0].0);
+        }
+
+        #[test]
+        fn a_mapping_item_excluded_by_the_same_output_is_rejected() {
+            let f = faults(&output_with(
+                "        - sku\n        - amount: qty\n",
+                "      exclude: [qty]\n",
+            ));
+            assert_eq!(f.len(), 1, "{f:?}");
+            assert!(f[0].0.contains("'qty'"), "{}", f[0].0);
+            assert!(f[0].0.contains("exclude"), "{}", f[0].0);
+        }
+
+        #[test]
+        fn a_well_formed_sequence_produces_no_fault() {
+            let f = faults(&output_with("        - sku\n        - amount: qty\n", ""));
+            assert!(f.is_empty(), "{f:?}");
+        }
+    }
+}

--- a/crates/clinker-plan/src/config/output_mapping.rs
+++ b/crates/clinker-plan/src/config/output_mapping.rs
@@ -277,7 +277,7 @@ impl<'de> Deserialize<'de> for MappingEntry {
                          source column; got `{output}: {source}`. {MAPPING_SHAPE_HELP}"
                     )));
                 }
-                Ok(MappingEntry { output, source })
+                Ok(MappingEntry::rename(output, source))
             }
         }
 

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -1212,6 +1212,9 @@ impl PipelineConfig {
             .into_iter()
             .chain(crate::config::multi_value::output_node_faults(&self.nodes))
             .chain(crate::config::record_path::record_path_faults(&self.nodes))
+            .chain(crate::config::output_mapping::output_mapping_faults(
+                &self.nodes,
+            ))
         {
             let primary = doc_node_line_by_name
                 .get(self.nodes[fault.node_index].value.name())
@@ -1343,7 +1346,11 @@ impl PipelineConfig {
             .iter()
             .map(|o| crate::plan::execution::OutputSpec {
                 name: o.name.clone(),
-                mapping: o.mapping.clone().unwrap_or_default(),
+                mapping: o
+                    .mapping
+                    .as_ref()
+                    .map(|m| m.entries().to_vec())
+                    .unwrap_or_default(),
                 exclude: o.exclude.clone().unwrap_or_default(),
                 include_unmapped: o.include_unmapped,
             })

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -1212,13 +1212,29 @@ impl PipelineConfig {
             .into_iter()
             .chain(crate::config::multi_value::output_node_faults(&self.nodes))
             .chain(crate::config::record_path::record_path_faults(&self.nodes))
-            .chain(crate::config::output_mapping::output_mapping_faults(
-                &self.nodes,
-            ))
         {
             let primary = doc_node_line_by_name
                 .get(self.nodes[fault.node_index].value.name())
                 .map(|&line| Span::line_only(line))
+                .unwrap_or(Span::SYNTHETIC);
+            diags.push(
+                Diagnostic::error(
+                    fault.code,
+                    fault.message,
+                    LabeledSpan::primary(primary, String::new()),
+                )
+                .with_help(fault.help),
+            );
+        }
+        for fault in crate::config::output_mapping::output_mapping_faults_spanned(&self.nodes) {
+            let primary = fault
+                .item_line
+                .map(Span::line_only)
+                .or_else(|| {
+                    doc_node_line_by_name
+                        .get(self.nodes[fault.node_index].value.name())
+                        .map(|&line| Span::line_only(line))
+                })
                 .unwrap_or(Span::SYNTHETIC);
             diags.push(
                 Diagnostic::error(

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -1536,10 +1536,43 @@ pub struct CombineBody {
 }
 
 /// Output variant body. Wraps the existing sink config.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct OutputBody {
     #[serde(flatten)]
     pub output: crate::config::OutputConfig,
+}
+
+impl<'de> Deserialize<'de> for OutputBody {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OutputBodyVisitor;
+
+        impl<'de> Visitor<'de> for OutputBodyVisitor {
+            type Value = OutputBody;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("an output configuration")
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                // `#[serde(flatten)]` buffers through ContentDeserializer and
+                // loses nested item locations. Delegate the native map stream
+                // directly so `OutputMapping` can retain each sequence item's
+                // span for E364/E365.
+                let output = crate::config::OutputConfig::deserialize(
+                    de::value::MapAccessDeserializer::new(map),
+                )?;
+                Ok(OutputBody { output })
+            }
+        }
+
+        deserializer.deserialize_map(OutputBodyVisitor)
+    }
 }
 
 /// Engine-stamped audit column set `true` on every record a Reshape

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -324,6 +324,26 @@ pub enum PipelineError {
         observed_count: u64,
         total_count: u64,
     },
+    /// E365 (write-boundary surface) — an Output's `mapping:` declared a
+    /// column the stream does not supply, so the established output schema is
+    /// missing the column that entry would have written.
+    ///
+    /// The compile-time half of E365 answers this wherever the planner can
+    /// enumerate the upstream column set. This is the half for where it
+    /// cannot: inside a composition body, whose rows are open by construction
+    /// and whose open tail may legitimately supply anything, and for columns
+    /// that reach the sink only through the `auto_widen` sidecar. Raised once
+    /// per output stream at schema establishment, never per record.
+    ///
+    /// Always aborts. `mapping:` selects, so an unresolved entry deletes a
+    /// column from the written file rather than leaving it unrenamed.
+    OutputMappingColumnMissing {
+        output: String,
+        /// The source columns the unresolved entries read.
+        columns: Vec<String>,
+        /// The column names the established output schema does carry.
+        available: Vec<String>,
+    },
     /// A chunk-boundary shutdown poll tripped (SIGINT/SIGTERM or a
     /// programmatic shutdown request from the execution layer).
     /// The dispatch unwinds so the executor can drop senders, join worker
@@ -635,6 +655,34 @@ impl fmt::Display for PipelineError {
                      max_rate {max_rate:.4} ({observed_count}/{total_count} records)"
                 ),
             },
+            Self::OutputMappingColumnMissing {
+                output,
+                columns,
+                available,
+            } => {
+                let missing = columns
+                    .iter()
+                    .map(|c| format!("'{c}'"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let have = if available.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    available
+                        .iter()
+                        .map(|c| format!("'{c}'"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                write!(
+                    f,
+                    "E365 output '{output}': `mapping:` reads column(s) {missing}, which the \
+                     records reaching this output do not carry, so the declared column(s) were \
+                     not written. Columns actually present: {have}. `mapping:` selects the \
+                     output columns, so an entry that resolves to nothing drops a column from \
+                     the file — correct the column name, or remove the item"
+                )
+            }
             Self::Interrupted => write!(f, "pipeline interrupted by shutdown signal"),
         }
     }

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -324,26 +324,6 @@ pub enum PipelineError {
         observed_count: u64,
         total_count: u64,
     },
-    /// E365 (write-boundary surface) — an Output's `mapping:` declared a
-    /// column the stream does not supply, so the established output schema is
-    /// missing the column that entry would have written.
-    ///
-    /// The compile-time half of E365 answers this wherever the planner can
-    /// enumerate the upstream column set. This is the half for where it
-    /// cannot: inside a composition body, whose rows are open by construction
-    /// and whose open tail may legitimately supply anything, and for columns
-    /// that reach the sink only through the `auto_widen` sidecar. Raised once
-    /// per output stream at schema establishment, never per record.
-    ///
-    /// Always aborts. `mapping:` selects, so an unresolved entry deletes a
-    /// column from the written file rather than leaving it unrenamed.
-    OutputMappingColumnMissing {
-        output: String,
-        /// The source columns the unresolved entries read.
-        columns: Vec<String>,
-        /// The column names the established output schema does carry.
-        available: Vec<String>,
-    },
     /// A chunk-boundary shutdown poll tripped (SIGINT/SIGTERM or a
     /// programmatic shutdown request from the execution layer).
     /// The dispatch unwinds so the executor can drop senders, join worker
@@ -655,34 +635,6 @@ impl fmt::Display for PipelineError {
                      max_rate {max_rate:.4} ({observed_count}/{total_count} records)"
                 ),
             },
-            Self::OutputMappingColumnMissing {
-                output,
-                columns,
-                available,
-            } => {
-                let missing = columns
-                    .iter()
-                    .map(|c| format!("'{c}'"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let have = if available.is_empty() {
-                    "(none)".to_string()
-                } else {
-                    available
-                        .iter()
-                        .map(|c| format!("'{c}'"))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                };
-                write!(
-                    f,
-                    "E365 output '{output}': `mapping:` reads column(s) {missing}, which the \
-                     records reaching this output do not carry, so the declared column(s) were \
-                     not written. Columns actually present: {have}. `mapping:` selects the \
-                     output columns, so an entry that resolves to nothing drops a column from \
-                     the file — correct the column name, or remove the item"
-                )
-            }
             Self::Interrupted => write!(f, "pipeline interrupted by shutdown signal"),
         }
     }

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1471,25 +1471,21 @@ fn validate_output_mapping_columns(
             .join(", ")
     };
 
-    let mut missing: Vec<&str> = Vec::new();
-    for entry in mapping.entries() {
+    let mut missing: Vec<(usize, &str)> = Vec::new();
+    for (index, entry) in mapping.entries().iter().enumerate() {
         let source = entry.source.as_str();
-        if !is_available(source) && !missing.contains(&source) {
-            missing.push(source);
+        if !is_available(source) && !missing.iter().any(|(_, name)| *name == source) {
+            missing.push((index, source));
         }
     }
-    for name in missing {
+    for (entry_index, name) in missing {
         let near = cxl::resolve::levenshtein::best_match(name, &candidate_refs, 3);
-        // Per-ENTRY waiver, not per-block. Standing the gate down for the whole
-        // block whenever the sidecar is in play would let a plain typo through
-        // under `auto_widen`, which is the default source policy and therefore
-        // the commonest shape there is. A name close enough to a declared column
-        // to have a did-you-mean is a misspelling of that column, not a drift
-        // column that happens to resemble it, so it keeps its diagnostic. A name
-        // resembling nothing declared may genuinely be arriving in the sidecar,
-        // so it is left to the end-of-stream report — which knows, as no
-        // compile-time check can, whether any record actually carried it.
-        if sidecar_expands && near.is_none() {
+        // Edit distance is useful help only after absence is known. A sidecar
+        // can legitimately carry a drift column whose spelling happens to be
+        // close to a declared column, so similarity cannot turn an unknown
+        // runtime fact into a compile-time error. W365 reports the item after
+        // the run if no delivered record actually carried it.
+        if sidecar_expands {
             continue;
         }
         let help = match near {
@@ -1511,7 +1507,13 @@ fn validate_output_mapping_columns(
                     "output {node_name:?}: `mapping:` reads column '{name}', which does not \
                      exist at this point in the pipeline"
                 ),
-                LabeledSpan::primary(span, String::new()),
+                LabeledSpan::primary(
+                    mapping
+                        .entry_line(entry_index)
+                        .map(Span::line_only)
+                        .unwrap_or(span),
+                    String::new(),
+                ),
             )
             .with_help(help),
         );
@@ -1523,26 +1525,26 @@ fn validate_output_mapping_columns(
     if !output.include_unmapped {
         return;
     }
-    let mut collisions: Vec<&str> = Vec::new();
+    let mut collisions: Vec<(&str, usize)> = Vec::new();
     for (qf, _) in upstream.fields() {
         let column = qf.name.as_ref();
+        let mapped_entry = mapping
+            .entries()
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| entry.output == column);
         if column.starts_with('$')
             || mapping.claims_source(column)
             || excluded(column)
-            || !mapping.claims_output(column)
-            || collisions.contains(&column)
+            || mapped_entry.is_none()
+            || collisions.iter().any(|(name, _)| *name == column)
         {
             continue;
         }
-        collisions.push(column);
+        collisions.push((column, mapped_entry.expect("checked above").0));
     }
-    for column in collisions {
-        let source = mapping
-            .entries()
-            .iter()
-            .find(|e| e.output == column)
-            .map(|e| e.source.as_str())
-            .unwrap_or(column);
+    for (column, entry_index) in collisions {
+        let source = mapping.entries()[entry_index].source.as_str();
         diags.push(
             Diagnostic::error(
                 "E364",
@@ -1552,7 +1554,13 @@ fn validate_output_mapping_columns(
                      through beside it — the file would carry two '{column}' columns and readers \
                      would resolve the wrong one"
                 ),
-                LabeledSpan::primary(span, String::new()),
+                LabeledSpan::primary(
+                    mapping
+                        .entry_line(entry_index)
+                        .map(Span::line_only)
+                        .unwrap_or(span),
+                    String::new(),
+                ),
             )
             .with_help(format!(
                 "rename the mapped column to a name the upstream does not already use, add \
@@ -3230,9 +3238,6 @@ fn bind_composition(
             ))
             .chain(crate::config::record_path::record_path_faults(
                 &body_file.nodes,
-            ))
-            .chain(crate::config::output_mapping::output_mapping_faults(
-                &body_file.nodes,
             ));
         let mut has_node_config_violation = false;
         for fault in faults {
@@ -3246,6 +3251,28 @@ fn bind_composition(
                     ),
                     LabeledSpan::primary(
                         span_for_node(&body_file.nodes[fault.node_index]),
+                        String::new(),
+                    ),
+                )
+                .with_help(fault.help),
+            );
+            has_node_config_violation = true;
+        }
+        for fault in crate::config::output_mapping::output_mapping_faults_spanned(&body_file.nodes)
+        {
+            diags.push(
+                Diagnostic::error(
+                    fault.code,
+                    format!(
+                        "composition node {node_name:?}: body file {}: {}",
+                        resolved_path.display(),
+                        fault.message
+                    ),
+                    LabeledSpan::primary(
+                        fault
+                            .item_line
+                            .map(Span::line_only)
+                            .unwrap_or_else(|| span_for_node(&body_file.nodes[fault.node_index])),
                         String::new(),
                     ),
                 )

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1479,6 +1479,7 @@ fn validate_output_mapping_columns(
         }
     }
     for (entry_index, name) in missing {
+        let entry = &mapping.entries()[entry_index];
         let near = cxl::resolve::levenshtein::best_match(name, &candidate_refs, 3);
         // Edit distance is useful help only after absence is known. A sidecar
         // can legitimately carry a drift column whose spelling happens to be
@@ -1489,10 +1490,14 @@ fn validate_output_mapping_columns(
             continue;
         }
         let help = match near {
-            Some(near) => format!(
-                "did you mean `- <output_name>: {near}`? Columns available at output \
-                 {node_name:?}: {available}"
-            ),
+            Some(near) => {
+                let corrected =
+                    crate::config::output_mapping::render_mapping_item(&entry.output, near);
+                format!(
+                    "did you mean `{corrected}`? Columns available at output \
+                     {node_name:?}: {available}"
+                )
+            }
             None => format!(
                 "columns available at output {node_name:?}: {available}. If '{name}' reaches \
                  the sink only through `on_unmapped: auto_widen`, either set \

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1401,23 +1401,26 @@ pub(crate) fn validate_output_path_collisions(
     }
 }
 
-/// **E365** — an Output's `mapping:` reads a column the graph does not supply
-/// at that point.
+/// The two schema-dependent `mapping:` gates on an Output node.
 ///
+/// **E365** — an entry reads a column the graph does not supply at that point.
 /// The output schema is known at plan time, so a stale or mistyped column name
 /// is answerable here with a span instead of by reading the written file and
 /// noticing a header that is not the one the block declared.
 ///
-/// Runs only against a **closed** row. An open row is the composition-port
-/// case: the caller's extra columns bind to the row variable and flow through,
-/// so a name missing from `declared` there is not evidence the column is
-/// absent at run time. Reporting it would reject a body that is correct for
-/// every caller.
+/// **E364** — an entry's OUTPUT name collides with an upstream column that
+/// `include_unmapped` would append beside it. Two same-named columns on one
+/// schema resolve last-write-wins through `Record::get`, so the writer would
+/// serve the passthrough column's value under the renamed column's header —
+/// the renamed value silently dropped.
 ///
-/// A column that reaches the sink only through the `auto_widen` sidecar is
-/// undeclared by construction and so is reported. That matches the rest of the
-/// surface — CXL cannot name an undeclared column either — and the help says
-/// how to make it nameable.
+/// Both run only against a **closed** row. An open row is the composition-port
+/// case: the caller's extra columns bind to the row variable and flow through,
+/// so a name missing from `declared` there is not evidence the column is absent
+/// at run time, and an unlisted column set that cannot be enumerated cannot be
+/// checked for collisions either. Reporting either would reject a body that is
+/// correct for every caller. The runtime carries its own guard for both, which
+/// is what covers the open-row and sidecar cases.
 fn validate_output_mapping_columns(
     node_name: &str,
     output: &crate::config::OutputConfig,
@@ -1431,30 +1434,31 @@ fn validate_output_mapping_columns(
     if !matches!(upstream.tail, cxl::typecheck::RowTail::Closed) {
         return;
     }
-    // Match on the bare name, and also accept the `qualifier.name` spelling a
-    // combine merged row carries — `has_field` answers `false` for a name two
-    // combine inputs both declare, and an ambiguous column is present, not
-    // missing.
-    let is_available = |wanted: &str| {
-        upstream
-            .fields()
-            .any(|(qf, _)| qf.name.as_ref() == wanted || qf.to_string() == wanted)
+    // An Output's upstream row carries only bare names: a Combine publishes its
+    // merged row as `QualifiedField::bare`, so the qualified spelling never
+    // reaches here and matching it would accept a name the record cannot carry.
+    let is_available = |wanted: &str| upstream.fields().any(|(qf, _)| qf.name.as_ref() == wanted);
+    let excluded = |name: &str| {
+        output
+            .exclude
+            .as_ref()
+            .is_some_and(|ex| ex.iter().any(|x| x == name))
     };
-    let mut missing: Vec<&str> = Vec::new();
-    for entry in mapping.entries() {
-        let source = entry.source.as_str();
-        if !is_available(source) && !missing.contains(&source) {
-            missing.push(source);
-        }
-    }
-    if missing.is_empty() {
-        return;
-    }
+
+    // A row that reserves the `auto_widen` sidecar can carry columns the
+    // declared set does not name — but only where the sidecar is expanded, and
+    // expansion is gated on `include_unmapped: true`. Under `false` the sidecar
+    // stays packed and a mapping naming one of its columns genuinely cannot
+    // resolve, so the gate still applies there.
+    let sidecar_may_supply_anything = upstream
+        .has_field(crate::config::pipeline_node::WIDENED_SIDECAR_COLUMN)
+        && output.include_unmapped;
+
     // Suggest only author-facing columns: the engine-stamped namespaces
     // (`$widened`, `$source.*`, `$ck.*`) are not names a pipeline author types.
     let candidates: Vec<String> = upstream
         .fields()
-        .map(|(qf, _)| qf.to_string())
+        .map(|(qf, _)| qf.name.to_string())
         .filter(|n| !n.starts_with('$'))
         .collect();
     let candidate_refs: Vec<&str> = candidates.iter().map(String::as_str).collect();
@@ -1467,28 +1471,85 @@ fn validate_output_mapping_columns(
             .collect::<Vec<_>>()
             .join(", ")
     };
-    for name in missing {
-        let help = match cxl::resolve::levenshtein::best_match(name, &candidate_refs, 3) {
-            Some(near) => format!(
-                "did you mean `- <output_name>: {near}`? Columns available at output \
-                 {node_name:?}: {available}"
-            ),
-            None => format!(
-                "columns available at output {node_name:?}: {available}. If '{name}' reaches \
-                 the sink only through `on_unmapped: auto_widen`, declare it in the source's \
-                 `schema:` block so the rest of the pipeline can name it too"
-            ),
-        };
+
+    if !sidecar_may_supply_anything {
+        let mut missing: Vec<&str> = Vec::new();
+        for entry in mapping.entries() {
+            let source = entry.source.as_str();
+            if !is_available(source) && !missing.contains(&source) {
+                missing.push(source);
+            }
+        }
+        for name in missing {
+            let help = match cxl::resolve::levenshtein::best_match(name, &candidate_refs, 3) {
+                Some(near) => format!(
+                    "did you mean `- <output_name>: {near}`? Columns available at output \
+                     {node_name:?}: {available}"
+                ),
+                None => format!(
+                    "columns available at output {node_name:?}: {available}. If '{name}' reaches \
+                     the sink only through `on_unmapped: auto_widen`, either set \
+                     `include_unmapped: true` on this output so the sidecar is expanded before \
+                     the mapping reads it, or declare the column in the source's `schema:` block"
+                ),
+            };
+            diags.push(
+                Diagnostic::error(
+                    "E365",
+                    format!(
+                        "output {node_name:?}: `mapping:` reads column '{name}', which does not \
+                         exist at this point in the pipeline"
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                )
+                .with_help(help),
+            );
+        }
+    }
+
+    // Collision gate. Only `include_unmapped: true` appends anything, so only
+    // it can collide. A column some entry READS is consumed by that entry and
+    // never appended; one this output excludes is removed before the append.
+    if !output.include_unmapped {
+        return;
+    }
+    let mut collisions: Vec<&str> = Vec::new();
+    for (qf, _) in upstream.fields() {
+        let column = qf.name.as_ref();
+        if column.starts_with('$')
+            || mapping.claims_source(column)
+            || excluded(column)
+            || !mapping.claims_output(column)
+            || collisions.contains(&column)
+        {
+            continue;
+        }
+        collisions.push(column);
+    }
+    for column in collisions {
+        let source = mapping
+            .entries()
+            .iter()
+            .find(|e| e.output == column)
+            .map(|e| e.source.as_str())
+            .unwrap_or(column);
         diags.push(
             Diagnostic::error(
-                "E365",
+                "E364",
                 format!(
-                    "output {node_name:?}: `mapping:` reads column '{name}', which does not \
-                     exist at this point in the pipeline"
+                    "output {node_name:?}: `mapping:` writes column '{column}', and \
+                     `include_unmapped: true` would also carry the upstream column of that name \
+                     through beside it — the file would carry two '{column}' columns and readers \
+                     would resolve the wrong one"
                 ),
                 LabeledSpan::primary(span, String::new()),
             )
-            .with_help(help),
+            .with_help(format!(
+                "rename the mapped column to a name the upstream does not already use, add \
+                 '{column}' to this output's `exclude:` so only the mapped column is written, \
+                 or set `include_unmapped: false` so the block is the whole output. The \
+                 colliding item reads '{source}'."
+            )),
         );
     }
 }

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1401,6 +1401,98 @@ pub(crate) fn validate_output_path_collisions(
     }
 }
 
+/// **E365** — an Output's `mapping:` reads a column the graph does not supply
+/// at that point.
+///
+/// The output schema is known at plan time, so a stale or mistyped column name
+/// is answerable here with a span instead of by reading the written file and
+/// noticing a header that is not the one the block declared.
+///
+/// Runs only against a **closed** row. An open row is the composition-port
+/// case: the caller's extra columns bind to the row variable and flow through,
+/// so a name missing from `declared` there is not evidence the column is
+/// absent at run time. Reporting it would reject a body that is correct for
+/// every caller.
+///
+/// A column that reaches the sink only through the `auto_widen` sidecar is
+/// undeclared by construction and so is reported. That matches the rest of the
+/// surface — CXL cannot name an undeclared column either — and the help says
+/// how to make it nameable.
+fn validate_output_mapping_columns(
+    node_name: &str,
+    output: &crate::config::OutputConfig,
+    upstream: &Row,
+    span: Span,
+    diags: &mut Vec<Diagnostic>,
+) {
+    let Some(mapping) = output.mapping.as_ref() else {
+        return;
+    };
+    if !matches!(upstream.tail, cxl::typecheck::RowTail::Closed) {
+        return;
+    }
+    // Match on the bare name, and also accept the `qualifier.name` spelling a
+    // combine merged row carries — `has_field` answers `false` for a name two
+    // combine inputs both declare, and an ambiguous column is present, not
+    // missing.
+    let is_available = |wanted: &str| {
+        upstream
+            .fields()
+            .any(|(qf, _)| qf.name.as_ref() == wanted || qf.to_string() == wanted)
+    };
+    let mut missing: Vec<&str> = Vec::new();
+    for entry in mapping.entries() {
+        let source = entry.source.as_str();
+        if !is_available(source) && !missing.contains(&source) {
+            missing.push(source);
+        }
+    }
+    if missing.is_empty() {
+        return;
+    }
+    // Suggest only author-facing columns: the engine-stamped namespaces
+    // (`$widened`, `$source.*`, `$ck.*`) are not names a pipeline author types.
+    let candidates: Vec<String> = upstream
+        .fields()
+        .map(|(qf, _)| qf.to_string())
+        .filter(|n| !n.starts_with('$'))
+        .collect();
+    let candidate_refs: Vec<&str> = candidates.iter().map(String::as_str).collect();
+    let available = if candidate_refs.is_empty() {
+        "(none)".to_string()
+    } else {
+        candidate_refs
+            .iter()
+            .map(|c| format!("'{c}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    for name in missing {
+        let help = match cxl::resolve::levenshtein::best_match(name, &candidate_refs, 3) {
+            Some(near) => format!(
+                "did you mean `- <output_name>: {near}`? Columns available at output \
+                 {node_name:?}: {available}"
+            ),
+            None => format!(
+                "columns available at output {node_name:?}: {available}. If '{name}' reaches \
+                 the sink only through `on_unmapped: auto_widen`, declare it in the source's \
+                 `schema:` block so the rest of the pipeline can name it too"
+            ),
+        };
+        diags.push(
+            Diagnostic::error(
+                "E365",
+                format!(
+                    "output {node_name:?}: `mapping:` reads column '{name}', which does not \
+                     exist at this point in the pipeline"
+                ),
+                LabeledSpan::primary(span, String::new()),
+            )
+            .with_help(help),
+        );
+    }
+}
+
 fn synthetic_typed_program(output_row: Row) -> TypedProgram {
     TypedProgram {
         program: cxl::ast::Program {
@@ -2546,9 +2638,10 @@ fn bind_schema_inner(
                     artifacts.typed_insert(node_id, Arc::new(synthetic_typed_program(row)));
                 }
             }
-            PipelineNode::Output { header, .. } => {
+            PipelineNode::Output { header, config } => {
                 if let Some(upstream) = upstream_schema(&header.input.value, schema_by_name) {
                     let row = upstream.clone();
+                    validate_output_mapping_columns(&name, &config.output, &row, span, diags);
                     schema_by_name.insert(name.clone(), row.clone());
                     artifacts.typed_insert(node_id, Arc::new(synthetic_typed_program(row)));
                 }
@@ -3065,6 +3158,9 @@ fn bind_composition(
                 &body_file.nodes,
             ))
             .chain(crate::config::record_path::record_path_faults(
+                &body_file.nodes,
+            ))
+            .chain(crate::config::output_mapping::output_mapping_faults(
                 &body_file.nodes,
             ));
         let mut has_node_config_violation = false;

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1450,8 +1450,7 @@ fn validate_output_mapping_columns(
     // expansion is gated on `include_unmapped: true`. Under `false` the sidecar
     // stays packed and a mapping naming one of its columns genuinely cannot
     // resolve, so the gate still applies there.
-    let sidecar_may_supply_anything = upstream
-        .has_field(crate::config::pipeline_node::WIDENED_SIDECAR_COLUMN)
+    let sidecar_expands = upstream.has_field(crate::config::pipeline_node::WIDENED_SIDECAR_COLUMN)
         && output.include_unmapped;
 
     // Suggest only author-facing columns: the engine-stamped namespaces
@@ -1472,39 +1471,50 @@ fn validate_output_mapping_columns(
             .join(", ")
     };
 
-    if !sidecar_may_supply_anything {
-        let mut missing: Vec<&str> = Vec::new();
-        for entry in mapping.entries() {
-            let source = entry.source.as_str();
-            if !is_available(source) && !missing.contains(&source) {
-                missing.push(source);
-            }
+    let mut missing: Vec<&str> = Vec::new();
+    for entry in mapping.entries() {
+        let source = entry.source.as_str();
+        if !is_available(source) && !missing.contains(&source) {
+            missing.push(source);
         }
-        for name in missing {
-            let help = match cxl::resolve::levenshtein::best_match(name, &candidate_refs, 3) {
-                Some(near) => format!(
-                    "did you mean `- <output_name>: {near}`? Columns available at output \
-                     {node_name:?}: {available}"
-                ),
-                None => format!(
-                    "columns available at output {node_name:?}: {available}. If '{name}' reaches \
-                     the sink only through `on_unmapped: auto_widen`, either set \
-                     `include_unmapped: true` on this output so the sidecar is expanded before \
-                     the mapping reads it, or declare the column in the source's `schema:` block"
-                ),
-            };
-            diags.push(
-                Diagnostic::error(
-                    "E365",
-                    format!(
-                        "output {node_name:?}: `mapping:` reads column '{name}', which does not \
-                         exist at this point in the pipeline"
-                    ),
-                    LabeledSpan::primary(span, String::new()),
-                )
-                .with_help(help),
-            );
+    }
+    for name in missing {
+        let near = cxl::resolve::levenshtein::best_match(name, &candidate_refs, 3);
+        // Per-ENTRY waiver, not per-block. Standing the gate down for the whole
+        // block whenever the sidecar is in play would let a plain typo through
+        // under `auto_widen`, which is the default source policy and therefore
+        // the commonest shape there is. A name close enough to a declared column
+        // to have a did-you-mean is a misspelling of that column, not a drift
+        // column that happens to resemble it, so it keeps its diagnostic. A name
+        // resembling nothing declared may genuinely be arriving in the sidecar,
+        // so it is left to the end-of-stream report — which knows, as no
+        // compile-time check can, whether any record actually carried it.
+        if sidecar_expands && near.is_none() {
+            continue;
         }
+        let help = match near {
+            Some(near) => format!(
+                "did you mean `- <output_name>: {near}`? Columns available at output \
+                 {node_name:?}: {available}"
+            ),
+            None => format!(
+                "columns available at output {node_name:?}: {available}. If '{name}' reaches \
+                 the sink only through `on_unmapped: auto_widen`, either set \
+                 `include_unmapped: true` on this output so the sidecar is expanded before \
+                 the mapping reads it, or declare the column in the source's `schema:` block"
+            ),
+        };
+        diags.push(
+            Diagnostic::error(
+                "E365",
+                format!(
+                    "output {node_name:?}: `mapping:` reads column '{name}', which does not \
+                     exist at this point in the pipeline"
+                ),
+                LabeledSpan::primary(span, String::new()),
+            )
+            .with_help(help),
+        );
     }
 
     // Collision gate. Only `include_unmapped: true` appends anything, so only

--- a/crates/clinker-plan/src/plan/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/deferred_region.rs
@@ -1298,9 +1298,13 @@ fn output_consumed_columns(
     } = &graph[out_idx]
     {
         let cfg = &payload.output;
+        // `entry.source` is the column read from upstream — the right-hand side
+        // of an `output_name: source_column` pair, and the whole of a bare-name
+        // entry. Seeding from the output names instead would prune the columns
+        // the projection actually reads.
         if let Some(mapping) = cfg.mapping.as_ref() {
-            for src_col in mapping.values() {
-                set.insert(src_col.clone());
+            for entry in mapping.entries() {
+                set.insert(entry.source.clone());
             }
         }
         if cfg.include_unmapped {

--- a/crates/clinker-plan/src/plan/execution/dag.rs
+++ b/crates/clinker-plan/src/plan/execution/dag.rs
@@ -5,7 +5,6 @@ use super::*;
 
 use std::collections::{HashMap, HashSet};
 
-use indexmap::IndexMap;
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::{Control, DfsEvent, depth_first_search};
 use serde::Serialize;
@@ -568,10 +567,17 @@ pub enum ParallelismClass {
 }
 
 /// Per-output projection specification.
+///
+/// A projection-shaped summary of each Output node, carried on the execution
+/// plan alongside the graph. The executor does not read it — it projects from
+/// the `OutputConfig` on the node's resolved payload — so the fields here exist
+/// to describe the plan, not to drive it; `clinker --explain` reports the count.
+/// `mapping` mirrors [`crate::config::OutputMapping::entries`] so the summary
+/// cannot disagree with the config about the block's shape or direction.
 #[derive(Debug, Clone)]
 pub struct OutputSpec {
     pub name: String,
-    pub mapping: IndexMap<String, String>,
+    pub mapping: Vec<crate::config::MappingEntry>,
     pub exclude: Vec<String>,
     pub include_unmapped: bool,
 }

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -428,6 +428,8 @@ pub const EXPLAIN_PAGES: &[(&str, &str)] = &[
     ("W302", include_str!("../../../../docs/explain/W302.md")),
     ("W305", include_str!("../../../../docs/explain/W305.md")),
     ("W306", include_str!("../../../../docs/explain/W306.md")),
+    ("W365", include_str!("../../../../docs/explain/W365.md")),
+    ("W366", include_str!("../../../../docs/explain/W366.md")),
 ];
 
 /// Look up error/warning code documentation embedded at compile time.

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -416,6 +416,8 @@ pub const EXPLAIN_PAGES: &[(&str, &str)] = &[
     ("E361", include_str!("../../../../docs/explain/E361.md")),
     ("E362", include_str!("../../../../docs/explain/E362.md")),
     ("E363", include_str!("../../../../docs/explain/E363.md")),
+    ("E364", include_str!("../../../../docs/explain/E364.md")),
+    ("E365", include_str!("../../../../docs/explain/E365.md")),
     ("E323", include_str!("../../../../docs/explain/E323.md")),
     ("E150b", include_str!("../../../../docs/explain/E150b.md")),
     ("E150c", include_str!("../../../../docs/explain/E150c.md")),

--- a/crates/clinker-plan/src/plan/tests/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/tests/deferred_region.rs
@@ -260,8 +260,8 @@ nodes:
       path: out.csv
       include_unmapped: false
       mapping:
-        out_dept: dept_keep
-        out_total: running_total
+        - out_dept: dept_keep
+        - out_total: running_total
 "#;
     let plan = compile(yaml);
     let agg_idx = node_idx_for(&plan, "agg");

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -19,6 +19,7 @@ mod explain_buffer_class;
 mod explain_examples;
 mod explain_polish;
 mod multi_value_validation;
+mod output_mapping_validation;
 mod overlay_compile;
 mod plan_time_window_root;
 mod predicate_support;

--- a/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
@@ -1,0 +1,186 @@
+//! The plan-time gates on an Output's `mapping:` block (E364 / E365).
+//!
+//! `mapping:` used to be a map whose keys the executor read as SOURCE column
+//! names and whose keys the documentation described as OUTPUT column names. An
+//! entry that matched nothing fell through, the column kept its upstream name,
+//! and the run exited 0 — so a block written to the documented contract renamed
+//! nothing, silently. These tests pin the replacement: the block is an ordered
+//! sequence with the output name on the left, and every way of writing one that
+//! cannot mean what it says is a spanned compile-time diagnostic.
+
+use clinker_core_types::Diagnostic;
+
+use crate::config::{CompileContext, parse_config};
+
+/// A source declaring `first_name` / `last_name` / `department`, feeding one
+/// CSV output whose `config:` carries the spliced-in lines.
+fn pipeline(output_extra: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: output_mapping_gate
+nodes:
+  - type: source
+    name: people
+    config:
+      name: people
+      type: csv
+      path: ./people.csv
+      schema:
+        - {{ name: first_name, type: string }}
+        - {{ name: last_name, type: string }}
+        - {{ name: department, type: string }}
+  - type: output
+    name: out
+    input: people
+    config:
+      name: out
+      type: csv
+      path: out.csv
+{output_extra}"#
+    )
+}
+
+fn compile_err(yaml: &str) -> Vec<Diagnostic> {
+    let config = parse_config(yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect_err("compile must fail")
+}
+
+fn only(diags: &[Diagnostic], code: &str) -> Diagnostic {
+    let matching: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one {code}, got {:?}",
+        diags.iter().map(|d| &d.code).collect::<Vec<_>>()
+    );
+    matching[0].clone()
+}
+
+/// The migration diagnostic. An author arriving from the map form gets a code,
+/// a span, and their own block already rewritten.
+#[test]
+fn map_form_is_rejected_with_the_authors_own_block_rewritten() {
+    let diags = compile_err(&pipeline(
+        "      mapping:\n        first_name: first_name\n        surname: last_name\n",
+    ));
+    let d = only(&diags, "E364");
+    assert!(
+        d.message.contains("not a map"),
+        "message must name the rule broken: {}",
+        d.message
+    );
+    let help = d.help.as_deref().unwrap_or_default();
+    assert!(
+        help.contains("- first_name\n") && help.contains("- surname: last_name"),
+        "help must echo the block in the sequence form, identity entries collapsed \
+         to a bare name: {help}"
+    );
+    assert!(
+        help.contains("OUTPUT name is on the left"),
+        "help must state the pair direction, since the map form was documented one way \
+         round and implemented the other: {help}"
+    );
+}
+
+/// A YAML map gave output-name uniqueness for free. The sequence has to enforce
+/// it: two columns cannot share one CSV header.
+#[test]
+fn duplicate_output_name_is_rejected() {
+    let diags = compile_err(&pipeline(
+        "      mapping:\n        - department\n        - department: last_name\n",
+    ));
+    let d = only(&diags, "E364");
+    assert!(d.message.contains("'department'"), "{}", d.message);
+    assert!(d.message.contains("more than once"), "{}", d.message);
+}
+
+/// `exclude:` runs before `mapping:` reads the column, so the entry could only
+/// ever produce nothing — the same silent-no-op shape this change exists to
+/// remove.
+#[test]
+fn a_mapping_entry_the_same_output_excludes_is_rejected() {
+    let diags = compile_err(&pipeline(
+        "      exclude: [last_name]\n      mapping:\n        - surname: last_name\n",
+    ));
+    let d = only(&diags, "E364");
+    assert!(d.message.contains("'last_name'"), "{}", d.message);
+    assert!(d.message.contains("exclude"), "{}", d.message);
+}
+
+/// The headline defect: a column name that matches nothing. It used to rename
+/// nothing and exit 0.
+#[test]
+fn unknown_source_column_is_rejected_with_a_suggestion() {
+    let diags = compile_err(&pipeline(
+        "      mapping:\n        - given_name: firstname\n",
+    ));
+    let d = only(&diags, "E365");
+    assert!(
+        d.message.contains("'firstname'"),
+        "message must name the offending column: {}",
+        d.message
+    );
+    let help = d.help.as_deref().unwrap_or_default();
+    assert!(
+        help.contains("did you mean `- <output_name>: first_name`"),
+        "help must offer the near miss in the corrected shape: {help}"
+    );
+    assert!(
+        help.contains("'department'"),
+        "help must list the columns that are available: {help}"
+    );
+}
+
+/// The direction contract, seen from the diagnostic: naming the OUTPUT column
+/// on the right of the pair is rejected, because the right-hand side is the
+/// column being read.
+#[test]
+fn naming_the_output_column_on_the_right_is_rejected() {
+    let diags = compile_err(&pipeline("      mapping:\n        - last_name: surname\n"));
+    let d = only(&diags, "E365");
+    assert!(
+        d.message.contains("'surname'"),
+        "the RIGHT-hand name is the one that must exist upstream: {}",
+        d.message
+    );
+}
+
+/// No near miss: the help falls back to the available-columns list plus the way
+/// to make an auto-widened column nameable.
+#[test]
+fn unknown_column_with_no_near_miss_names_the_auto_widen_route() {
+    let diags = compile_err(&pipeline(
+        "      mapping:\n        - x: totally_unrelated\n",
+    ));
+    let d = only(&diags, "E365");
+    let help = d.help.as_deref().unwrap_or_default();
+    assert!(help.contains("auto_widen"), "{help}");
+    assert!(help.contains("'first_name'"), "{help}");
+}
+
+/// Over-rejection guard: a well-formed block against real columns compiles.
+#[test]
+fn a_well_formed_mapping_compiles() {
+    let yaml = pipeline(
+        "      include_unmapped: false\n      mapping:\n        - department\n        \
+         - surname: last_name\n        - first_name\n",
+    );
+    let config = parse_config(&yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("a mapping over declared columns must compile");
+}
+
+/// Over-rejection guard: one upstream column feeding two output columns is
+/// legal — uniqueness is a constraint on the output side only.
+#[test]
+fn one_source_column_feeding_two_output_columns_compiles() {
+    let yaml = pipeline("      mapping:\n        - department\n        - dept: department\n");
+    let config = parse_config(&yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("two output columns may read one source column");
+}

--- a/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
@@ -155,20 +155,32 @@ fn a_mapping_entry_the_same_output_excludes_is_rejected() {
     assert!(d.message.contains("exclude"), "{}", d.message);
 }
 
-/// `exclude:` matches INCOMING names and runs before the rename, so excluding a
-/// mapping's OUTPUT name suppresses nothing and the column is written anyway.
+/// `exclude:` operates on INCOMING column names, so naming one the mapping also
+/// produces as an output name is not a fault — it removes the upstream column of
+/// that name and leaves the mapped one standing. That is precisely the fix the
+/// collision diagnostic (E364) hands the author, so rejecting it here would make
+/// one diagnostic reject the form another prescribes.
 #[test]
-fn excluding_a_mapping_output_name_is_rejected() {
-    let diags = compile_err(&pipeline(
-        "      exclude: [surname]\n      mapping:\n        - surname: last_name\n",
-    ));
-    let d = only(&diags, "E364");
-    assert!(d.message.contains("'surname'"), "{}", d.message);
-    assert!(
-        d.message.contains("before the rename"),
-        "message must name the ordering that makes the exclusion inert: {}",
-        d.message
+fn excluding_a_mapping_output_name_compiles() {
+    let yaml = pipeline("      exclude: [surname]\n      mapping:\n        - surname: last_name\n");
+    let config = parse_config(&yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("`exclude:` naming a produced output name is the documented collision fix");
+}
+
+/// End to end on the collision advice: an upstream column named the same as a
+/// mapped output, resolved by excluding the upstream one, compiles clean.
+#[test]
+fn the_collision_diagnostics_own_advice_compiles() {
+    let yaml = pipeline(
+        "      include_unmapped: true\n      exclude: [department]\n      mapping:\n        \
+         - department: first_name\n",
     );
+    let config = parse_config(&yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("excluding the colliding upstream column must resolve the collision");
 }
 
 /// The headline defect: a column name that matches nothing. It used to rename

--- a/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
@@ -14,6 +14,13 @@ use crate::config::{CompileContext, parse_config};
 
 /// A source declaring `first_name` / `last_name` / `department`, feeding one
 /// CSV output whose `config:` carries the spliced-in lines.
+///
+/// `on_unmapped: drop` is deliberate. The engine-wide default is `auto_widen`,
+/// which reserves the `$widened` sidecar and — under `include_unmapped: true` —
+/// can legitimately supply a column the declared schema does not name, so E365
+/// stands down there (see [`auto_widen_under_include_unmapped_suppresses_e365`]).
+/// These fixtures want the gate live, so they use a source policy that cannot
+/// carry an undeclared column.
 fn pipeline(output_extra: &str) -> String {
     format!(
         r#"
@@ -26,6 +33,8 @@ nodes:
       name: people
       type: csv
       path: ./people.csv
+      on_unmapped:
+        mode: drop
       schema:
         - {{ name: first_name, type: string }}
         - {{ name: last_name, type: string }}
@@ -73,16 +82,52 @@ fn map_form_is_rejected_with_the_authors_own_block_rewritten() {
         d.message
     );
     let help = d.help.as_deref().unwrap_or_default();
+    // The pairs come back SWAPPED. The engine looked map entries up by the
+    // incoming field name, so `surname: last_name` renamed the SOURCE column
+    // `surname` to `last_name`; the sequence form spells that
+    // `- last_name: surname`. Emitting `- surname: last_name` would hand the
+    // author a block that inverts the rename their pipeline was performing.
     assert!(
-        help.contains("- first_name\n") && help.contains("- surname: last_name"),
-        "help must echo the block in the sequence form, identity entries collapsed \
-         to a bare name: {help}"
+        help.contains("- first_name\n") && help.contains("- last_name: surname"),
+        "help must rewrite the block into the sequence form with each pair swapped \
+         into the new direction, identity entries collapsed to a bare name: {help}"
+    );
+    assert!(
+        !help.contains("- surname: last_name"),
+        "the unswapped pair would invert the rename the pipeline was performing: {help}"
     );
     assert!(
         help.contains("OUTPUT name is on the left"),
         "help must state the pair direction, since the map form was documented one way \
          round and implemented the other: {help}"
     );
+    assert!(
+        help.contains("SWAPPED") && help.contains("old documentation"),
+        "help must say the swap is deliberate and name the one block it is wrong for — \
+         one written to the old documentation, which renamed nothing: {help}"
+    );
+}
+
+/// An empty block passes every content-based check — no legacy pairs, no
+/// duplicates, no exclude clash — but under `include_unmapped: false` it states
+/// that the file carries no columns at all, which is a header line and one blank
+/// row per record. Both spellings are rejected.
+#[test]
+fn an_empty_mapping_is_rejected() {
+    for block in ["      mapping: {}\n", "      mapping: []\n"] {
+        let diags = compile_err(&pipeline(block));
+        let d = only(&diags, "E364");
+        assert!(
+            d.message.contains("mapping:"),
+            "message must name the block: {}",
+            d.message
+        );
+        let help = d.help.as_deref().unwrap_or_default();
+        assert!(
+            help.contains("remove the `mapping:` block") || help.contains("list the columns"),
+            "help must say what to write instead: {help}"
+        );
+    }
 }
 
 /// A YAML map gave output-name uniqueness for free. The sequence has to enforce
@@ -108,6 +153,22 @@ fn a_mapping_entry_the_same_output_excludes_is_rejected() {
     let d = only(&diags, "E364");
     assert!(d.message.contains("'last_name'"), "{}", d.message);
     assert!(d.message.contains("exclude"), "{}", d.message);
+}
+
+/// `exclude:` matches INCOMING names and runs before the rename, so excluding a
+/// mapping's OUTPUT name suppresses nothing and the column is written anyway.
+#[test]
+fn excluding_a_mapping_output_name_is_rejected() {
+    let diags = compile_err(&pipeline(
+        "      exclude: [surname]\n      mapping:\n        - surname: last_name\n",
+    ));
+    let d = only(&diags, "E364");
+    assert!(d.message.contains("'surname'"), "{}", d.message);
+    assert!(
+        d.message.contains("before the rename"),
+        "message must name the ordering that makes the exclusion inert: {}",
+        d.message
+    );
 }
 
 /// The headline defect: a column name that matches nothing. It used to rename
@@ -183,4 +244,114 @@ fn one_source_column_feeding_two_output_columns_compiles() {
     config
         .compile(&CompileContext::default())
         .expect("two output columns may read one source column");
+}
+
+/// A renamed column landing on a name `include_unmapped` also carries through
+/// would put two same-named columns on one schema. The schema's name index is
+/// last-write-wins, so the passthrough column would answer for the renamed one
+/// and serve its value under the renamed header — the rename silently lost.
+#[test]
+fn an_output_name_colliding_with_a_passthrough_column_is_rejected() {
+    let diags = compile_err(&pipeline(
+        "      include_unmapped: true\n      mapping:\n        - department: first_name\n",
+    ));
+    let d = only(&diags, "E364");
+    assert!(d.message.contains("'department'"), "{}", d.message);
+    assert!(
+        d.message.contains("two"),
+        "message must say the file would carry the column twice: {}",
+        d.message
+    );
+    let help = d.help.as_deref().unwrap_or_default();
+    assert!(
+        help.contains("exclude:") && help.contains("include_unmapped: false"),
+        "help must offer both ways out: {help}"
+    );
+}
+
+/// The same collision is fine under `include_unmapped: false` — nothing is
+/// appended, so nothing can collide.
+#[test]
+fn an_output_name_matching_an_unlisted_column_is_fine_when_nothing_is_appended() {
+    let yaml = pipeline(
+        "      include_unmapped: false\n      mapping:\n        - department: first_name\n",
+    );
+    let config = parse_config(&yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("with no passthrough columns there is nothing to collide with");
+}
+
+/// An `auto_widen` source can carry a column its declared schema does not name,
+/// and `include_unmapped: true` expands the sidecar into the field map BEFORE
+/// the mapping reads it — so the column is genuinely reachable and E365 must
+/// stand down. Rejecting it would break a pipeline that worked, and the only
+/// remedy the diagnostic could offer (declare the column) defeats auto-widen.
+#[test]
+fn auto_widen_under_include_unmapped_suppresses_e365() {
+    let yaml = r#"
+pipeline:
+  name: output_mapping_widen
+nodes:
+  - type: source
+    name: people
+    config:
+      name: people
+      type: csv
+      path: ./people.csv
+      schema:
+        - { name: first_name, type: string }
+  - type: output
+    name: out
+    input: people
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+      mapping:
+        - nickname: drifted_column
+"#;
+    let config = parse_config(yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("a sidecar-reserving row may supply an undeclared column");
+}
+
+/// The relaxation is conditioned on expansion actually happening. Under
+/// `include_unmapped: false` the sidecar stays packed, so the same mapping
+/// cannot resolve and E365 still applies.
+#[test]
+fn auto_widen_without_include_unmapped_still_fires_e365() {
+    let yaml = r#"
+pipeline:
+  name: output_mapping_widen_packed
+nodes:
+  - type: source
+    name: people
+    config:
+      name: people
+      type: csv
+      path: ./people.csv
+      schema:
+        - { name: first_name, type: string }
+  - type: output
+    name: out
+    input: people
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: false
+      mapping:
+        - nickname: drifted_column
+"#;
+    let diags = compile_err(yaml);
+    let d = only(&diags, "E365");
+    assert!(d.message.contains("'drifted_column'"), "{}", d.message);
+    let help = d.help.as_deref().unwrap_or_default();
+    assert!(
+        help.contains("include_unmapped: true"),
+        "help must name the flag that would make the sidecar column reachable: {help}"
+    );
 }

--- a/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
@@ -134,12 +134,21 @@ fn an_empty_mapping_is_rejected() {
 /// it: two columns cannot share one CSV header.
 #[test]
 fn duplicate_output_name_is_rejected() {
-    let diags = compile_err(&pipeline(
-        "      mapping:\n        - department\n        - department: last_name\n",
-    ));
+    let yaml = pipeline("      mapping:\n        - department\n        - department: last_name\n");
+    let duplicate_line = yaml
+        .lines()
+        .position(|line| line.contains("- department: last_name"))
+        .map(|index| index as u32 + 1)
+        .expect("duplicate item line");
+    let diags = compile_err(&yaml);
     let d = only(&diags, "E364");
     assert!(d.message.contains("'department'"), "{}", d.message);
     assert!(d.message.contains("more than once"), "{}", d.message);
+    assert_eq!(
+        d.primary.span.synthetic_line_number(),
+        Some(duplicate_line),
+        "the duplicate item, not the Output node, is highlighted"
+    );
 }
 
 /// `exclude:` runs before `mapping:` reads the column, so the entry could only
@@ -187,9 +196,13 @@ fn the_collision_diagnostics_own_advice_compiles() {
 /// nothing and exit 0.
 #[test]
 fn unknown_source_column_is_rejected_with_a_suggestion() {
-    let diags = compile_err(&pipeline(
-        "      mapping:\n        - given_name: firstname\n",
-    ));
+    let yaml = pipeline("      mapping:\n        - given_name: firstname\n");
+    let item_line = yaml
+        .lines()
+        .position(|line| line.contains("- given_name: firstname"))
+        .map(|index| index as u32 + 1)
+        .expect("mapping item line");
+    let diags = compile_err(&yaml);
     let d = only(&diags, "E365");
     assert!(
         d.message.contains("'firstname'"),
@@ -204,6 +217,11 @@ fn unknown_source_column_is_rejected_with_a_suggestion() {
     assert!(
         help.contains("'department'"),
         "help must list the columns that are available: {help}"
+    );
+    assert_eq!(
+        d.primary.span.synthetic_line_number(),
+        Some(item_line),
+        "the unmatched item, not the Output node, is highlighted"
     );
 }
 
@@ -328,6 +346,40 @@ nodes:
     config
         .compile(&CompileContext::default())
         .expect("a sidecar-reserving row may supply an undeclared column");
+}
+
+/// Similarity is not proof of absence: a real drift column may differ from a
+/// declared column only by punctuation. The runtime W365 report, which sees
+/// delivered records, owns the unresolved case.
+#[test]
+fn auto_widen_near_match_still_suppresses_e365() {
+    let yaml = r#"
+pipeline:
+  name: output_mapping_widen_near_match
+nodes:
+  - type: source
+    name: people
+    config:
+      name: people
+      type: csv
+      path: ./people.csv
+      schema:
+        - { name: first_name, type: string }
+  - type: output
+    name: out
+    input: people
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+      mapping:
+        - nickname: firstname
+"#;
+    let config = parse_config(yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("a similarly named sidecar column may be real drift");
 }
 
 /// The relaxation is conditioned on expansion actually happening. Under

--- a/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
@@ -108,6 +108,19 @@ fn map_form_is_rejected_with_the_authors_own_block_rewritten() {
     );
 }
 
+#[test]
+fn map_form_rewrite_quotes_names_that_are_not_plain_yaml_scalars() {
+    let diags = compile_err(&pipeline(
+        "      mapping:\n        \"customer: id\": \"sold to\"\n",
+    ));
+    let d = only(&diags, "E364");
+    let help = d.help.as_deref().unwrap_or_default();
+    assert!(
+        help.contains(r#"- "sold to": "customer: id""#),
+        "the swapped rewrite must remain pasteable YAML: {help}"
+    );
+}
+
 /// An empty block passes every content-based check — no legacy pairs, no
 /// duplicates, no exclude clash — but under `include_unmapped: false` it states
 /// that the file carries no columns at all, which is a header line and one blank
@@ -211,8 +224,8 @@ fn unknown_source_column_is_rejected_with_a_suggestion() {
     );
     let help = d.help.as_deref().unwrap_or_default();
     assert!(
-        help.contains("did you mean `- <output_name>: first_name`"),
-        "help must offer the near miss in the corrected shape: {help}"
+        help.contains("did you mean `- given_name: first_name`"),
+        "help must preserve the authored output name and offer the corrected source: {help}"
     );
     assert!(
         help.contains("'department'"),

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -294,6 +294,33 @@ impl Record {
             .map(|(i, name)| (name.as_ref(), &self.values[i]))
     }
 
+    /// Iterator over the correlation-lattice columns alone (`$ck.<field>`
+    /// source-CK shadows and `$ck.aggregate.<name>` synthetic-CK lineage),
+    /// in schema order.
+    ///
+    /// The complement of [`Record::iter_user_fields`] within
+    /// [`Record::iter_user_and_correlation_fields`]. Selects on
+    /// [`crate::schema::FieldMetadata`], never on a name prefix: `$` is not a
+    /// reserved namespace on the input side, so a source column legitimately
+    /// named `$id` or `$schema` — ordinary in JSON-Schema and MongoDB-shaped
+    /// payloads — carries `FieldMetadata::None` and is a user field, not an
+    /// engine one.
+    pub fn iter_correlation_fields(&self) -> impl Iterator<Item = (&str, &Value)> {
+        use crate::schema::FieldMetadata;
+        self.schema
+            .columns()
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| {
+                matches!(
+                    self.schema.field_metadata(*i),
+                    Some(FieldMetadata::SourceCorrelation { .. })
+                        | Some(FieldMetadata::AggregateGroupIndex { .. })
+                )
+            })
+            .map(|(i, name)| (name.as_ref(), &self.values[i]))
+    }
+
     /// Number of schema fields.
     pub fn field_count(&self) -> usize {
         self.schema.column_count()

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -625,12 +625,7 @@ fn main() -> ExitCode {
                         | PipelineError::CombineOutputCapExceeded { .. }
                         | PipelineError::EnvelopeMultiHeaderConflict { .. }
                         | PipelineError::EnvelopeHeaderGrainUnmatched { .. }
-                        | PipelineError::EnvelopeHeaderMultipleForGrain { .. }
-                        // E365 at the write boundary — the pipeline names a
-                        // column its own stream does not carry. A config
-                        // error the author fixes in the YAML, so exit 1 with
-                        // the rest of that class, not the data-quality exit 3.
-                        | PipelineError::OutputMappingColumnMissing { .. } => ExitCode::from(1),
+                        | PipelineError::EnvelopeHeaderMultipleForGrain { .. } => ExitCode::from(1),
                         // Disk-cap exceedance (E320) is a resource-exhaustion
                         // halt — the run filled its configured spill budget.
                         // Group it with the other infrastructure failures
@@ -2388,6 +2383,15 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
             "  Total: {} bytes (compare against the --explain estimate)",
             report.cumulative_spill_bytes
         );
+    }
+
+    // Advisory end-of-run findings — today the per-Output `mapping:` report
+    // (W365 / W366). Rendered like the startup storage warnings: to stderr and
+    // the tracing log, leaving stdout for the run summary, and never affecting
+    // the exit code. Each describes a file that was written and is readable.
+    for advisory in &report.advisories {
+        tracing::warn!("{advisory}");
+        eprintln!("{advisory}");
     }
 
     // Exit codes per spec §10.2. An interrupted run takes precedence:

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -625,7 +625,12 @@ fn main() -> ExitCode {
                         | PipelineError::CombineOutputCapExceeded { .. }
                         | PipelineError::EnvelopeMultiHeaderConflict { .. }
                         | PipelineError::EnvelopeHeaderGrainUnmatched { .. }
-                        | PipelineError::EnvelopeHeaderMultipleForGrain { .. } => ExitCode::from(1),
+                        | PipelineError::EnvelopeHeaderMultipleForGrain { .. }
+                        // E365 at the write boundary — the pipeline names a
+                        // column its own stream does not carry. A config
+                        // error the author fixes in the YAML, so exit 1 with
+                        // the rest of that class, not the data-quality exit 3.
+                        | PipelineError::OutputMappingColumnMissing { .. } => ExitCode::from(1),
                         // Disk-cap exceedance (E320) is a resource-exhaustion
                         // halt — the run filled its configured spill budget.
                         // Group it with the other infrastructure failures

--- a/docs/explain/E364.md
+++ b/docs/explain/E364.md
@@ -17,13 +17,16 @@ with the **output name on the left** and the source column on the right — the
 same side the first token of a bare item names. Declaration order is the output
 column order.
 
-E364 fires on three shapes the block cannot mean:
+E364 fires on the shapes the block cannot mean:
 
 | Written | Why it is rejected |
 |---------|--------------------|
 | `mapping:` written as a map (`sold_to: customer_id` with no `- `) | The map form is superseded. It could not express order, and it forced every passthrough column to name itself twice. |
+| `mapping: {}` or `mapping: []` | The block declares no columns, so it states the file carries none. Under `include_unmapped: false` that is an empty header and one blank line per record. To write every upstream column, remove the block rather than emptying it. |
 | The same output name twice | A written file cannot carry two columns under one header. A YAML map gave key uniqueness for free; a sequence has to enforce it. |
 | A mapping item reading a column this output's own `exclude:` removes | `exclude:` names incoming columns and runs before `mapping:` reads them, so the item could only ever produce nothing. |
+| `exclude:` naming a column the mapping *produces* | Same ordering, other direction: `exclude:` is consulted before the rename, so the output name does not exist yet and the exclusion suppresses nothing. The column would be written anyway. |
+| An output name that `include_unmapped: true` would also carry through | The file would carry two columns of that name. A schema's name index is last-write-wins, so readers would resolve the passthrough column and the mapped value would be lost. |
 
 A column named by the block that does not exist upstream is the neighbouring
 diagnostic **E365**, not this one.
@@ -109,6 +112,57 @@ nodes:
         - sold_to: customer_id
 ```
 
+<!-- explain-test: expect-code=E364 -->
+```yaml
+# Rejected: the block declares no columns, so it says the file carries none.
+# To write every upstream column, delete the `mapping:` key instead.
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      mapping: []
+```
+
+<!-- explain-test: expect-code=E364 -->
+```yaml
+# Rejected: `sold_to` is produced by the mapping AND already exists upstream.
+# `include_unmapped: true` would carry the upstream one through beside the
+# mapped one, and a reader resolving `sold_to` would get the upstream value.
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: customer_id, type: string }
+        - { name: sold_to, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      include_unmapped: true
+      mapping:
+        - sold_to: customer_id
+```
+
 <!-- explain-test: expect-clean -->
 ```yaml
 # Corrected: a sequence, one item per output column, each output name declared
@@ -140,42 +194,71 @@ nodes:
 
 ## How to fix
 
-1. **Lift a map into a sequence.** Put `- ` in front of each line. A pair whose
-   two sides are the same column collapses to a bare name:
+1. **Paste the rewritten block out of the diagnostic.** The help prints your own
+   map already converted — lifted into a sequence, identity pairs collapsed to
+   bare names, and **each pair's two sides swapped**:
 
    ```yaml
    # before                    # after
    mapping:                    mapping:
      order_id: order_id          - order_id
-     sold_to: customer_id        - sold_to: customer_id
+     customer_id: sold_to        - sold_to: customer_id
    ```
 
-   The diagnostic's help prints your own block already rewritten, so this is a
-   paste.
+   The swap is deliberate, and it is the part to understand before pasting. The
+   engine looked map entries up by the **incoming** field name, so the key was
+   the *source* column: `customer_id: sold_to` renamed `customer_id` to
+   `sold_to`. The sequence form puts the output name first, so that same rename
+   is `- sold_to: customer_id`. Lifting the line without swapping would invert
+   it and write the wrong column under the wrong header.
 
-2. **Check the direction while you are there.** The pair is
-   `output_name: source_column`. Releases before this one documented that
-   direction but implemented the reverse, so a block written against the old
-   *behaviour* — source on the left — needs its sides swapped as well as
-   lifted. A block written against the old *documentation* lifts unchanged.
+   **The one case where you should swap back:** a block written to follow the
+   old *documentation*, which described the opposite direction. Such a block
+   never renamed anything — its keys matched no incoming field, so every entry
+   fell through — so there is no behaviour to preserve, and what you want is
+   what you originally meant. If your `mapping:` was documented-direction and
+   you had noticed it doing nothing, swap the emitted pairs back.
 
-3. **Give each output column one item.** To write one upstream column into two
+2. **Give each output column one item.** To write one upstream column into two
    output columns, name each separately — `- sku` and `- item_code: sku` — which
    the sequence form allows because uniqueness is required on the output side,
    not the source side.
 
+3. **List the columns rather than emptying the block.** `mapping: {}` and
+   `mapping: []` declare an output with no columns. To write every upstream
+   column, delete the `mapping:` key entirely.
+
 4. **Pick one of `exclude:` and `mapping:` for a given column.** Under
    `include_unmapped: false` the mapping already selects: anything it does not
    list is dropped, so `exclude:` is redundant. Under `include_unmapped: true`,
-   `exclude:` is for columns you are *not* mapping.
+   `exclude:` is for columns you are *not* mapping. Either way `exclude:` names
+   **incoming** columns and runs first, so it can never refer to a name the
+   mapping produces.
+
+5. **Resolve a collision with a passthrough column** by renaming the mapped
+   column to a name upstream does not use, excluding the upstream column of that
+   name, or setting `include_unmapped: false` so the block is the whole output.
 
 ## Technical context
 
 The map form is not accepted alongside the sequence. It is parsed only so this
-diagnostic can carry a source span and echo the author's own pairs back in the
+diagnostic can carry a source span and rewrite the author's own pairs into the
 corrected shape — the same device the retired `array_paths:` key uses for
 **E360**. A captured map declares no entries, so it renames nothing even on a
-path that somehow skipped the gate; the failure mode is inert, not wrong.
+path that somehow skipped the gate; the failure mode is inert, not wrong. The
+gate keys off the block's *shape*, not off the capture having content, so an
+empty map is caught as the superseded form rather than reading as a well-formed
+block that happens to declare nothing.
+
+The collision check is why `mapping:` and `include_unmapped: true` are not
+independent. `SchemaBuilder` does not deduplicate, and a schema's name→index map
+is built last-write-wins, so two columns named `sold_to` on one record leave
+`Record::get("sold_to")` resolving to the second — the passthrough — and the
+mapped value never reaches the writer under its own header. The compile-time
+gate catches this wherever the planner can enumerate the upstream columns; the
+projection pass carries the same guard for the cases it cannot see (a
+composition body's open row, and columns expanded out of the `auto_widen`
+sidecar), where the mapped column wins and the passthrough is dropped.
 
 The move from a map to a sequence buys two things a map could not give. Order:
 a YAML map has no meaningful order to a reader, so the block could not state the

--- a/docs/explain/E364.md
+++ b/docs/explain/E364.md
@@ -1,0 +1,205 @@
+# Error E364: an Output's `mapping:` block is malformed or contradicts itself
+
+## What it means
+
+An Output node's `mapping:` block is the ordered declaration of the columns the
+file carries — which columns, under which names, in which order. It is a
+**sequence**, one item per output column:
+
+```yaml
+mapping:
+  - order_id                # carried through under its own name
+  - sold_to: customer_id    # output column `sold_to` reads `customer_id`
+```
+
+A bare scalar carries a column through unchanged. A single-key pair renames it,
+with the **output name on the left** and the source column on the right — the
+same side the first token of a bare item names. Declaration order is the output
+column order.
+
+E364 fires on three shapes the block cannot mean:
+
+| Written | Why it is rejected |
+|---------|--------------------|
+| `mapping:` written as a map (`sold_to: customer_id` with no `- `) | The map form is superseded. It could not express order, and it forced every passthrough column to name itself twice. |
+| The same output name twice | A written file cannot carry two columns under one header. A YAML map gave key uniqueness for free; a sequence has to enforce it. |
+| A mapping item reading a column this output's own `exclude:` removes | `exclude:` names incoming columns and runs before `mapping:` reads them, so the item could only ever produce nothing. |
+
+A column named by the block that does not exist upstream is the neighbouring
+diagnostic **E365**, not this one.
+
+## Example
+
+<!-- explain-test: expect-code=E364 -->
+```yaml
+# Rejected: the superseded map form. `mapping:` is a sequence now.
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: customer_id, type: string }
+        - { name: sku, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      mapping:
+        order_id: order_id
+        sold_to: customer_id
+        sku: sku
+```
+
+<!-- explain-test: expect-code=E364 -->
+```yaml
+# Rejected: `sku` is declared as an output column twice.
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: sku, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      mapping:
+        - sku
+        - sku: order_id
+```
+
+<!-- explain-test: expect-code=E364 -->
+```yaml
+# Rejected: `exclude:` removes `customer_id` before `mapping:` can read it, so
+# the `sold_to` column would never be written.
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: customer_id, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      exclude: [customer_id]
+      mapping:
+        - order_id
+        - sold_to: customer_id
+```
+
+<!-- explain-test: expect-clean -->
+```yaml
+# Corrected: a sequence, one item per output column, each output name declared
+# once. `order_id` and `sku` pass through; `customer_id` is written as
+# `sold_to`.
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: customer_id, type: string }
+        - { name: sku, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      mapping:
+        - order_id
+        - sold_to: customer_id
+        - sku
+```
+
+## How to fix
+
+1. **Lift a map into a sequence.** Put `- ` in front of each line. A pair whose
+   two sides are the same column collapses to a bare name:
+
+   ```yaml
+   # before                    # after
+   mapping:                    mapping:
+     order_id: order_id          - order_id
+     sold_to: customer_id        - sold_to: customer_id
+   ```
+
+   The diagnostic's help prints your own block already rewritten, so this is a
+   paste.
+
+2. **Check the direction while you are there.** The pair is
+   `output_name: source_column`. Releases before this one documented that
+   direction but implemented the reverse, so a block written against the old
+   *behaviour* — source on the left — needs its sides swapped as well as
+   lifted. A block written against the old *documentation* lifts unchanged.
+
+3. **Give each output column one item.** To write one upstream column into two
+   output columns, name each separately — `- sku` and `- item_code: sku` — which
+   the sequence form allows because uniqueness is required on the output side,
+   not the source side.
+
+4. **Pick one of `exclude:` and `mapping:` for a given column.** Under
+   `include_unmapped: false` the mapping already selects: anything it does not
+   list is dropped, so `exclude:` is redundant. Under `include_unmapped: true`,
+   `exclude:` is for columns you are *not* mapping.
+
+## Technical context
+
+The map form is not accepted alongside the sequence. It is parsed only so this
+diagnostic can carry a source span and echo the author's own pairs back in the
+corrected shape — the same device the retired `array_paths:` key uses for
+**E360**. A captured map declares no entries, so it renames nothing even on a
+path that somehow skipped the gate; the failure mode is inert, not wrong.
+
+The move from a map to a sequence buys two things a map could not give. Order:
+a YAML map has no meaningful order to a reader, so the block could not state the
+output column order, and the previous implementation rebuilt each record in the
+*input* record's order regardless of how the block was written. And legibility:
+in a thirteen-column output that renames one column, the renames are now the
+only items carrying a colon, so they are found by scanning for structure rather
+than by comparing two strings on every line.
+
+Identity-by-omission — a bare name means "unchanged", with no placeholder token
+spent on it — is the settled convention in query and object-construction
+languages. The alternatives were considered and rejected: a sentinel value like
+`status: _` draws from the same alphabet as the data (`_` is a legal column
+name, and reads as *discard* to anyone who has met it as a wildcard binding),
+and an empty value gives three interchangeable spellings of one thing
+(`status:`, `status: null`, `status: ~`) that common YAML linters flag by
+default.
+
+The gate runs over the call-site pipeline's nodes and again over each
+composition body's nodes, so an Output declared inside a composition body cannot
+bypass it.
+
+## See also
+
+- "Output Nodes → Field mapping" in the user guide
+- Error E365 — an Output's `mapping:` reads a column that does not exist there
+- Error E360 — a source still carrying the superseded `array_paths:` block

--- a/docs/explain/E364.md
+++ b/docs/explain/E364.md
@@ -25,8 +25,12 @@ E364 fires on the shapes the block cannot mean:
 | `mapping: {}` or `mapping: []` | The block declares no columns, so it states the file carries none. Under `include_unmapped: false` that is an empty header and one blank line per record. To write every upstream column, remove the block rather than emptying it. |
 | The same output name twice | A written file cannot carry two columns under one header. A YAML map gave key uniqueness for free; a sequence has to enforce it. |
 | A mapping item reading a column this output's own `exclude:` removes | `exclude:` names incoming columns and runs before `mapping:` reads them, so the item could only ever produce nothing. |
-| `exclude:` naming a column the mapping *produces* | Same ordering, other direction: `exclude:` is consulted before the rename, so the output name does not exist yet and the exclusion suppresses nothing. The column would be written anyway. |
 | An output name that `include_unmapped: true` would also carry through | The file would carry two columns of that name. A schema's name index is last-write-wins, so readers would resolve the passthrough column and the mapped value would be lost. |
+
+`exclude:` naming a column the mapping *produces* is **not** a fault. `exclude:`
+matches incoming names, so it removes the upstream column of that name and
+leaves the mapped one standing — which is one of the three fixes for the last
+row of that table.
 
 A column named by the block that does not exist upstream is the neighbouring
 diagnostic **E365**, not this one.
@@ -228,12 +232,14 @@ nodes:
    `mapping: []` declare an output with no columns. To write every upstream
    column, delete the `mapping:` key entirely.
 
-4. **Pick one of `exclude:` and `mapping:` for a given column.** Under
-   `include_unmapped: false` the mapping already selects: anything it does not
-   list is dropped, so `exclude:` is redundant. Under `include_unmapped: true`,
-   `exclude:` is for columns you are *not* mapping. Either way `exclude:` names
-   **incoming** columns and runs first, so it can never refer to a name the
-   mapping produces.
+4. **Do not exclude a column the mapping reads.** `exclude:` names **incoming**
+   columns and runs first, so excluding an item's source column removes it
+   before the item can read it. Under `include_unmapped: false` the mapping
+   already selects — anything it does not list is dropped — so `exclude:` is
+   redundant there anyway; under `include_unmapped: true` it is for columns you
+   are *not* mapping. Excluding a name the mapping **produces** is a different
+   thing and is allowed: it removes the upstream column of that name, which is
+   how you resolve a collision.
 
 5. **Resolve a collision with a passthrough column** by renaming the mapped
    column to a name upstream does not use, excluding the upstream column of that

--- a/docs/explain/E365.md
+++ b/docs/explain/E365.md
@@ -91,11 +91,11 @@ nodes:
    column absent from a source's `schema:` reaches the sink through the
    `auto_widen` sidecar, and the sidecar is expanded back to top-level fields
    only under `include_unmapped: true`. With that set, the mapping can name it
-   and the compile-time check stands down — unless the name is a near miss of a
-   column the row does declare, which is a misspelling however the column
-   travels. Under `include_unmapped: false` the sidecar stays packed and the
-   column is genuinely unreachable — set the flag, or declare the column in the
-   source's `schema:` block.
+   and the compile-time check stands down, even when the name resembles a
+   declared column: edit distance cannot prove a dynamic field is absent.
+   Under `include_unmapped: false` the sidecar stays packed and the column is
+   genuinely unreachable — set the flag, or declare the column in the source's
+   `schema:` block.
 
 4. **Emit it upstream.** If a transform's CXL stopped emitting the column, the
    mapping item is stale: restore the `emit`, or drop the item.
@@ -104,7 +104,7 @@ nodes:
    look for **W365** at the end of the run. That is the same fault seen from the
    other side: the planner could not rule the column out — it arrives through a
    composition port or the `auto_widen` sidecar — and no record turned out to
-   carry it. Run `clinker explain W365`.
+   carry it. Run `clinker explain --code W365`.
 
 ## Technical context
 
@@ -127,12 +127,11 @@ rather than rejecting a pipeline that works:
   Under `include_unmapped: false` the sidecar is never expanded, so the same
   entry cannot resolve and the check still applies.
 
-The sidecar waiver is **per item**, not per block. An item naming a column the
-row declares, or a near miss of one, keeps its diagnostic and its `did you mean`
-even under `auto_widen`: a name one edit away from a declared column is a
-misspelling of that column, not a drift column that happens to resemble it.
-Standing the whole block down would let a plain typo through under the commonest
-source configuration there is.
+The sidecar waiver applies to every item whose source is absent from the
+declared row. A near match still compiles: edit distance can offer a suggestion,
+but it cannot establish that a dynamic field is absent. If the name was a typo
+and no written record carries it, **W365** identifies it from the delivered
+stream instead.
 
 What the compile-time check cannot see, the **end of the run** reports as
 **W365**. Every record writes every column the block declares — an item whose

--- a/docs/explain/E365.md
+++ b/docs/explain/E365.md
@@ -1,0 +1,124 @@
+# Error E365: an Output's `mapping:` reads a column that does not exist there
+
+## What it means
+
+An item in an Output node's `mapping:` block names a source column the pipeline
+does not carry at that point in the graph. The pair form is
+`output_name: source_column`, so it is the **right-hand** side that must exist
+upstream; a bare item names a column that must exist under that same name.
+
+Almost always this is a typo, a column renamed upstream, or a block left behind
+after a transform stopped emitting something.
+
+The output schema is known before any input is opened, so this is answerable at
+compile time with a span. Previously it was not reported at all: an item that
+matched nothing fell through, the column kept whatever name it already had, and
+the run exited 0 with a header nobody had asked for. That silent outcome is what
+this diagnostic removes.
+
+The message names the column, and the help lists the columns that *are*
+available at that output — with a `did you mean` when one of them is a near
+miss.
+
+## Example
+
+<!-- explain-test: expect-code=E365 -->
+```yaml
+# Rejected: the column is `first_name`, not `firstname`. Before this diagnostic
+# existed the item matched nothing, the column kept the name `first_name`, and
+# the run exited 0.
+nodes:
+  - type: source
+    name: people
+    config:
+      name: people
+      type: csv
+      path: ./people.csv
+      schema:
+        - { name: first_name, type: string }
+        - { name: last_name, type: string }
+  - type: output
+    name: out
+    input: people
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      include_unmapped: false
+      mapping:
+        - given_name: firstname
+        - last_name
+```
+
+<!-- explain-test: expect-clean -->
+```yaml
+# Corrected: the source column on the right of the pair is one that exists.
+nodes:
+  - type: source
+    name: people
+    config:
+      name: people
+      type: csv
+      path: ./people.csv
+      schema:
+        - { name: first_name, type: string }
+        - { name: last_name, type: string }
+  - type: output
+    name: out
+    input: people
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      include_unmapped: false
+      mapping:
+        - given_name: first_name
+        - last_name
+```
+
+## How to fix
+
+1. **Read the help's column list.** It is the exact set of columns reaching that
+   output, in order. A `did you mean` line appears when the name you wrote is
+   within a small edit distance of one of them.
+
+2. **Check which side of the pair you meant.** The item is
+   `output_name: source_column` — output on the left. Naming the *output*
+   column on the right is the common way to land here after writing the block
+   from memory.
+
+3. **Declare the column if it only rides along.** A column absent from a
+   source's `schema:` reaches the sink only through the `auto_widen` sidecar. It
+   is undeclared as far as the rest of the pipeline is concerned — CXL cannot
+   name it either — so add it to the source's `schema:` block and the mapping
+   can name it.
+
+4. **Emit it upstream.** If a transform's CXL stopped emitting the column, the
+   mapping item is stale: restore the `emit`, or drop the item.
+
+## Technical context
+
+The check runs against the **closed** row bound to the output's upstream edge.
+A closed row is the ordinary case: a source declares a typed schema, and each
+node's row is derived from it, so a name absent from the row is a name the
+pipeline genuinely cannot supply.
+
+An **open** row is skipped. That is the composition-port case, where the
+caller's extra columns bind to the row variable and pass through by
+construction — a name missing from a body's declared row there is not evidence
+the column is absent at run time, and reporting it would reject a body that is
+correct for every caller.
+
+A name that two combine inputs both declare (`orders.id` and `products.id`) is
+present, not missing, so an ambiguous match satisfies the check; the qualified
+spelling `orders.id` is accepted as well as the bare one.
+
+The engine-stamped namespaces (`$widened`, `$source.*`, `$ck.*`) are left out of
+the suggestion list. They are not names a pipeline author is expected to type.
+
+## See also
+
+- "Output Nodes → Field mapping" in the user guide
+- Error E364 — an Output's `mapping:` block is malformed or contradicts itself
+- "Auto-Widen & Schema Drift" in the format reference, for columns that reach
+  the sink without being declared

--- a/docs/explain/E365.md
+++ b/docs/explain/E365.md
@@ -87,31 +87,63 @@ nodes:
    column on the right is the common way to land here after writing the block
    from memory.
 
-3. **Declare the column if it only rides along.** A column absent from a
-   source's `schema:` reaches the sink only through the `auto_widen` sidecar. It
-   is undeclared as far as the rest of the pipeline is concerned — CXL cannot
-   name it either — so add it to the source's `schema:` block and the mapping
-   can name it.
+3. **For a column that only rides along, set `include_unmapped: true`.** A
+   column absent from a source's `schema:` reaches the sink through the
+   `auto_widen` sidecar, and the sidecar is expanded back to top-level fields
+   only under `include_unmapped: true`. With that set, the mapping can name it
+   and the compile-time check stands down. Under `include_unmapped: false` the
+   sidecar stays packed and the column is genuinely unreachable — set the flag,
+   or declare the column in the source's `schema:` block.
 
 4. **Emit it upstream.** If a transform's CXL stopped emitting the column, the
    mapping item is stale: restore the `emit`, or drop the item.
 
+5. **If the error arrived at run time rather than at compile time**, the column
+   was one the planner could not rule out — it comes through a composition port
+   or the `auto_widen` sidecar — and the records themselves turned out not to
+   carry it. The name is wrong, the upstream stopped producing it, or the input
+   data changed shape. The message lists the columns the records actually had.
+
 ## Technical context
 
-The check runs against the **closed** row bound to the output's upstream edge.
-A closed row is the ordinary case: a source declares a typed schema, and each
-node's row is derived from it, so a name absent from the row is a name the
-pipeline genuinely cannot supply.
+E365 has two surfaces, because one of them cannot see every case.
 
-An **open** row is skipped. That is the composition-port case, where the
-caller's extra columns bind to the row variable and pass through by
-construction — a name missing from a body's declared row there is not evidence
-the column is absent at run time, and reporting it would reject a body that is
-correct for every caller.
+**At compile time**, the check runs against the **closed** row bound to the
+output's upstream edge. A closed row is the ordinary case: a source declares a
+typed schema, each node's row is derived from it, so a name absent from the row
+is a name the pipeline genuinely cannot supply.
 
-A name that two combine inputs both declare (`orders.id` and `products.id`) is
-present, not missing, so an ambiguous match satisfies the check; the qualified
-spelling `orders.id` is accepted as well as the bare one.
+Two situations are deliberately not decidable there, and the compile-time half
+stands down for both rather than rejecting a pipeline that works:
+
+- An **open** row — the composition-body case, where the caller's extra columns
+  bind to the row variable and pass through by construction. A name missing
+  from a body's declared row is not evidence the column is absent at run time,
+  and reporting it would reject a body that is correct for every caller.
+- A row that reserves the **`auto_widen` sidecar**, under
+  `include_unmapped: true`. The sidecar absorbs columns the schema does not
+  declare, and `include_unmapped: true` expands it back to top-level fields
+  *before* the mapping reads them — so a drift column really is nameable there.
+  Under `include_unmapped: false` the sidecar is never expanded, so the same
+  entry cannot resolve and the compile-time check still applies.
+
+**At the write boundary**, the check runs again — once per output stream, when
+the output schema is established from the stream's own records, never per
+record. That is what covers the two cases above: whatever the planner could not
+decide, the writer can, because by then the columns are real. Column names are a
+property of the stream, not of one row, so one check at schema establishment
+answers it for the whole file.
+
+The runtime surface is not a nicety. `mapping:` **selects** the output columns,
+so an entry that resolves to nothing does not leave a column unrenamed — it
+removes the column from the file. With `include_unmapped: false` a block none of
+whose entries resolve writes an empty header and one blank line per record. The
+run is stopped instead.
+
+Column names are matched **bare**. An Output's upstream row carries only bare
+names — a Combine publishes its merged row with the qualifier stripped — so
+there is no qualified spelling to write, and `orders.id` in a `mapping:` item
+names a column called literally `orders.id`.
 
 The engine-stamped namespaces (`$widened`, `$source.*`, `$ck.*`) are left out of
 the suggestion list. They are not names a pipeline author is expected to type.

--- a/docs/explain/E365.md
+++ b/docs/explain/E365.md
@@ -91,30 +91,30 @@ nodes:
    column absent from a source's `schema:` reaches the sink through the
    `auto_widen` sidecar, and the sidecar is expanded back to top-level fields
    only under `include_unmapped: true`. With that set, the mapping can name it
-   and the compile-time check stands down. Under `include_unmapped: false` the
-   sidecar stays packed and the column is genuinely unreachable — set the flag,
-   or declare the column in the source's `schema:` block.
+   and the compile-time check stands down — unless the name is a near miss of a
+   column the row does declare, which is a misspelling however the column
+   travels. Under `include_unmapped: false` the sidecar stays packed and the
+   column is genuinely unreachable — set the flag, or declare the column in the
+   source's `schema:` block.
 
 4. **Emit it upstream.** If a transform's CXL stopped emitting the column, the
    mapping item is stale: restore the `emit`, or drop the item.
 
-5. **If the error arrived at run time rather than at compile time**, the column
-   was one the planner could not rule out — it comes through a composition port
-   or the `auto_widen` sidecar — and the records themselves turned out not to
-   carry it. The name is wrong, the upstream stopped producing it, or the input
-   data changed shape. The message lists the columns the records actually had.
+5. **If nothing was reported at compile time but the column came out empty**,
+   look for **W365** at the end of the run. That is the same fault seen from the
+   other side: the planner could not rule the column out — it arrives through a
+   composition port or the `auto_widen` sidecar — and no record turned out to
+   carry it. Run `clinker explain W365`.
 
 ## Technical context
 
-E365 has two surfaces, because one of them cannot see every case.
+E365 is the compile-time half of a pair. It runs against the **closed** row
+bound to the output's upstream edge. A closed row is the ordinary case: a source
+declares a typed schema, each node's row is derived from it, so a name absent
+from the row is a name the pipeline genuinely cannot supply.
 
-**At compile time**, the check runs against the **closed** row bound to the
-output's upstream edge. A closed row is the ordinary case: a source declares a
-typed schema, each node's row is derived from it, so a name absent from the row
-is a name the pipeline genuinely cannot supply.
-
-Two situations are deliberately not decidable there, and the compile-time half
-stands down for both rather than rejecting a pipeline that works:
+Two situations are not decidable there, and the check stands down for both
+rather than rejecting a pipeline that works:
 
 - An **open** row — the composition-body case, where the caller's extra columns
   bind to the row variable and pass through by construction. A name missing
@@ -125,20 +125,22 @@ stands down for both rather than rejecting a pipeline that works:
   declare, and `include_unmapped: true` expands it back to top-level fields
   *before* the mapping reads them — so a drift column really is nameable there.
   Under `include_unmapped: false` the sidecar is never expanded, so the same
-  entry cannot resolve and the compile-time check still applies.
+  entry cannot resolve and the check still applies.
 
-**At the write boundary**, the check runs again — once per output stream, when
-the output schema is established from the stream's own records, never per
-record. That is what covers the two cases above: whatever the planner could not
-decide, the writer can, because by then the columns are real. Column names are a
-property of the stream, not of one row, so one check at schema establishment
-answers it for the whole file.
+The sidecar waiver is **per item**, not per block. An item naming a column the
+row declares, or a near miss of one, keeps its diagnostic and its `did you mean`
+even under `auto_widen`: a name one edit away from a declared column is a
+misspelling of that column, not a drift column that happens to resemble it.
+Standing the whole block down would let a plain typo through under the commonest
+source configuration there is.
 
-The runtime surface is not a nicety. `mapping:` **selects** the output columns,
-so an entry that resolves to nothing does not leave a column unrenamed — it
-removes the column from the file. With `include_unmapped: false` a block none of
-whose entries resolve writes an empty header and one blank line per record. The
-run is stopped instead.
+What the compile-time check cannot see, the **end of the run** reports as
+**W365**. Every record writes every column the block declares — an item whose
+source the record lacks writes an empty value rather than dropping the column —
+so an item no record ever resolved produced an empty column throughout, and that
+is what W365 names. This is more precise than any schema-derived check could be:
+an item some records resolve and others do not is a sparse column in a
+heterogeneous stream, and is correctly left alone.
 
 Column names are matched **bare**. An Output's upstream row carries only bare
 names — a Combine publishes its merged row with the qualifier stripped — so

--- a/docs/explain/W365.md
+++ b/docs/explain/W365.md
@@ -1,0 +1,123 @@
+# Warning W365: a `mapping:` item's column was on no record
+
+## What it means
+
+An Output's `mapping:` block names a source column, the run finished, and not
+one record carried that column. The item therefore wrote an empty value in every
+row of the file.
+
+The file is written and readable — that is why this is a warning and not an
+error. But an output column that is empty in every row is almost never what the
+block meant to declare. The usual causes are a misspelled column name, a column
+the upstream stopped producing, or input data that changed shape.
+
+This is the run-time counterpart of **E365**. The compile-time check catches the
+same fault wherever the planner can enumerate the columns reaching that output;
+W365 covers what it cannot see — a mapping inside a composition body, whose rows
+are open by construction, and a column expected to arrive through the
+`auto_widen` sidecar.
+
+The warning prints to standard error when the run finishes, names the output and
+the column, and **does not change the exit code**.
+
+## Example
+
+<!-- explain-test: expect-clean -->
+```yaml
+# Compiles clean, then warns at the end of the run. `goes_by` is not in the
+# source's `schema:`, so it could only arrive through the `auto_widen` sidecar,
+# and `include_unmapped: true` expands the sidecar before the mapping reads it —
+# the planner cannot rule the column out. If the data never carries it, the
+# `nickname` column is empty in every row and W365 says so.
+nodes:
+  - type: source
+    name: people
+    config:
+      name: people
+      type: csv
+      path: ./people.csv
+      schema:
+        - { name: first_name, type: string }
+  - type: output
+    name: out
+    input: people
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      include_unmapped: true
+      mapping:
+        - first_name
+        - nickname: goes_by
+```
+
+Given `people.csv` carrying only `first_name`, the run writes:
+
+```text
+first_name,nickname
+Alice,
+```
+
+and reports:
+
+```text
+W365 output 'out': `mapping:` reads column(s) 'goes_by', which no record
+carried — those output columns are empty in every row. Check the spelling, or
+remove the item if the column is gone from upstream
+```
+
+## How to fix
+
+Pick whichever applies:
+
+1. **Correct the spelling.** Compare the name against a column the data actually
+   carries. This is the common case, and it is the one the compile-time E365
+   would have caught had the column set been visible.
+
+2. **Delete the item.** If the column is genuinely gone from upstream, the block
+   is stale. Removing the item removes the empty column from the file.
+
+3. **Declare the column in the source's `schema:`.** Then the compile-time check
+   can see it, and a future misspelling is rejected with a `did you mean` before
+   the run starts rather than reported after it.
+
+4. **Ignore it** if an all-empty column is intended — a fixed-shape file whose
+   consumer requires the column present whether or not this batch populates it.
+   The run's exit code is unaffected.
+
+## Technical context
+
+Every record projects the **full declared column set**, in declaration order. An
+item whose source the record does not carry writes an empty value rather than
+dropping the column, so the file's shape is a function of the config alone and
+not of whichever record happened to arrive first.
+
+That is what makes this warning precise. The engine tracks, per Output, whether
+each item's source resolved on **any** record, and reports at end of stream the
+items that resolved on **none**. A misspelling is supplied by no record, so it
+fires. A column only some records carry — an ordinary sparse column in a
+heterogeneous stream — is supplied by some record, so it does not.
+
+Asking the question over the whole stream is what the earlier design could not
+do. Checking the established output schema instead looked cheaper, but that
+schema is derived from the **first record** on every write path except the
+buffered CSV union, so it answered a different question: it aborted runs whose
+first record merely happened to be sparse, and stayed silent about a column
+absent from every record after the first.
+
+The state is bounded and does not grow with input: one flag per mapping item,
+allocated once per Output, set on first hit. The per-record path only sets a
+flag.
+
+The report is advisory rather than fatal by construction. It can only be
+produced once the stream has ended, and by then the run's other outputs have
+already been flushed — aborting there would leave a half-written run behind for
+a fault that is plainly visible in the file itself.
+
+## See also
+
+- Error E365 — an Output's `mapping:` reads a column that does not exist there
+- Warning W366 — an upstream column a `mapping:` output name displaced
+- "Output Nodes → Field mapping" in the user guide
+- "Auto-Widen & Schema Drift" in the format reference, for columns that reach
+  the sink without being declared

--- a/docs/explain/W366.md
+++ b/docs/explain/W366.md
@@ -1,0 +1,117 @@
+# Warning W366: an upstream column was displaced by a `mapping:` output name
+
+## What it means
+
+An Output's `mapping:` block writes a column under some name, `include_unmapped:
+true` would also have carried an upstream column of that same name through, and
+only one of them can occupy the header. The **mapped** value is what the file
+carries — the block is your explicit statement of what the output contains — and
+the upstream column of that name was dropped.
+
+W366 names the dropped column. Without it the loss would be silent, which is the
+one outcome that is not acceptable: real upstream data leaves the pipeline and
+nothing says so.
+
+The warning prints to standard error when the run finishes and **does not change
+the exit code**. The file is written and readable; every row carries the mapped
+value under that header, consistently.
+
+Where the planner can enumerate the columns reaching the output, the same
+collision is rejected at compile time as **E364** instead. W366 is for where it
+cannot: a mapping inside a composition body, whose rows are open by
+construction, and a column arriving through the `auto_widen` sidecar.
+
+## Example
+
+<!-- explain-test: expect-clean -->
+```yaml
+# Compiles clean, then warns at the end of the run. The mapping writes a
+# `sold_to` column read from `customer_id`. If the input file also carries a
+# column literally named `sold_to`, it is not in the source's `schema:`, so it
+# arrives through the `auto_widen` sidecar — which `include_unmapped: true`
+# expands — and collides with the name the mapping writes.
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: customer_id, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+      include_unmapped: true
+      mapping:
+        - order_id
+        - sold_to: customer_id
+```
+
+Given an `orders.csv` that also carries a `sold_to` column, the run reports:
+
+```text
+W366 output 'out': upstream column(s) 'sold_to' were dropped because `mapping:`
+writes an output column of the same name; the mapped value is what the file
+carries. Rename the mapped column, or add the upstream name to this output's
+`exclude:` to state the intent
+```
+
+## How to fix
+
+Pick whichever applies:
+
+1. **Exclude the upstream column**, if displacing it is what you meant:
+
+   ```yaml
+         exclude: [sold_to]
+         mapping:
+           - order_id
+           - sold_to: customer_id
+   ```
+
+   `exclude:` matches **incoming** names and runs before the mapping, so this
+   removes the upstream `sold_to` and leaves the mapped one standing. The
+   behaviour is identical; the warning stops, because the intent is now on the
+   page.
+
+2. **Rename the mapped column** to a name the input does not use, if you meant
+   to keep both:
+
+   ```yaml
+         mapping:
+           - order_id
+           - sold_to_id: customer_id
+   ```
+
+3. **Set `include_unmapped: false`**, if the block is meant to be the whole
+   output. Nothing is appended, so nothing can collide.
+
+4. **Declare the column in the source's `schema:`.** Then the planner can see
+   the collision and rejects it as E364 before the run starts.
+
+## Technical context
+
+The mapped value wins because the alternative is worse. A schema's name index is
+last-write-wins, so appending the passthrough column beside the mapped one would
+make it answer lookups for the mapped column and serve its value under the mapped
+header — the block would silently write something other than what it declares.
+Dropping the passthrough is deterministic and documented; the only defect was
+that it used to be silent.
+
+The engine records the displaced names per Output, first-seen order, and reports
+them once when the stream ends. The state is bounded by the number of distinct
+displaced columns, not by input size.
+
+## See also
+
+- Error E364 — an Output's `mapping:` block is malformed or contradicts itself
+- Warning W365 — a `mapping:` item's column was on no record
+- "Output Nodes → Field mapping" in the user guide
+- "Auto-Widen & Schema Drift" in the format reference, for columns that reach
+  the sink without being declared

--- a/docs/explain/W366.md
+++ b/docs/explain/W366.md
@@ -104,9 +104,9 @@ header — the block would silently write something other than what it declares.
 Dropping the passthrough is deterministic and documented; the only defect was
 that it used to be silent.
 
-The engine records the displaced names per Output, first-seen order, and reports
-them once when the stream ends. The state is bounded by the number of distinct
-displaced columns, not by input size.
+The engine records the displaced names per Output and reports them once when the
+stream ends, in `mapping:` declaration order. The state is bounded by the number
+of declared mapping columns, not by input size.
 
 ## See also
 

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -71,15 +71,68 @@ The CSV, XML, fixed-width, EDIFACT, X12, and HL7 writers can only write flat sca
 
 ### Field mapping
 
-Rename fields at output time without changing upstream CXL:
+`mapping:` declares the columns the file carries -- which columns, under what
+names, in what order -- without changing upstream CXL. It is a sequence, one
+item per output column:
 
 ```yaml
     mapping:
-      "Customer Name": "full_name"
-      "Order Total": "amount"
+      - order_id                  # carried through under its own name
+      - sold_to: customer_id      # written as `sold_to`, read from `customer_id`
+      - contact_email: customer_email
+      - channel
+      - sku
 ```
 
-Keys are output column names; values are the source field names from upstream.
+Two item shapes:
+
+- **A bare column name** emits that column unchanged. This is the common case,
+  and it costs one line naming the column once.
+- **A single-key pair** renames. The **output name is on the left**, the source
+  column on the right -- the same side the bare form names. Reading an item
+  left to right always tells you what appears in the file first.
+
+The renames are the only items carrying a colon, so in a wide output they are
+found by scanning for structure rather than by comparing two names per line.
+
+#### Order and selection
+
+**Declaration order is the output column order.** Listed columns are written
+first, in the order the block declares them, whatever order they arrive in.
+
+**`include_unmapped` governs everything the block does not list.** With
+`include_unmapped: true` (the default) unlisted columns are appended after the
+declared ones, in their existing relative order. With `include_unmapped: false`
+they are dropped, so the block becomes the complete statement of the output:
+
+```yaml
+    include_unmapped: false
+    mapping:
+      - department
+      - surname: last_name
+      - first_name
+```
+
+Given upstream columns `first_name, last_name, department`, that writes exactly
+`department,surname,first_name`.
+
+One upstream column may feed two output columns -- `- sku` and
+`- item_code: sku` -- because names must be unique on the output side, not the
+source side. Declaring the same *output* name twice is rejected (**E364**): a
+file cannot carry two columns under one header.
+
+#### Diagnostics
+
+A `mapping:` item naming a column that does not exist at that point in the
+pipeline is rejected at compile time (**E365**), with the available column list
+and a `did you mean` when the name is a near miss. Nothing is renamed silently.
+
+Writing the block as a YAML map instead of a sequence is rejected (**E364**);
+the message prints your own block already rewritten. Run `clinker explain E364`
+for the migration, including the direction change -- releases before this one
+documented `output_name: source_field` but implemented the reverse, so a block
+written against the old *behaviour* needs its two sides swapped as well as
+lifted into a sequence.
 
 ### Excluding fields
 
@@ -381,10 +434,10 @@ This is automatic — there is no setting to enable it. It applies only to this 
     type: csv
     path: "./output/employees.csv"
     mapping:
-      "Employee ID": "employee_id"
-      "Full Name": "display_name"
-      "Department": "department"
-      "Annual Salary": "salary"
+      - "Employee ID": employee_id
+      - "Full Name": display_name
+      - department
+      - "Annual Salary": salary
     exclude: [internal_flags]
     include_header: true
     sort_order:

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -121,18 +121,40 @@ One upstream column may feed two output columns -- `- sku` and
 source side. Declaring the same *output* name twice is rejected (**E364**): a
 file cannot carry two columns under one header.
 
+For the same reason, an output name that `include_unmapped: true` would also
+carry through is rejected. If upstream already has a `sold_to` column, writing
+`- sold_to: customer_id` under `include_unmapped: true` would put two `sold_to`
+columns in the file and readers would resolve the wrong one. Rename the mapped
+column, exclude the upstream one, or set `include_unmapped: false`.
+
 #### Diagnostics
 
 A `mapping:` item naming a column that does not exist at that point in the
 pipeline is rejected at compile time (**E365**), with the available column list
 and a `did you mean` when the name is a near miss. Nothing is renamed silently.
 
+Because `mapping:` *selects*, an item that resolves to nothing removes a column
+from the file rather than leaving it unrenamed -- so where the compiler cannot
+prove the column absent, the check runs again at the write boundary, once per
+output, before the first byte. That covers a mapping inside a composition body
+and a column arriving through the `auto_widen` sidecar. Both surface as
+**E365**.
+
+A column absent from the source's `schema:` reaches the sink only through the
+`auto_widen` sidecar, which is expanded to top-level columns only under
+`include_unmapped: true`. A `mapping:` item may name such a column when that
+flag is set; under `include_unmapped: false` it cannot resolve and is rejected.
+
+An empty block -- `mapping: {}` or `mapping: []` -- is rejected (**E364**): it
+declares an output with no columns. To write every upstream column, remove the
+`mapping:` key rather than emptying it.
+
 Writing the block as a YAML map instead of a sequence is rejected (**E364**);
 the message prints your own block already rewritten. Run `clinker explain E364`
-for the migration, including the direction change -- releases before this one
-documented `output_name: source_field` but implemented the reverse, so a block
-written against the old *behaviour* needs its two sides swapped as well as
-lifted into a sequence.
+for the migration, and read the direction note there before pasting: releases
+before this one documented `output_name: source_field` but *executed* the
+reverse, so the rewrite swaps each pair's two sides to preserve what the
+pipeline was actually writing.
 
 ### Excluding fields
 
@@ -433,12 +455,16 @@ This is automatic — there is no setting to enable it. It applies only to this 
     name: department_reports
     type: csv
     path: "./output/employees.csv"
+    # `include_unmapped: false` makes the mapping the whole output: these four
+    # columns, in this order, and nothing else. Without it every unlisted
+    # upstream column would still be appended after them, and an `exclude:`
+    # would be needed to keep any of them out.
+    include_unmapped: false
     mapping:
       - "Employee ID": employee_id
       - "Full Name": display_name
       - department
       - "Annual Salary": salary
-    exclude: [internal_flags]
     include_header: true
     sort_order:
       - { field: "department", order: asc }

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -149,9 +149,9 @@ and a `did you mean` when the name is a near miss. Nothing is renamed silently.
 The compiler cannot always see the column set. Inside a composition body the
 rows are open by construction, and under `on_unmapped: auto_widen` a column can
 reach the sink through the sidecar without being declared anywhere. There an
-item naming an unknown column compiles, unless the name is a near miss of a
-column that *is* declared -- a misspelling of a known column keeps its **E365**
-and its `did you mean` even under `auto_widen`.
+item naming an unknown column compiles even when its name resembles a declared
+column: spelling similarity cannot prove that a dynamic field is absent.
+**W365** reports it after the run if no written record supplied it.
 
 What catches the rest is the end of the run: if no record supplied an item's
 source column, that item wrote an empty column in every row, and the run reports
@@ -174,7 +174,7 @@ declares an output with no columns. To write every upstream column, remove the
 `mapping:` key rather than emptying it.
 
 Writing the block as a YAML map instead of a sequence is rejected (**E364**);
-the message prints your own block already rewritten. Run `clinker explain E364`
+the message prints your own block already rewritten. Run `clinker explain --code E364`
 for the migration, and read the direction note there before pasting: releases
 before this one documented `output_name: source_field` but *executed* the
 reverse, so the rewrite swaps each pair's two sides to preserve what the

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -116,6 +116,13 @@ they are dropped, so the block becomes the complete statement of the output:
 Given upstream columns `first_name, last_name, department`, that writes exactly
 `department,surname,first_name`.
 
+**Every record carries every declared column.** When a record does not supply an
+item's source column, that column is still written, empty. The file's shape
+follows the block, not the data — so a stream whose records differ in shape (a
+multi-record-type source, a column arriving through `auto_widen`, a composition
+body's open row) still produces one stable column set in declaration order,
+rather than one that depends on which record happened to arrive first.
+
 One upstream column may feed two output columns -- `- sku` and
 `- item_code: sku` -- because names must be unique on the output side, not the
 source side. Declaring the same *output* name twice is rejected (**E364**): a
@@ -127,23 +134,40 @@ carry through is rejected. If upstream already has a `sold_to` column, writing
 columns in the file and readers would resolve the wrong one. Rename the mapped
 column, exclude the upstream one, or set `include_unmapped: false`.
 
+Where the compiler cannot enumerate the upstream columns, the same collision
+reaches the run. The mapped value wins -- the block is your explicit statement
+of what the file carries -- and the displaced upstream column is named in a
+**W366** warning at the end of the run. Applying one of the three fixes above
+silences it.
+
 #### Diagnostics
 
 A `mapping:` item naming a column that does not exist at that point in the
 pipeline is rejected at compile time (**E365**), with the available column list
 and a `did you mean` when the name is a near miss. Nothing is renamed silently.
 
-Because `mapping:` *selects*, an item that resolves to nothing removes a column
-from the file rather than leaving it unrenamed -- so where the compiler cannot
-prove the column absent, the check runs again at the write boundary, once per
-output, before the first byte. That covers a mapping inside a composition body
-and a column arriving through the `auto_widen` sidecar. Both surface as
-**E365**.
+The compiler cannot always see the column set. Inside a composition body the
+rows are open by construction, and under `on_unmapped: auto_widen` a column can
+reach the sink through the sidecar without being declared anywhere. There an
+item naming an unknown column compiles, unless the name is a near miss of a
+column that *is* declared -- a misspelling of a known column keeps its **E365**
+and its `did you mean` even under `auto_widen`.
+
+What catches the rest is the end of the run: if no record supplied an item's
+source column, that item wrote an empty column in every row, and the run reports
+it as **W365**, naming the column to correct. An item some records supply and
+others do not is a sparse column, not a mistake, and is not reported.
+
+Both **W365** and **W366** are advisory. They print to standard error when the
+run finishes and do not change the exit code -- the file is written and readable
+either way, and by the time a stream ends the run's other outputs have already
+been flushed.
 
 A column absent from the source's `schema:` reaches the sink only through the
 `auto_widen` sidecar, which is expanded to top-level columns only under
 `include_unmapped: true`. A `mapping:` item may name such a column when that
-flag is set; under `include_unmapped: false` it cannot resolve and is rejected.
+flag is set; under `include_unmapped: false` it cannot resolve and is rejected
+at compile time.
 
 An empty block -- `mapping: {}` or `mapping: []` -- is rejected (**E364**): it
 declares an output with no columns. To write every upstream column, remove the
@@ -163,6 +187,21 @@ Remove specific fields from output:
 ```yaml
     exclude: [internal_id, _debug_flag, temp_calc]
 ```
+
+`exclude:` matches **incoming** column names, and runs before `mapping:`. Two
+consequences:
+
+- The columns that survive keep their relative order. Upstream `a, b, c, d` with
+  `exclude: [b]` writes `a, c, d`.
+- Naming a column that a `mapping:` item also *produces* is not a conflict --
+  the exclusion removes the upstream column of that name and leaves the mapped
+  one standing. That is the fix for the two-columns-under-one-header collision
+  above: `- sold_to: customer_id` with `exclude: [sold_to]` writes one `sold_to`
+  column, carrying `customer_id`'s value.
+
+Excluding a column a `mapping:` item *reads* is a different matter, and is
+rejected (**E364**): the exclusion removes the column before the item can read
+it, so the item could never resolve.
 
 ### Header control (CSV)
 

--- a/examples/scenarios/01-storefront-orders/README.md
+++ b/examples/scenarios/01-storefront-orders/README.md
@@ -70,10 +70,10 @@ rides along.
 
 **Column order.** Emitted columns that exist in the source schema come first in
 schema order; derived columns follow in emit order, which is why
-`gross_amount` and `line_total` are last. The Output node has a `mapping:` key
-that looks like it should control this, but its behaviour is under review in
-[#974](https://github.com/rustpunk/clinker/issues/974) — rename in the transform
-instead, where the reader can see it happen.
+`gross_amount` and `line_total` are last. The Output node's `mapping:` key can
+state the order explicitly instead — it declares the output columns, their
+names, and their order in one sequence. This scenario renames in the transform
+so the emitted names and the written header are read from one place.
 
 **Row order is stable because the read is.** A single-file source delivers
 records in file order, deterministically, so this output is byte-comparable

--- a/examples/scenarios/01-storefront-orders/pipeline.yaml
+++ b/examples/scenarios/01-storefront-orders/pipeline.yaml
@@ -74,7 +74,8 @@ nodes:
       # appear last.
       #
       # Renaming happens in the transform above rather than through the Output
-      # node's `mapping:`, which is under review in #974.
+      # node's `mapping:`. Either works; keeping it in the transform means the
+      # emitted names and the written header are read from one place.
       include_unmapped: false
       # Row order here is the order the reader delivers records, which is
       # deterministic for a single file — that is what makes this output


### PR DESCRIPTION
Closes #974.
Closes #977.

Output `mapping:` is now an ordered sequence with one item per written column:

```yaml
mapping:
  - order_id
  - sold_to: customer_id
  - channel
```

A bare scalar carries a column through under its own name. A single-key item uses `output_name: source_column`. Declaration order is output-column order.

## Why this changes

The old map was ambiguous in practice: planning and documentation treated the left side as the output name, while execution treated it as the source name. A block written from the documentation could therefore rename nothing and still complete successfully. A sequence makes order explicit, gives identity columns a short form, and applies uniqueness to the output names a writer actually constrains.

The superseded map form is captured long enough to produce E364 with a pasteable sequence rewrite. E364 also covers empty mappings, duplicate output names, exclusion conflicts, and output/passthrough collisions. E365 identifies source columns that are provably absent and points at the offending mapping item.

For open rows and `auto_widen` sidecars, compile time cannot prove a dynamic field is absent. Those entries compile; W365 reports a source that no delivered record supplied. W366 reports an upstream passthrough displaced by a mapped output name. Both advisories are based only on successfully delivered records, preserve Output and mapping declaration order, and do not turn a completed multi-output run into a partial failure.

## Runtime and memory behavior

Projection writes every declared mapping column on every row, using null when that row does not carry the source field. The common projection path performs no per-record probe allocation. Advisory state is fixed by the authored mapping size, rejected and dead-lettered rows are discarded from the evidence, and Outputs without `mapping:` bypass probe work. No dependency, native build step, or C implementation is added.

## Compatibility

This is a breaking YAML and Rust API migration:

- map-valued `mapping:` becomes the ordered sequence above;
- `OutputConfig.mapping` becomes `Option<OutputMapping>`;
- `OutputSpec.mapping` becomes `Vec<MappingEntry>`;
- `ExecutionReport` struct literals must provide `advisories`.

The changelog, Output guide, explain pages, scenario, and benchmark fixture have been updated with the migration and corrected behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --locked --offline -- -D warnings`
- `cargo clippy --workspace --all-targets --locked --offline -- -D warnings`
- `cargo test --offline -p clinker-plan`
- `cargo test --offline -p clinker-exec -- --test-threads=1`
- `cargo check --benches --workspace --locked --offline`
- `mdbook build docs/user`
- `mdbook build docs/engine`
- `git diff --check`
