### PR TITLE
exec: fail loudly on missing planned node-buffer inputs

### DIFF
--- a/benches/pipelines/cxl_ops/filter_selectivity.yaml
+++ b/benches/pipelines/cxl_ops/filter_selectivity.yaml
@@ -2,12 +2,37 @@ pipeline:
   name: bench-filter-selectivity
 
 nodes:
+  # Keep each selectivity path independent until source fan-out is safe (#908).
   - type: source
-    name: source
+    name: source_90pct
     config:
-      name: source
+      name: source_90pct
       type: csv
-      path: bench://input.csv
+      path: bench://input_90.csv
+      options:
+        has_header: true
+      schema:
+        - { name: f0, type: int }
+        - { name: f1, type: string }
+
+  - type: source
+    name: source_50pct
+    config:
+      name: source_50pct
+      type: csv
+      path: bench://input_50.csv
+      options:
+        has_header: true
+      schema:
+        - { name: f0, type: int }
+        - { name: f1, type: string }
+
+  - type: source
+    name: source_10pct
+    config:
+      name: source_10pct
+      type: csv
+      path: bench://input_10.csv
       options:
         has_header: true
       schema:
@@ -16,7 +41,7 @@ nodes:
 
   - type: transform
     name: filter_90pct
-    input: source
+    input: source_90pct
     config:
       cxl: |
         filter f0 > 100000
@@ -24,7 +49,7 @@ nodes:
 
   - type: transform
     name: filter_50pct
-    input: source
+    input: source_50pct
     config:
       cxl: |
         filter f0 > 500000
@@ -32,7 +57,7 @@ nodes:
 
   - type: transform
     name: filter_10pct
-    input: source
+    input: source_10pct
     config:
       cxl: |
         filter f0 > 900000

--- a/benches/pipelines/realistic/route_fanout.yaml
+++ b/benches/pipelines/realistic/route_fanout.yaml
@@ -34,29 +34,9 @@ nodes:
         medium: "priority == \"medium\""
       default: low
 
-  - type: aggregate
-    name: agg_high
-    input: split.high
-    config:
-      group_by: [priority]
-      strategy: hash
-      cxl: |
-        emit total = sum(value)
-        emit n = count(*)
-
-  - type: aggregate
-    name: agg_low
-    input: split.low
-    config:
-      group_by: [priority]
-      strategy: hash
-      cxl: |
-        emit total = sum(value)
-        emit n = count(*)
-
   - type: output
     name: high_out
-    input: agg_high
+    input: split.high
     config:
       name: high_out
       type: csv
@@ -74,7 +54,7 @@ nodes:
 
   - type: output
     name: low_out
-    input: agg_low
+    input: split.low
     config:
       name: low_out
       type: csv

--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -18,8 +18,8 @@ use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
     ExecutorContext, RetainedAggregatorState, admit_node_buffer, advance_cursor,
-    drain_node_buffer_slot, finalize_node_rooted_windows, node_buffer_spill_allowed,
-    project_rows_to_buffer_schema, push_dlq, record_error_to_buffer_if_grouped, source_file_arc_of,
+    finalize_node_rooted_windows, node_buffer_spill_allowed, project_rows_to_buffer_schema,
+    push_dlq, record_error_to_buffer_if_grouped, require_node_buffer_slot, source_file_arc_of,
     source_name_arc_of, stream_linear_producer_emit, tee_emit_to_region_input_buffers,
 };
 use crate::executor::schema_check::check_input_schema;
@@ -157,15 +157,24 @@ pub(crate) fn dispatch_aggregation(
         return finalize_aggregate_emit(ctx, current_dag, node_idx, name, agg_timer, ingest);
     }
 
+    let producer_port = current_dag
+        .graph
+        .find_edge(pred, node_idx)
+        .and_then(|edge| current_dag.graph.edge_weight(edge))
+        .and_then(|edge| edge.producer_port.as_deref());
+    let input_buffer = require_node_buffer_slot(
+        ctx,
+        pred,
+        name,
+        current_dag.graph[pred].name(),
+        producer_port,
+    )?;
+    // Meter the re-materialized drain so a spill-backed predecessor cannot
+    // re-inflate into RAM past the hard limit uncharged.
     let (input, input_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
-    ) = match drain_node_buffer_slot(ctx, pred) {
-        // Meter the re-materialized drain so a spill-backed predecessor cannot
-        // re-inflate into RAM past the hard limit uncharged.
-        Some(nb) => nb.drain_split_metered(&ctx.memory_budget, name)?,
-        None => (Vec::new(), Vec::new()),
-    };
+    ) = input_buffer.drain_split_metered(&ctx.memory_budget, name)?;
 
     if let Some(expected) = current_dag.graph[node_idx]
         .expected_input_schema_in(current_dag)

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -19,8 +19,8 @@ use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
     ExecutorContext, NodeBufferKey, admit_node_buffer, advance_cursor, drain_or_clone_shared_input,
-    finalize_node_rooted_windows, node_buffer_spill_allowed, push_dlq,
-    record_error_to_buffer_if_grouped, source_file_arc_of, source_name_arc_of,
+    finalize_node_rooted_windows, missing_node_buffer_input_error, node_buffer_spill_allowed,
+    push_dlq, record_error_to_buffer_if_grouped, source_file_arc_of, source_name_arc_of,
     stream_linear_producer_emit, tee_emit_to_region_input_buffers,
 };
 use crate::executor::schema_check::check_input_schema;
@@ -308,26 +308,26 @@ pub(crate) fn dispatch_combine(
     ) = if streaming_probe_driver.is_some() {
         (Vec::new(), Vec::new())
     } else {
-        match drain_or_clone_shared_input(
+        let input = drain_or_clone_shared_input(
             ctx,
             current_dag,
             NodeBufferKey::with_port(driver_pred, driver_port.as_deref()),
-        ) {
-            Some(nb) => nb.drain_split()?,
-            None => (Vec::new(), Vec::new()),
-        }
+        )
+        .ok_or_else(|| {
+            missing_node_buffer_input_error(name, driver_upstream, driver_port.as_deref())
+        })?;
+        input.drain_split()?
     };
     let (build_buf, build_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
-    ) = match drain_or_clone_shared_input(
+    ) = drain_or_clone_shared_input(
         ctx,
         current_dag,
         NodeBufferKey::with_port(build_pred, build_port.as_deref()),
-    ) {
-        Some(nb) => nb.drain_split()?,
-        None => (Vec::new(), Vec::new()),
-    };
+    )
+    .ok_or_else(|| missing_node_buffer_input_error(name, build_upstream, build_port.as_deref()))?
+    .drain_split()?;
     // The empty-punctuation common case folds to an empty vector,
     // leaving the no-document path byte-identical to a bare union. For
     // the streaming-probe path the driver's punctuations have not arrived

--- a/crates/clinker-exec/src/executor/composition_dispatch.rs
+++ b/crates/clinker-exec/src/executor/composition_dispatch.rs
@@ -18,7 +18,8 @@ use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
     ExecutorContext, NodeBufferKey, admit_node_buffer, dispatch_plan_node, drain_node_buffer_slot,
-    finalize_node_rooted_windows, node_buffer_spill_allowed, tee_emit_to_region_input_buffers,
+    finalize_node_rooted_windows, missing_node_buffer_input_error, node_buffer_spill_allowed,
+    require_node_buffer_slot, tee_emit_to_region_input_buffers,
 };
 use crate::executor::node_buffer::NodeBuffer;
 use crate::executor::schema_check::check_input_schema;
@@ -198,21 +199,22 @@ fn collect_port_records(
         // with the pull-mode arbitrator and cannot itself raise E310. #1028
         // tracks reserving the duplicate before allocation and transferring
         // that accounting into the body scope without a gap or double count.
-        let records = ctx
-            .node_buffers
-            .get(&edge.source().into())
-            .map(|nb| {
-                // Composition port seeding clones records only; the
-                // composition body operates inside its own document-
-                // boundary scope and re-emits punctuations at the call-
-                // site level on body exit, so the parent's puncts do not
-                // forward through the body's port-source boundary.
-                nb.clone_memory_only()
-                    .into_iter()
-                    .filter_map(|e| e.into_record())
-                    .collect::<Vec<(Record, u64)>>()
-            })
-            .unwrap_or_default();
+        let input_buffer = ctx.node_buffers.get(&edge.source().into()).ok_or_else(|| {
+            missing_node_buffer_input_error(
+                composition_name,
+                parent_dag.graph[edge.source()].name(),
+                edge.weight().producer_port.as_deref(),
+            )
+        })?;
+        // Composition port seeding clones records only; the composition body
+        // operates inside its own document-boundary scope and re-emits
+        // punctuations at the call-site level on body exit, so the parent's
+        // punctuations do not forward through the body's port-source boundary.
+        let records = input_buffer
+            .clone_memory_only()
+            .into_iter()
+            .filter_map(|event| event.into_record())
+            .collect::<Vec<(Record, u64)>>();
         // Two parallel edges to the same port (e.g. `inputs: { p: a,
         // p: a }` — currently rejected at parse, but the runtime is
         // defensive) would overwrite; the wiring pass guarantees
@@ -363,9 +365,9 @@ fn execute_composition_body(
     }
 
     // Harvest output before restoring parent buffers. When the output
-    // port aliases a deferred-region producer (a relaxed-CK Aggregate
-    // sitting at the body's terminal port), the producer's forward
-    // emit is NOT a final stream — the commit-pass body→parent
+    // port participates in a deferred region (for example a Transform
+    // downstream of a relaxed-CK Aggregate), its forward emit is NOT a final
+    // stream — the commit-pass body→parent
     // harvest path re-emits the post-recompute narrow rows into the
     // parent's `node_buffers[composition_idx]`. Returning the forward
     // emit here would double-feed the parent's continuation: once
@@ -380,17 +382,21 @@ fn execute_composition_body(
             // pipeline scope; they re-emit when the parent's call
             // site re-introduces document context. The body harvest
             // takes records only.
-            let drained: Vec<(Record, u64)> = match drain_node_buffer_slot(ctx, idx) {
-                Some(nb) => {
-                    let (records, _puncts) = nb.drain_split()?;
-                    records
-                }
-                None => Vec::new(),
-            };
-            if body_dag.deferred_region_at_producer(idx).is_some() {
+            if body_dag.deferred_region_at(idx).is_some() {
+                // A deferred body terminal is harvested by the commit pass. Its
+                // forward slot is optional and is drained only as cleanup.
+                drain_node_buffer_slot(ctx, idx);
                 Vec::new()
             } else {
-                drained
+                let (records, _puncts) = require_node_buffer_slot(
+                    ctx,
+                    idx,
+                    composition_name,
+                    body_dag.graph[idx].name(),
+                    None,
+                )?
+                .drain_split()?;
+                records
             }
         }
         _ => Vec::new(),

--- a/crates/clinker-exec/src/executor/cull_dispatch.rs
+++ b/crates/clinker-exec/src/executor/cull_dispatch.rs
@@ -67,8 +67,8 @@ use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
 
 use crate::executor::dispatch::{
-    ExecutorContext, NodeBufferKey, admit_node_buffer, drain_node_buffer_slot,
-    node_buffer_spill_allowed, source_file_arc_of, source_name_arc_of,
+    ExecutorContext, NodeBufferKey, admit_node_buffer, node_buffer_spill_allowed,
+    require_node_buffer_slot, source_file_arc_of, source_name_arc_of,
 };
 use crate::executor::{GroupedNodeKind, giant_group_error};
 use crate::pipeline::memory::{
@@ -167,13 +167,22 @@ pub(crate) fn dispatch_cull(
     };
 
     let pred = single_predecessor(current_dag, node_idx, "cull", name)?;
+    let producer_port = current_dag
+        .graph
+        .find_edge(pred, node_idx)
+        .and_then(|edge| current_dag.graph.edge_weight(edge))
+        .and_then(|edge| edge.producer_port.as_deref());
+    let input_buffer = require_node_buffer_slot(
+        ctx,
+        pred,
+        name,
+        current_dag.graph[pred].name(),
+        producer_port,
+    )?;
     let (input, input_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
-    ) = match drain_node_buffer_slot(ctx, pred) {
-        Some(nb) => nb.drain_split()?,
-        None => (Vec::new(), Vec::new()),
-    };
+    ) = input_buffer.drain_split()?;
 
     if input.is_empty() {
         // Empty-input fast path returns BEFORE any consumer registers, so

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1649,6 +1649,59 @@ pub(crate) fn drain_node_buffer_slot(
     ctx.node_buffers.remove(&key)
 }
 
+/// Build the cold-path invariant error for a required materialized input that
+/// was not present after every intentional input alternative was exhausted.
+#[cold]
+pub(crate) fn missing_node_buffer_input_error(
+    consumer_name: &str,
+    producer_name: &str,
+    producer_port: Option<&str>,
+) -> PipelineError {
+    let port_detail = producer_port
+        .map(|port| format!(" on port '{port}'"))
+        .unwrap_or_default();
+    PipelineError::Internal {
+        op: "executor",
+        node: consumer_name.to_string(),
+        detail: format!(
+            "planned input from producer '{producer_name}'{port_detail} was unavailable; the run stopped instead of treating it as empty"
+        ),
+    }
+}
+
+/// Drain a required materialized input slot, failing loudly when the slot is
+/// absent. A present empty [`NodeBuffer`] remains a valid zero-row input.
+pub(crate) fn require_node_buffer_slot(
+    ctx: &mut ExecutorContext<'_>,
+    key: impl Into<NodeBufferKey>,
+    consumer_name: &str,
+    producer_name: &str,
+    producer_port: Option<&str>,
+) -> Result<NodeBuffer, PipelineError> {
+    drain_node_buffer_slot(ctx, key)
+        .ok_or_else(|| missing_node_buffer_input_error(consumer_name, producer_name, producer_port))
+}
+
+#[cfg(test)]
+mod required_node_buffer_tests {
+    use super::missing_node_buffer_input_error;
+    use clinker_plan::error::PipelineError;
+
+    #[test]
+    fn missing_input_error_names_consumer_producer_and_port() {
+        let error =
+            missing_node_buffer_input_error("aggregate_orders", "route_orders", Some("matched"));
+
+        let PipelineError::Internal { op, node, detail } = error else {
+            panic!("missing node-buffer input must be an internal executor error");
+        };
+        assert_eq!(op, "executor");
+        assert_eq!(node, "aggregate_orders");
+        assert!(detail.contains("producer 'route_orders' on port 'matched'"));
+        assert!(detail.contains("run stopped instead of treating it as empty"));
+    }
+}
+
 /// Take a predecessor-slot reader's input from `key`, cloning the slot (leaving
 /// it intact) when other predecessor-slot consumers of the SAME
 /// `(producer, port)` slot still need it — so one producer output port fanned

--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -59,7 +59,7 @@ use petgraph::graph::NodeIndex;
 
 use crate::aggregation::{AggregateEvalScope, eval_expr_in_agg_scope};
 use crate::executor::dispatch::{
-    ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
+    ExecutorContext, admit_node_buffer, node_buffer_spill_allowed, require_node_buffer_slot,
 };
 use crate::executor::envelope::distinct_body_headers;
 use crate::executor::node_buffer::DrainedEvents;
@@ -132,10 +132,19 @@ pub(crate) fn dispatch_envelope(
         Some(header_pred) => body_predecessor_excluding(current_dag, node_idx, name, header_pred)?,
         None => single_predecessor(current_dag, node_idx, "envelope", name)?,
     };
-    let (mut records, puncts) = match drain_node_buffer_slot(ctx, body_pred) {
-        Some(nb) => nb.drain_split()?,
-        None => (Vec::new(), Vec::new()),
-    };
+    let body_port = current_dag
+        .graph
+        .edges_connecting(body_pred, node_idx)
+        .next()
+        .and_then(|edge| edge.weight().producer_port.as_deref());
+    let (mut records, puncts) = require_node_buffer_slot(
+        ctx,
+        body_pred,
+        name,
+        current_dag.graph[body_pred].name(),
+        body_port,
+    )?
+    .drain_split()?;
 
     // Drain the wired header stream and replace each body grain's ambient
     // envelope with its grain-matched header record. This runs BEFORE the
@@ -146,10 +155,19 @@ pub(crate) fn dispatch_envelope(
         // body's punctuations drive output framing, and the header is a
         // 1-row-per-grain metadata stream whose document boundaries are not part
         // of the framed body.
-        let (header_records, _header_puncts) = match drain_node_buffer_slot(ctx, header_pred) {
-            Some(nb) => nb.drain_split()?,
-            None => (Vec::new(), Vec::new()),
-        };
+        let header_port = current_dag
+            .graph
+            .edges_connecting(header_pred, node_idx)
+            .next()
+            .and_then(|edge| edge.weight().producer_port.as_deref());
+        let (header_records, _header_puncts) = require_node_buffer_slot(
+            ctx,
+            header_pred,
+            name,
+            current_dag.graph[header_pred].name(),
+            header_port,
+        )?
+        .drain_split()?;
         replace_headers_by_grain(name, &mut records, &header_records)?;
     }
 

--- a/crates/clinker-exec/src/executor/merge_dispatch.rs
+++ b/crates/clinker-exec/src/executor/merge_dispatch.rs
@@ -17,7 +17,8 @@ use petgraph::graph::NodeIndex;
 use crate::executor::dispatch::{
     ExecutorContext, FusedMergeOutput, MergeStreamHandoff, NodeBufferKey, admit_node_buffer,
     drain_or_clone_shared_input, finalize_node_rooted_windows, merge_fused_interleave,
-    node_buffer_spill_allowed, stream_linear_producer_emit, tee_emit_to_region_input_buffers,
+    missing_node_buffer_input_error, node_buffer_spill_allowed, stream_linear_producer_emit,
+    tee_emit_to_region_input_buffers,
 };
 use crate::executor::schema_check::check_input_schema;
 use clinker_plan::error::PipelineError;
@@ -228,19 +229,21 @@ pub(crate) fn dispatch_merge(
             clinker_plan::config::MergeMode::Concat => {
                 for (src, port) in &ordered_inputs {
                     let upstream_name = current_dag.graph[*src].name().to_string();
-                    if let Some(buf) = drain_or_clone_shared_input(
+                    let buf = drain_or_clone_shared_input(
                         ctx,
                         current_dag,
                         NodeBufferKey::with_port(*src, port.as_deref()),
-                    ) {
-                        for event in buf.drain() {
-                            match event? {
-                                crate::executor::stream_event::StreamEvent::Record(record, rn) => {
-                                    emit(&mut merged, &upstream_name, record, rn)?;
-                                }
-                                crate::executor::stream_event::StreamEvent::Punctuation(p) => {
-                                    all_puncts.push(p);
-                                }
+                    )
+                    .ok_or_else(|| {
+                        missing_node_buffer_input_error(name, &upstream_name, port.as_deref())
+                    })?;
+                    for event in buf.drain() {
+                        match event? {
+                            crate::executor::stream_event::StreamEvent::Record(record, rn) => {
+                                emit(&mut merged, &upstream_name, record, rn)?;
+                            }
+                            crate::executor::stream_event::StreamEvent::Punctuation(p) => {
+                                all_puncts.push(p);
                             }
                         }
                     }
@@ -261,18 +264,22 @@ pub(crate) fn dispatch_merge(
                     .iter()
                     .map(
                         |(src, port)| -> Result<VecDeque<(Record, u64)>, PipelineError> {
-                            match drain_or_clone_shared_input(
+                            let upstream_name = current_dag.graph[*src].name();
+                            let nb = drain_or_clone_shared_input(
                                 ctx,
                                 current_dag,
                                 NodeBufferKey::with_port(*src, port.as_deref()),
-                            ) {
-                                Some(nb) => {
-                                    let (records, puncts) = nb.drain_split()?;
-                                    all_puncts.extend(puncts);
-                                    Ok(VecDeque::from(records))
-                                }
-                                None => Ok(VecDeque::new()),
-                            }
+                            )
+                            .ok_or_else(|| {
+                                missing_node_buffer_input_error(
+                                    name,
+                                    upstream_name,
+                                    port.as_deref(),
+                                )
+                            })?;
+                            let (records, puncts) = nb.drain_split()?;
+                            all_puncts.extend(puncts);
+                            Ok(VecDeque::from(records))
                         },
                     )
                     .collect::<Result<Vec<_>, _>>()?;

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -18,7 +18,8 @@ use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
     CorrelationRecordSlot, ExecutorContext, buffer_key_for_record, drain_node_buffer_slot,
-    mapping_probe, push_dlq, push_write_error, sink_collision_dlq_entry, source_file_path_of,
+    mapping_probe, missing_node_buffer_input_error, push_dlq, push_write_error,
+    sink_collision_dlq_entry, source_file_path_of,
 };
 use crate::executor::schema_check::check_input_schema;
 use crate::executor::structured_output_guard::{
@@ -185,7 +186,7 @@ pub(crate) fn dispatch_output(
                     }
                 }
             }
-            found.unwrap_or_default()
+            found.ok_or_else(|| missing_output_input_error(current_dag, node_idx, name))?
         };
 
     let OutputInputs {
@@ -521,7 +522,7 @@ fn dispatch_output_document_dlq(
     node_idx: NodeIndex,
     name: &str,
 ) -> Result<(), PipelineError> {
-    let events = drain_output_input_events(ctx, current_dag, node_idx)?;
+    let events = drain_output_input_events(ctx, current_dag, node_idx, name)?;
 
     let OutputInputs {
         expected_input_schema,
@@ -561,8 +562,9 @@ fn drain_output_input_events(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
+    name: &str,
 ) -> Result<Vec<crate::executor::stream_event::StreamEvent>, PipelineError> {
-    drain_output_input_event_iter(ctx, current_dag, node_idx).collect()
+    drain_output_input_event_iter(ctx, current_dag, node_idx, name).collect()
 }
 
 /// Execute the `Output` arm under envelope reconstruction
@@ -637,7 +639,7 @@ fn dispatch_output_envelope(
     let scan_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::SchemaScan);
     let mut any_record = false;
 
-    let events = drain_output_input_event_iter(ctx, current_dag, node_idx);
+    let events = drain_output_input_event_iter(ctx, current_dag, node_idx, name);
     let mut driver = EnvelopeWriterDriver::default();
     let mut structured_guard = StructuredOutputDocumentGuard::new(&out_cfg.format);
 
@@ -885,9 +887,8 @@ fn drain_output_input_event_iter(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
+    name: &str,
 ) -> Box<dyn Iterator<Item = Result<crate::executor::stream_event::StreamEvent, PipelineError>>> {
-    use crate::executor::stream_event::StreamEvent;
-
     if let Some(own_buf) = drain_node_buffer_slot(ctx, node_idx) {
         return Box::new(own_buf.drain());
     }
@@ -913,7 +914,35 @@ fn drain_output_input_event_iter(
             return Box::new(cloned.into_iter().map(Ok));
         }
     }
-    Box::new(std::iter::empty::<Result<StreamEvent, PipelineError>>())
+    Box::new(std::iter::once(Err(missing_output_input_error(
+        current_dag,
+        node_idx,
+        name,
+    ))))
+}
+
+/// Build the fail-loud diagnostic only after every valid Output input location
+/// (own slot, predecessor drain, or predecessor clone) has been checked.
+#[cold]
+fn missing_output_input_error(
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    name: &str,
+) -> PipelineError {
+    use petgraph::visit::EdgeRef;
+
+    let incoming = current_dag
+        .graph
+        .edges_directed(node_idx, Direction::Incoming)
+        .next();
+    match incoming {
+        Some(edge) => missing_node_buffer_input_error(
+            name,
+            current_dag.graph[edge.source()].name(),
+            edge.weight().producer_port.as_deref(),
+        ),
+        None => missing_node_buffer_input_error(name, "<missing predecessor>", None),
+    }
 }
 
 /// The Output node's resolved write target plus the run-scoped writer

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -52,8 +52,9 @@ use petgraph::graph::NodeIndex;
 
 use crate::executor::DlqEntry;
 use crate::executor::dispatch::{
-    ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
-    push_dlq, source_file_arc_of, source_name_arc_of, tee_emit_to_region_input_buffers,
+    ExecutorContext, admit_node_buffer, node_buffer_spill_allowed, push_dlq,
+    require_node_buffer_slot, source_file_arc_of, source_name_arc_of,
+    tee_emit_to_region_input_buffers,
 };
 use crate::executor::{GroupedNodeKind, giant_group_error};
 use crate::pipeline::memory::{
@@ -190,13 +191,22 @@ pub(crate) fn dispatch_reshape(
     };
 
     let pred = single_predecessor(current_dag, node_idx, "reshape", name)?;
+    let producer_port = current_dag
+        .graph
+        .find_edge(pred, node_idx)
+        .and_then(|edge| current_dag.graph.edge_weight(edge))
+        .and_then(|edge| edge.producer_port.as_deref());
+    let input_buffer = require_node_buffer_slot(
+        ctx,
+        pred,
+        name,
+        current_dag.graph[pred].name(),
+        producer_port,
+    )?;
     let (input, input_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
-    ) = match drain_node_buffer_slot(ctx, pred) {
-        Some(nb) => nb.drain_split()?,
-        None => (Vec::new(), Vec::new()),
-    };
+    ) = input_buffer.drain_split()?;
 
     if input.is_empty() {
         // Empty-input fast path returns BEFORE any consumer registers, so

--- a/crates/clinker-exec/src/executor/route_dispatch.rs
+++ b/crates/clinker-exec/src/executor/route_dispatch.rs
@@ -15,7 +15,8 @@ use petgraph::graph::NodeIndex;
 use crate::executor::cull_dispatch::reads_predecessor_slot;
 use crate::executor::dispatch::{
     ExecutorContext, NodeBufferKey, admit_node_buffer, advance_cursor, drain_node_buffer_slot,
-    node_buffer_spill_allowed, push_dlq, record_error_to_buffer_if_grouped, source_file_arc_of,
+    missing_node_buffer_input_error, node_buffer_spill_allowed, push_dlq,
+    record_error_to_buffer_if_grouped, require_node_buffer_slot, source_file_arc_of,
     source_name_arc_of, stream_linear_producer_emit,
 };
 use crate::executor::schema_check::check_input_schema;
@@ -61,13 +62,57 @@ pub(crate) fn dispatch_route(
     ) = if let Some(own_buf) = drain_node_buffer_slot(ctx, node_idx) {
         own_buf.drain_split()?
     } else {
-        match predecessors
-            .iter()
-            .find_map(|p| drain_node_buffer_slot(ctx, *p))
-        {
-            Some(nb) => nb.drain_split()?,
-            None => (Vec::new(), Vec::new()),
-        }
+        let pred_buf = if predecessors.len() == 1 {
+            let pred = predecessors[0];
+            let producer_port = current_dag
+                .graph
+                .find_edge(pred, node_idx)
+                .and_then(|edge| current_dag.graph.edge_weight(edge))
+                .and_then(|edge| edge.producer_port.as_deref());
+            Some(require_node_buffer_slot(
+                ctx,
+                pred,
+                name,
+                current_dag.graph[pred].name(),
+                producer_port,
+            )?)
+        } else {
+            predecessors
+                .iter()
+                .find_map(|p| drain_node_buffer_slot(ctx, *p))
+        };
+        let input_buffer = match pred_buf {
+            Some(buffer) => buffer,
+            None => {
+                let authored_input = ctx
+                    .current_body_node_input_refs
+                    .as_ref()
+                    .and_then(|refs| refs.get(name.as_str()))
+                    .and_then(|refs| refs.first())
+                    .map(String::as_str);
+                let (producer_name, producer_port) = if let Some(&pred) = predecessors.first() {
+                    let producer_port = current_dag
+                        .graph
+                        .find_edge(pred, node_idx)
+                        .and_then(|edge| current_dag.graph.edge_weight(edge))
+                        .and_then(|edge| edge.producer_port.as_deref());
+                    (current_dag.graph[pred].name(), producer_port)
+                } else if let Some(input) = authored_input {
+                    match input.split_once('.') {
+                        Some((producer, port)) => (producer, Some(port)),
+                        None => (input, None),
+                    }
+                } else {
+                    ("composition input", None)
+                };
+                return Err(missing_node_buffer_input_error(
+                    name,
+                    producer_name,
+                    producer_port,
+                ));
+            }
+        };
+        input_buffer.drain_split()?
     };
 
     if let Some(expected) = current_dag.graph[node_idx]

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -7,17 +7,16 @@
 //! `Sort` arm is a single delegating call into [`dispatch_sort`].
 
 use clinker_record::Record;
-use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
-    ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
+    ExecutorContext, admit_node_buffer, node_buffer_spill_allowed, require_node_buffer_slot,
     tee_emit_to_region_input_buffers,
 };
 use crate::executor::{parse_memory_limit, stage_metrics};
 use crate::pipeline::spill_merge::merge_sorted_runs;
 use clinker_plan::error::PipelineError;
-use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
+use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
 
 /// Execute the `Sort` arm for `node_idx`: buffer the predecessor's records,
 /// sort by the enforced `sort_fields` key (carrying each record's `row_num`
@@ -44,20 +43,23 @@ pub(crate) fn dispatch_sort(
     // parallel bookkeeping map rides alongside.
     use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
 
-    let predecessors: Vec<NodeIndex> = current_dag
+    let pred = single_predecessor(current_dag, node_idx, "sort", name)?;
+    let producer_port = current_dag
         .graph
-        .neighbors_directed(node_idx, Direction::Incoming)
-        .collect();
+        .find_edge(pred, node_idx)
+        .and_then(|edge| current_dag.graph.edge_weight(edge))
+        .and_then(|edge| edge.producer_port.as_deref());
+    let input_buffer = require_node_buffer_slot(
+        ctx,
+        pred,
+        name,
+        current_dag.graph[pred].name(),
+        producer_port,
+    )?;
     let (input_records, input_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
-    ) = match predecessors
-        .iter()
-        .find_map(|p| drain_node_buffer_slot(ctx, *p))
-    {
-        Some(nb) => nb.drain_split()?,
-        None => (Vec::new(), Vec::new()),
-    };
+    ) = input_buffer.drain_split()?;
 
     if input_records.is_empty() {
         tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &[])?;

--- a/crates/clinker-exec/src/executor/transform_dispatch.rs
+++ b/crates/clinker-exec/src/executor/transform_dispatch.rs
@@ -15,9 +15,9 @@ use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
     ExecutorContext, admit_node_buffer, advance_cursor, dispatch_transform_eval_error,
-    drain_node_buffer_slot, finalize_node_rooted_windows, node_buffer_spill_allowed,
-    source_file_arc_of, source_name_arc_of, tee_emit_to_region_input_buffers,
-    transform_fused_consume,
+    drain_node_buffer_slot, finalize_node_rooted_windows, missing_node_buffer_input_error,
+    node_buffer_spill_allowed, require_node_buffer_slot, source_file_arc_of, source_name_arc_of,
+    tee_emit_to_region_input_buffers, transform_fused_consume,
 };
 use crate::executor::schema_check::check_input_schema;
 use crate::executor::{
@@ -74,18 +74,58 @@ pub(crate) fn dispatch_transform(
             .neighbors_directed(node_idx, Direction::Incoming)
             .collect();
         let pred_buf = if predecessors.len() == 1 {
-            drain_node_buffer_slot(ctx, predecessors[0])
+            let pred = predecessors[0];
+            let producer_port = current_dag
+                .graph
+                .find_edge(pred, node_idx)
+                .and_then(|edge| current_dag.graph.edge_weight(edge))
+                .and_then(|edge| edge.producer_port.as_deref());
+            Some(require_node_buffer_slot(
+                ctx,
+                pred,
+                name,
+                current_dag.graph[pred].name(),
+                producer_port,
+            )?)
         } else {
             predecessors
                 .iter()
                 .find_map(|p| drain_node_buffer_slot(ctx, *p))
         };
-        match pred_buf {
-            // Meter the re-materialized drain so a spill-backed input cannot
-            // re-inflate into RAM past the hard limit uncharged.
-            Some(nb) => nb.drain_split_metered(&ctx.memory_budget, name.as_str())?,
-            None => (Vec::new(), Vec::new()),
-        }
+        let input_buffer = match pred_buf {
+            Some(buffer) => buffer,
+            None => {
+                let authored_input = ctx
+                    .current_body_node_input_refs
+                    .as_ref()
+                    .and_then(|refs| refs.get(name.as_str()))
+                    .and_then(|refs| refs.first())
+                    .map(String::as_str);
+                let (producer_name, producer_port) = if let Some(&pred) = predecessors.first() {
+                    let producer_port = current_dag
+                        .graph
+                        .find_edge(pred, node_idx)
+                        .and_then(|edge| current_dag.graph.edge_weight(edge))
+                        .and_then(|edge| edge.producer_port.as_deref());
+                    (current_dag.graph[pred].name(), producer_port)
+                } else if let Some(input) = authored_input {
+                    match input.split_once('.') {
+                        Some((producer, port)) => (producer, Some(port)),
+                        None => (input, None),
+                    }
+                } else {
+                    ("composition input", None)
+                };
+                return Err(missing_node_buffer_input_error(
+                    name,
+                    producer_name,
+                    producer_port,
+                ));
+            }
+        };
+        // Meter the re-materialized drain so a spill-backed input cannot
+        // re-inflate into RAM past the hard limit uncharged.
+        input_buffer.drain_split_metered(&ctx.memory_budget, name.as_str())?
     };
 
     // Read the typed program off the `PlanNode::Transform` payload. Every

--- a/crates/clinker-exec/tests/doc_index_rss_proof.rs
+++ b/crates/clinker-exec/tests/doc_index_rss_proof.rs
@@ -437,7 +437,7 @@ nodes:
         emit x = $doc.Head.blob
   - type: output
     name: out
-    input: docs
+    input: tag
     config:
       name: out
       type: json

--- a/crates/clinker-exec/tests/node_buffer_missing_fail_loud.rs
+++ b/crates/clinker-exec/tests/node_buffer_missing_fail_loud.rs
@@ -1,0 +1,571 @@
+//! End-to-end regressions for required materialized node-buffer inputs (#1029).
+//!
+//! The DAGs below are valid but expose the addressing/reader-count gaps tracked
+//! by #908, #996, and #1013. This safety landing does not make those shapes
+//! execute correctly; it guarantees that a missing planned slot aborts instead
+//! of becoming a successful empty stream.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{ExecutionReport, PipelineExecutor, PipelineRunParams};
+use clinker_plan::config::{CompileContext, parse_config};
+use clinker_plan::error::PipelineError;
+
+const CSV: &str = "id,dept,amount,status,label\n\
+                   1,eng,100,keep,one\n\
+                   2,eng,200,bad,two\n\
+                   3,sales,50,keep,three\n";
+
+fn pipeline(name: &str, body: &str) -> String {
+    format!(
+        r#"pipeline:
+  name: {name}
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: input.csv
+      schema:
+        - {{ name: id, type: string }}
+        - {{ name: dept, type: string }}
+        - {{ name: amount, type: int }}
+        - {{ name: status, type: string }}
+        - {{ name: label, type: string }}
+{body}
+"#,
+    )
+}
+
+fn run_pipeline(
+    yaml: &str,
+    csv: &str,
+) -> (
+    Result<ExecutionReport, PipelineError>,
+    HashMap<String, SharedBuffer>,
+) {
+    run_pipeline_with_context(yaml, csv, &CompileContext::default())
+}
+
+fn run_pipeline_with_context(
+    yaml: &str,
+    csv: &str,
+    compile_context: &CompileContext,
+) -> (
+    Result<ExecutionReport, PipelineError>,
+    HashMap<String, SharedBuffer>,
+) {
+    let config = parse_config(yaml).expect("fixture pipeline must parse");
+    let plan = config
+        .compile(compile_context)
+        .expect("fixture pipeline must compile");
+    let source_name = config
+        .source_configs()
+        .next()
+        .expect("fixture pipeline has one source")
+        .name
+        .clone();
+    let readers = HashMap::from([(
+        source_name,
+        clinker_exec::executor::single_file_reader(
+            "input.csv",
+            Box::new(Cursor::new(csv.as_bytes().to_vec())),
+        ),
+    )]);
+    let buffers: HashMap<String, SharedBuffer> = config
+        .output_configs()
+        .map(|output| (output.name.clone(), SharedBuffer::new()))
+        .collect();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = buffers
+        .iter()
+        .map(|(name, buffer)| {
+            (
+                name.clone(),
+                Box::new(buffer.clone()) as Box<dyn std::io::Write + Send>,
+            )
+        })
+        .collect();
+    let params = PipelineRunParams {
+        execution_id: "node-buffer-fail-loud".to_string(),
+        batch_id: "node-buffer-fail-loud".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    (
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params),
+        buffers,
+    )
+}
+
+fn assert_missing_input(
+    result: Result<ExecutionReport, PipelineError>,
+    consumer: &str,
+    producer: &str,
+    port: Option<&str>,
+) {
+    let error = result.expect_err("a missing planned input must stop the run");
+    let PipelineError::Internal { node, detail, .. } = error else {
+        panic!("missing planned input must be PipelineError::Internal, got {error:?}");
+    };
+
+    assert_eq!(node, consumer, "the error must name the consuming node");
+    assert!(
+        detail.contains(producer),
+        "the error must name producer {producer:?}: {detail}"
+    );
+    if let Some(port) = port {
+        assert!(
+            detail.contains(port),
+            "the error must name producer port {port:?}: {detail}"
+        );
+    }
+    assert!(
+        detail.contains("run stopped instead of treating it as empty"),
+        "the error must explain the fail-closed disposition: {detail}"
+    );
+}
+
+fn route_pipeline(name: &str, selected_consumer: &str) -> String {
+    pipeline(
+        name,
+        &format!(
+            r#"  - type: route
+    name: split
+    input: rows
+    config:
+      mode: exclusive
+      conditions:
+        keep: "status == 'keep'"
+      default: drop
+{selected_consumer}
+  - type: output
+    name: dropped
+    input: split.drop
+    config:
+      name: dropped
+      type: csv
+      path: dropped.csv
+"#,
+        ),
+    )
+}
+
+fn cull_pipeline(name: &str, main_consumer: &str) -> String {
+    pipeline(
+        name,
+        &format!(
+            r#"  - type: cull
+    name: gate
+    input: rows
+    config:
+      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: remove_bad
+          drop_group_when: "sum(if status == 'bad' then 1 else 0) > 0"
+{main_consumer}
+  - type: output
+    name: removed
+    input: gate.removed
+    config:
+      name: removed
+      type: csv
+      path: removed.csv
+"#,
+        ),
+    )
+}
+
+#[test]
+fn transform_diamond_stops_when_combine_direct_source_input_was_consumed() {
+    let yaml = pipeline(
+        "transform_diamond_missing_input",
+        r#"  - type: transform
+    name: flagged
+    input: rows
+    config:
+      cxl: |
+        emit flag = "seen"
+  - type: combine
+    name: joined
+    input:
+      detail: rows
+      extra: flagged
+    config:
+      drive: detail
+      where: "detail.id == extra.id"
+      match: first
+      on_miss: null_fields
+      cxl: |
+        emit id = detail.id
+        emit dept = detail.dept
+        emit flag = extra.flag
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+    );
+
+    assert_missing_input(run_pipeline(&yaml, CSV).0, "joined", "rows", None);
+}
+
+#[test]
+fn aggregate_diamond_stops_when_combine_direct_source_input_was_consumed() {
+    let yaml = pipeline(
+        "aggregate_diamond_missing_input",
+        r#"  - type: aggregate
+    name: summary
+    input: rows
+    config:
+      group_by: [dept]
+      cxl: |
+        emit dept = dept
+        emit n = count(*)
+  - type: combine
+    name: joined
+    input:
+      detail: rows
+      summary: summary
+    config:
+      drive: detail
+      where: "detail.dept == summary.dept"
+      match: first
+      on_miss: null_fields
+      cxl: |
+        emit id = detail.id
+        emit dept = detail.dept
+        emit n = summary.n
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+    );
+
+    assert_missing_input(run_pipeline(&yaml, CSV).0, "joined", "rows", None);
+}
+
+#[test]
+fn composition_input_stops_when_its_parent_slot_was_consumed() {
+    let yaml = r#"pipeline:
+  name: composition_missing_parent_input
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: input.csv
+      schema:
+        - { name: a, type: int }
+  - type: composition
+    name: composed
+    input: src
+    use: ../compositions/exec_transform_check.comp.yaml
+    inputs:
+      inp: src
+  - type: transform
+    name: sibling
+    input: src
+    config:
+      cxl: |
+        emit branch = "sibling"
+  - type: output
+    name: composed_out
+    input: composed
+    config:
+      name: composed_out
+      type: csv
+      path: composed.csv
+  - type: output
+    name: sibling_out
+    input: sibling
+    config:
+      name: sibling_out
+      type: csv
+      path: sibling.csv
+"#;
+    let fixture_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures");
+    let compile_context =
+        CompileContext::with_pipeline_dir(&fixture_root, PathBuf::from("pipelines"));
+
+    assert_missing_input(
+        run_pipeline_with_context(yaml, "a\n5\n7\n", &compile_context).0,
+        "composed",
+        "src",
+        None,
+    );
+}
+
+fn two_direct_outputs(first: &str, second: &str) -> String {
+    pipeline(
+        "two_direct_outputs_missing_input",
+        &format!(
+            r#"  - type: transform
+    name: prepared
+    input: rows
+    config:
+      cxl: |
+        emit marker = "ready"
+  - type: output
+    name: {first}
+    input: prepared
+    config:
+      name: {first}
+      type: csv
+      path: {first}.csv
+  - type: output
+    name: {second}
+    input: prepared
+    config:
+      name: {second}
+      type: csv
+      path: {second}.csv
+"#,
+        ),
+    )
+}
+
+#[test]
+fn first_of_two_direct_outputs_fails_loudly_in_alpha_beta_order() {
+    let yaml = two_direct_outputs("alpha", "beta");
+
+    assert_missing_input(run_pipeline(&yaml, CSV).0, "alpha", "prepared", None);
+}
+
+#[test]
+fn first_of_two_direct_outputs_fails_loudly_in_beta_alpha_order() {
+    let yaml = two_direct_outputs("beta", "alpha");
+
+    assert_missing_input(run_pipeline(&yaml, CSV).0, "beta", "prepared", None);
+}
+
+#[test]
+fn route_to_aggregate_names_the_route_branch_when_it_stops() {
+    let yaml = route_pipeline(
+        "route_to_aggregate_missing_input",
+        r#"  - type: aggregate
+    name: summarize
+    input: split.keep
+    config:
+      group_by: [dept]
+      cxl: |
+        emit dept = dept
+        emit n = count(*)
+  - type: output
+    name: out
+    input: summarize
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+    );
+
+    assert_missing_input(
+        run_pipeline(&yaml, CSV).0,
+        "summarize",
+        "split",
+        Some("keep"),
+    );
+}
+
+#[test]
+fn route_to_reshape_names_the_route_branch_when_it_stops() {
+    let yaml = route_pipeline(
+        "route_to_reshape_missing_input",
+        r#"  - type: reshape
+    name: relabel
+    input: split.keep
+    config:
+      partition_by: [id]
+      rules:
+        - name: mark
+          when: "true"
+          mutate:
+            set:
+              label: "'reshaped'"
+  - type: output
+    name: out
+    input: relabel
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+    );
+
+    assert_missing_input(run_pipeline(&yaml, CSV).0, "relabel", "split", Some("keep"));
+}
+
+#[test]
+fn route_to_cull_names_the_route_branch_when_it_stops() {
+    let yaml = route_pipeline(
+        "route_to_cull_missing_input",
+        r#"  - type: cull
+    name: filter_kept
+    input: split.keep
+    config:
+      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: remove_bad
+          drop_group_when: "sum(if status == 'bad' then 1 else 0) > 0"
+  - type: output
+    name: out
+    input: filter_kept
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: filtered
+    input: filter_kept.removed
+    config:
+      name: filtered
+      type: csv
+      path: filtered.csv
+"#,
+    );
+
+    assert_missing_input(
+        run_pipeline(&yaml, CSV).0,
+        "filter_kept",
+        "split",
+        Some("keep"),
+    );
+}
+
+#[test]
+fn cull_to_aggregate_stops_instead_of_treating_main_as_empty() {
+    let yaml = cull_pipeline(
+        "cull_to_aggregate_missing_input",
+        r#"  - type: aggregate
+    name: summarize
+    input: gate
+    config:
+      group_by: [dept]
+      cxl: |
+        emit dept = dept
+        emit n = count(*)
+  - type: output
+    name: out
+    input: summarize
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+    );
+
+    assert_missing_input(run_pipeline(&yaml, CSV).0, "summarize", "gate", None);
+}
+
+#[test]
+fn cull_to_reshape_stops_instead_of_treating_main_as_empty() {
+    let yaml = cull_pipeline(
+        "cull_to_reshape_missing_input",
+        r#"  - type: reshape
+    name: relabel
+    input: gate
+    config:
+      partition_by: [id]
+      rules:
+        - name: mark
+          when: "true"
+          mutate:
+            set:
+              label: "'reshaped'"
+  - type: output
+    name: out
+    input: relabel
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+    );
+
+    assert_missing_input(run_pipeline(&yaml, CSV).0, "relabel", "gate", None);
+}
+
+#[test]
+fn a_present_empty_materialized_buffer_remains_a_valid_input() {
+    let yaml = pipeline(
+        "present_empty_buffer",
+        r#"  - type: cull
+    name: filter_rows
+    input: rows
+    config:
+      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: remove_bad
+          drop_group_when: "sum(if status == 'bad' then 1 else 0) > 0"
+  - type: output
+    name: out
+    input: filter_rows
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: removed
+    input: filter_rows.removed
+    config:
+      name: removed
+      type: csv
+      path: removed.csv
+"#,
+    );
+
+    let (result, _) = run_pipeline(&yaml, "id,dept,amount,status,label\n");
+    let report = result.expect("an occupied zero-row buffer is not missing");
+    assert_eq!(report.counters.total_count, 0);
+    assert_eq!(report.counters.records_written, 0);
+}
+
+#[test]
+fn fused_transform_and_streaming_output_control_still_succeeds() {
+    let yaml = pipeline(
+        "fused_transform_streaming_output_control",
+        r#"  - type: transform
+    name: prepared
+    input: rows
+    config:
+      cxl: |
+        emit marker = "ready"
+  - type: output
+    name: out
+    input: prepared
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+    );
+
+    let (result, buffers) = run_pipeline(&yaml, CSV);
+    let report = result.expect("certified fused/streaming paths bypass node buffers");
+    assert_eq!(report.counters.records_written, 3);
+    assert!(buffers["out"].as_string().contains("ready"));
+}

--- a/crates/clinker-exec/tests/post_combine_window_strategies.rs
+++ b/crates/clinker-exec/tests/post_combine_window_strategies.rs
@@ -79,7 +79,7 @@ nodes:
       group_by: [department]
 - type: output
   name: out
-  input: enriched
+  input: running
   config:
     name: out
     path: out.csv
@@ -136,12 +136,9 @@ ENG,5000
     PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
         .expect("pipeline must run");
     let _output = buf.as_string();
-    // The Output node above is wired to the combine `enriched`, so the
-    // running window's emit columns aren't projected to the writer in
-    // this fixture — the load-bearing assertion is that compile + run
-    // succeeds against a HashBuildProbe combine feeding a downstream
-    // window. Value-level assertion lives below where the Output node
-    // sees the windowed transform.
+    // The load-bearing assertion is that compile + run succeeds against a
+    // HashBuildProbe combine feeding a downstream window. Value-level
+    // assertion lives below with a larger fixture.
 }
 
 /// HashBuildProbe combine feeding a windowed Transform whose output

--- a/crates/clinker/tests/node_buffer_missing_cli.rs
+++ b/crates/clinker/tests/node_buffer_missing_cli.rs
@@ -69,8 +69,9 @@ nodes:
         stderr.contains("prepared"),
         "diagnostic must name producer prepared; got:\n{stderr}"
     );
+    let normalized_stderr = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
     assert!(
-        stderr.contains("run stopped instead of treating it as empty"),
+        normalized_stderr.contains("run stopped instead of treating it as empty"),
         "diagnostic must explain its fail-closed disposition; got:\n{stderr}"
     );
 }

--- a/crates/clinker/tests/node_buffer_missing_cli.rs
+++ b/crates/clinker/tests/node_buffer_missing_cli.rs
@@ -69,9 +69,12 @@ nodes:
         stderr.contains("prepared"),
         "diagnostic must name producer prepared; got:\n{stderr}"
     );
-    let normalized_stderr = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
     assert!(
-        normalized_stderr.contains("run stopped instead of treating it as empty"),
+        stderr.contains("run stopped instead of"),
         "diagnostic must explain its fail-closed disposition; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("treating it as empty"),
+        "diagnostic must explain that the missing input was not treated as empty; got:\n{stderr}"
     );
 }

--- a/crates/clinker/tests/node_buffer_missing_cli.rs
+++ b/crates/clinker/tests/node_buffer_missing_cli.rs
@@ -1,0 +1,76 @@
+//! CLI regression for missing required materialized node-buffer inputs (#1029).
+
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+#[test]
+fn missing_planned_input_exits_nonzero_with_actionable_diagnostic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("input.csv"), "id\n1\n2\n").expect("write source fixture");
+
+    let pipeline_path = dir.path().join("pipeline.yaml");
+    let pipeline = r#"pipeline:
+  name: missing_node_buffer_cli
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: input.csv
+      schema:
+        - { name: id, type: string }
+  - type: transform
+    name: prepared
+    input: rows
+    config:
+      cxl: |
+        emit marker = "ready"
+  - type: output
+    name: alpha
+    input: prepared
+    config:
+      name: alpha
+      type: csv
+      path: alpha.csv
+  - type: output
+    name: beta
+    input: prepared
+    config:
+      name: beta
+      type: csv
+      path: beta.csv
+"#;
+    std::fs::write(&pipeline_path, pipeline).expect("write pipeline fixture");
+
+    let output = Command::new(clinker_bin())
+        .current_dir(dir.path())
+        .arg("run")
+        .arg(&pipeline_path)
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        !output.status.success(),
+        "a missing planned input must produce a nonzero exit; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("alpha"),
+        "diagnostic must name consuming node alpha; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("prepared"),
+        "diagnostic must name producer prepared; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("run stopped instead of treating it as empty"),
+        "diagnostic must explain its fail-closed disposition; got:\n{stderr}"
+    );
+}

--- a/crates/clinker/tests/scenarios.rs
+++ b/crates/clinker/tests/scenarios.rs
@@ -40,9 +40,9 @@
 //!
 //! A golden that a [`KnownBroken`] marker names is **not** re-blessed: the run
 //! is producing the wrong bytes, and that file is the only committed record of
-//! the right ones. Regenerate such a golden deliberately, from whatever variant
-//! of the scenario does behave correctly, and the blessing run says which files
-//! it skipped.
+//! the right ones. A marker may instead pin an exact fail-loud diagnostic; that
+//! run returns before output comparison and cannot overwrite its goldens.
+//! Regenerate either kind deliberately from a variant that behaves correctly.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -90,6 +90,15 @@ struct KnownBroken {
     /// correct one in [`Gate::counters`]. `None` means the counters are
     /// already correct and any deviation is a real failure.
     current_counters: Option<Counters>,
+    /// Exact fail-loud state while the underlying issue remains unresolved.
+    /// When present, the run must exit with this code and carry every named
+    /// diagnostic fragment. A return to silent success is a regression.
+    current_failure: Option<CurrentFailure>,
+}
+
+struct CurrentFailure {
+    exit_code: i32,
+    stderr_contains: &'static [&'static str],
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -133,21 +142,22 @@ const GATES: &[Gate] = &[
             written: 28,
             dlq: 0,
         },
-        // The goldens state what this pipeline SHOULD write to both sinks. It
-        // currently writes nothing to the first: a node feeding two Outputs
-        // delivers records only to the last-declared one, silently and with
-        // exit 0 (#996). `output/catalog.csv` is committed as the output of the
-        // single-sink variant — the correct answer — and the marker names it as
-        // the one output allowed to differ. `output/catalog.xml` stays fully
-        // gated, so the sink that works today cannot regress unnoticed.
+        // The goldens state what this pipeline SHOULD write to both sinks.
+        // Until #996 is fixed, the executor now stops before publishing either
+        // output instead of silently committing an empty first destination.
+        // The marker pins that fail-loud state so a return to exit-0 partial
+        // output is a regression and a complete fix makes the marker stale.
         known_broken: Some(KnownBroken {
             issue: "https://github.com/rustpunk/clinker/issues/996",
-            failing_outputs: &["output/catalog.csv"],
-            current_counters: Some(Counters {
-                total: 14,
-                ok: 14,
-                written: 14,
-                dlq: 0,
+            failing_outputs: &[],
+            current_counters: None,
+            current_failure: Some(CurrentFailure {
+                exit_code: 1,
+                stderr_contains: &[
+                    "internal error in executor 'catalog_csv'",
+                    "planned input from producer 'normalize' was unavailable",
+                    "instead of treating it as empty",
+                ],
             }),
         }),
     },
@@ -259,22 +269,21 @@ fn find_scenario(id: &str) -> &'static Scenario {
 
 /// One problem found while running a gate.
 ///
-/// `tolerable` distinguishes the two kinds. A golden mismatch is what a
-/// `known_broken` marker is *for* and may be suppressed. Everything else —
-/// generator-digest drift, a wrong exit code, a missing output file, an
-/// unparseable summary — indicates the scenario is not doing what the gate
-/// believes at all, and must surface even on a known-broken scenario. Without
-/// that split, a scenario parked on an issue could silently start crashing, or
-/// its input could drift, and the eventual un-parking would bless goldens
-/// against data nobody reasoned about.
+/// `tolerable` distinguishes a precisely declared current defect from a new
+/// regression. A marker may suppress a named golden/counter mismatch or one
+/// exact fail-loud exit and diagnostic. Everything else — generator drift, an
+/// undeclared exit code, a missing output file, an unparseable summary, or a
+/// changed diagnostic — indicates the scenario is not doing what the gate
+/// believes and must surface. Without that split, a parked scenario could fail
+/// in a new way and hide it behind the original issue.
 struct Failure {
     tolerable: bool,
     message: String,
 }
 
 impl Failure {
-    /// A deviation a `known_broken` marker may declare and tolerate — a golden
-    /// mismatch on a named failing output, or the declared current run summary.
+    /// A deviation a `known_broken` marker declares exactly: a named golden or
+    /// counter mismatch, or a pinned fail-loud exit and diagnostic.
     fn tolerable(message: String) -> Self {
         Self {
             tolerable: true,
@@ -361,6 +370,42 @@ fn run_gate(gate: &Gate) -> Vec<Failure> {
     let expected_exit = if gate.counters.dlq > 0 { 2 } else { 0 };
     match output.status.code() {
         Some(code) if code == expected_exit => {}
+        Some(code)
+            if gate
+                .known_broken
+                .as_ref()
+                .and_then(|known| known.current_failure.as_ref())
+                .is_some_and(|failure| failure.exit_code == code) =>
+        {
+            let failure = gate
+                .known_broken
+                .as_ref()
+                .and_then(|known| known.current_failure.as_ref())
+                .expect("guard established a known failure");
+            let missing: Vec<&str> = failure
+                .stderr_contains
+                .iter()
+                .copied()
+                .filter(|fragment| !stderr.contains(fragment))
+                .collect();
+            if !missing.is_empty() {
+                failures.push(Failure::fatal(format!(
+                    "{}: known-broken exit code {code} carried the wrong diagnostic; missing {:?}.\
+                     \nstdout:\n{stdout}\nstderr:\n{stderr}",
+                    gate.id, missing
+                )));
+            } else {
+                failures.push(Failure::tolerable(format!(
+                    "{}: still stops with the fail-loud diagnostic tracked by {}",
+                    gate.id,
+                    gate.known_broken
+                        .as_ref()
+                        .expect("known failure belongs to a marker")
+                        .issue
+                )));
+            }
+            return failures;
+        }
         Some(code) => {
             failures.push(Failure::fatal(format!(
                 "{}: exit code {code}, expected {expected_exit} ({} DLQ entries).\

--- a/docs/ai/AI_CHANGELOG.md
+++ b/docs/ai/AI_CHANGELOG.md
@@ -39,6 +39,20 @@ Representative code and manifest evidence cited by those docs includes:
 
 ## Entries
 
+### 2026-07-26: A Missing Planned Node Buffer Is Not Empty Input
+
+Type: Source-backed fact (issue #1029).
+
+Summary: Required materialized-input reads use one checked retrieval boundary.
+After certified streaming/fused and explicit alternate-slot paths are excluded,
+an absent planned slot returns `PipelineError::Internal` naming the consumer
+and producer/port; it is never converted to an empty collection. A real zero-
+row stage remains represented by an occupied `NodeBuffer::Memory(Vec::new())`.
+The guard is allocation-free on the successful path and deliberately does not
+change fan-out reader counts, slot addressing, clone reservation, or spill
+eligibility. Evidence: `crates/clinker-exec/src/executor/dispatch.rs` and the
+dispatcher integration tests.
+
 ### 2026-07-25: `ErrorStrategy` Has Exactly Two Variants
 
 Type: Source-backed fact (issue #951).

--- a/docs/engine/src/execution-model.md
+++ b/docs/engine/src/execution-model.md
@@ -9,6 +9,22 @@ Every node in a pipeline plan is one of two kinds at runtime:
 - **Streaming** stages hand their output downstream in bounded batches over a back-pressured channel, never crossing an inter-stage buffer that charges the memory budget. The two *fused* streaming paths additionally hold at most one batch of in-flight events at a time, so their inter-stage memory does not grow with input size. The other streaming stages still build their own result before handing it off — streaming spares them the *second* copy into a charged buffer and overlaps the writer with downstream work, but their own working set is as large as a blocking stage's would be.
 - **Blocking** stages must see their whole input before they can produce any output. They accumulate state inside the memory budget and spill to disk when the soft threshold trips, rather than holding everything in RAM.
 
+## Materialized input invariant
+
+Every planned materialized edge has an occupied node-buffer slot when its
+consumer runs. A producer that emitted no rows still admits an explicit empty
+slot; absence is not another spelling of an empty input. Once a dispatcher has
+excluded its certified streaming/fused path and any explicit alternate slot,
+a missing materialized slot is therefore an executor invariant failure. The run
+returns `PipelineError::Internal` and stops instead of manufacturing an empty
+collection and allowing plausible but incomplete output to commit.
+
+The checked retrieval is stage-level work: it performs the same map lookup and
+moves the same buffer as the successful path. It adds no record-rate
+allocation, clone, or per-record bookkeeping. Optional lookup remains limited
+to body seeding, own-slot-versus-predecessor selection, and cleanup paths where
+absence has defined control-flow meaning.
+
 This distinction is what makes Clinker a bounded-memory executor: a pipeline's peak memory is set by its largest live blocking-or-non-fused-streaming stage plus one batch per fused streaming stage, not by the cumulative size of every stage at once. A streaming stage's output is never separately buffered between dispatch arms, so it is never charged twice: the arbitrator counts each in-flight batch once when the producer flushes it and discharges that charge as the consumer drains it. If RSS still crosses the soft threshold while a single-consumer streaming stage holds batches in flight, the engine spills those batches' records to disk one batch at a time — the streaming handoff is the per-batch counterpart of a blocking stage's full-stage spill, not an exemption from spilling.
 
 ## Which stages stream

--- a/docs/user/src/pipelines/error-handling.md
+++ b/docs/user/src/pipelines/error-handling.md
@@ -30,6 +30,15 @@ The safest strategy. Any record-level error (type coercion failure, validation e
 
 Some failures abort the run under **either** strategy, because they are not record-scoped: an unwritable output path, a config or CXL compile error, and the DLQ-rate ceiling ([`dlq.max_rate`](#dlq-configuration), E315/E316) all end the run regardless of the strategy.
 
+An executor invariant failure also aborts under either strategy with exit code
+`1`. In particular, if a planned materialized input is unavailable when its
+consumer runs, Clinker stops instead of treating that input as a legitimate
+zero-row result. The message names the consuming node and planned producer
+(including the producer port when applicable) and says the input was not
+treated as empty. A source or stage that really emits zero rows remains valid;
+it carries an explicit empty buffer and completes normally. Report any missing-
+input internal error as an engine defect rather than routing it to the DLQ.
+
 ### continue
 
 The production workhorse. Bad records are written to the DLQ file with diagnostic metadata, and the pipeline continues processing remaining records. After the run completes, inspect the DLQ to understand and correct failures.

--- a/examples/scenarios/02-product-feed-normalize/README.md
+++ b/examples/scenarios/02-product-feed-normalize/README.md
@@ -7,9 +7,9 @@ through as a single multi-value field.
 This is the multi-value scenario. `<category>` appears more than once per
 product, and one column holds all of them.
 
-> **This scenario currently fails its own gate**, on purpose. See
-> [What is broken](#what-is-broken) below — the committed expected output states
-> what the engine *should* write, and one of the two sinks does not yet get it.
+> **This scenario cannot complete yet.** See [What is broken](#what-is-broken)
+> below. The committed expected output states what both sinks should write; the
+> gate pins the current fail-loud behavior until the fan-out bug is fixed.
 
 ## Run it
 
@@ -19,9 +19,8 @@ cd examples/scenarios/02-product-feed-normalize
 cargo run -p clinker -- run pipeline.yaml
 ```
 
-```
-Pipeline complete: 14 total, 14 ok, 14 written, 0 dlq
-```
+The run currently exits 1 and reports that `catalog_csv` could not obtain the
+planned input from `normalize`. It does not publish a plausible empty result.
 
 ## The input
 
@@ -100,38 +99,33 @@ but untransformable. The write side puts the container back with `wrap_in`.
 
 ## What is broken
 
-`output/catalog.csv` comes out **empty**, and the run still exits 0 reporting
-all 14 records written.
+The run exits 1 before publishing either destination because `normalize` cannot
+yet feed two direct Output consumers correctly.
 
-The cause is not this pipeline. A node feeding two Output nodes delivers records
-to only the last-declared one; every earlier sink gets a zero-byte file, with no
-diagnostic ([#996](https://github.com/rustpunk/clinker/issues/996)). Declaring
-either sink alone produces correct output, and swapping their order moves the
-empty file to the other one.
+The underlying fan-out defect is tracked by
+[#996](https://github.com/rustpunk/clinker/issues/996). Previously, a node
+feeding two Output nodes delivered records to only one and silently committed a
+zero-byte sibling. The executor now detects the missing planned input and stops
+instead of treating it as an empty stream. Declaring either sink alone still
+produces the correct output.
 
-The scenario keeps the two-sink shape rather than working around it, because
-writing one result in two formats is an ordinary thing to want and the corpus is
-meant to state what the engine *should* do. `expected/catalog.csv` is therefore
-the output of the single-sink variant — the correct answer — and the harness
-carries a `known_broken` marker pointing at #996.
+The scenario keeps the two-sink shape rather than working around it because
+writing one result in two formats is ordinary and the corpus is meant to state
+what the engine should do. Both committed goldens come from working single-sink
+variants and remain the correct answer. The harness carries a `known_broken`
+marker pointing at #996.
 
-The marker is narrow by design. It names `output/catalog.csv` as the only
-output allowed to differ and declares the run summary the engine currently
-prints; `output/catalog.xml` stays fully gated, so the sink that works today
-cannot regress unnoticed while the scenario is parked. The gate's `counters`
-record the **correct** summary — 14 records to each of two sinks, so 28 writes
-— which is what makes the run that fixes #996 report a stale marker rather than
-a counter mismatch. A re-bless run refuses to overwrite a golden the marker
-declares broken, since that file is the only record of the right answer;
-regenerate it from the single-sink variant instead.
+The marker requires exit 1 and the exact fail-loud diagnostic naming
+`catalog_csv` and `normalize`. A return to exit-0 partial output is therefore a
+regression. The gate's counters still record the correct result — 14 records to
+each of two sinks, so 28 writes — so a complete #996 fix makes the marker stale
+and restores normal golden comparison.
 
 ## Try changing it
 
-- Delete the **`catalog_xml`** output and rerun. `catalog_csv` is then the only
-  sink, it receives every record, and `output/catalog.csv` matches its golden
-  exactly — the clearest demonstration that #996 is about having two sinks and
-  not about this pipeline. (Deleting `catalog_csv` instead proves nothing: the
-  CSV simply stops being written at all.)
+- Delete either Output and rerun. The remaining sink receives every record and
+  matches its golden, demonstrating that #996 is about direct shared input
+  rather than either format.
 - Remove `multiple: true` from the schema and rerun — the repeated element is
   now an error rather than a collected field.
 - Drop the XML `join_values` override to see the unwrapped, column-named default.

--- a/examples/scenarios/README.md
+++ b/examples/scenarios/README.md
@@ -52,19 +52,20 @@ multi-record flat files, envelope reconstruction, and the EDI family.
 
 A scenario may be committed with goldens the engine does not yet produce, marked
 `known_broken` in the harness against an issue. The goldens state the correct
-answer; the marker records exactly how the engine disagrees.
+answer; the marker records exactly how the engine disagrees, including a pinned
+fail-loud diagnostic when the safe current behavior is to stop the run.
 
 The marker names the specific outputs allowed to differ and, where relevant, the
 run summary the engine currently prints. Every other output stays fully gated, so
 parking a scenario for one reason cannot silently stop its working parts from
-being checked. A wrong exit code, drifted input digest or missing output always
-fails. The gate's counters record the *correct* summary, so the run that fixes
-the underlying bug reports the marker as stale rather than a counter mismatch.
+being checked. An undeclared exit code, drifted input digest, or unexpected
+diagnostic always fails. The gate's counters record the *correct* summary, so
+the run that fixes the underlying bug reports the marker as stale rather than a
+counter mismatch.
 
-A re-bless run will not overwrite a golden the marker declares broken — that file
-is the only committed record of the right answer. Regenerate it deliberately
-(for #996, by running the scenario with a single sink) rather than from the
-engine's current output.
+A re-bless run will not replace correct goldens from a known failing run. For
+#996, regenerate either output deliberately from its single-sink variant rather
+than from the engine's current fail-loud run.
 
 Currently parked: **02-product-feed-normalize**, against
 [#996](https://github.com/rustpunk/clinker/issues/996).


### PR DESCRIPTION
## Summary

Required materialized node-buffer inputs now fail closed when their planned slot is absent. The executor returns `PipelineError::Internal`, names the consuming node and authored producer/port, and explains that the run stopped instead of treating the input as empty.

A present empty buffer remains a valid zero-row input. Certified fused and streaming paths, explicit alternate-slot probes, and deferred cleanup paths retain their existing behavior.

## Issue

Closes #1029.

## Changes

- Added one checked retrieval boundary for required materialized inputs.
- Applied it across Aggregate, Combine, Cull, Reshape, Route, Sort, Transform, Output, Merge, Envelope, and composition dispatch.
- Preserved Output own-slot/drain/clone selection, streaming Combine probe bypass, fused execution, body seeding, and deferred cleanup semantics.
- Added end-to-end executor coverage for the #908, #996, and #1013 failure families, explicit empty input, composition input, and fused/streaming controls.
- Added a CLI regression proving a nonzero exit and actionable diagnostic.
- Updated the user and engine documentation and changed the parked #996 scenario gate from silent partial success to an exact fail-loud expectation.
- Linearized two unrelated test fixtures that accidentally depended on silent fan-out starvation instead of exercising their documented document-index and Combine-window paths.

## Acceptance criteria

- [x] Missing required materialized input returns `PipelineError::Internal` and a nonzero CLI exit.
- [x] Diagnostics name the consumer, producer, and producer port when present.
- [x] Transform and Aggregate diamonds fail loudly.
- [x] Two direct Outputs fail loudly in both declaration orders.
- [x] Route-to-Aggregate/Reshape/Cull and Cull-to-Aggregate/Reshape fail loudly with both sides identified.
- [x] A present empty buffer remains valid.
- [x] Existing fused Transform, streaming Aggregate, streaming Combine probe, and streaming Output paths remain successful.
- [x] Remaining optional reads are limited to explicit alternate locations, certified bypasses, or cleanup.
- [x] The successful path adds no record-rate allocation, clone, or per-record bookkeeping.

## Verification

- `cargo test -p clinker-exec --locked --offline --no-fail-fast -- --test-threads=1` with the documented file-descriptor floor: passed.
- `cargo test -p clinker --locked --offline --no-fail-fast -- --test-threads=1`: passed.
- Focused missing-input executor tests: 12 passed.
- Focused CLI and scenario tests: 6 passed.
- Existing document, envelope, streaming, composition, and Combine-window regressions: passed as part of the full executor suite.
- `cargo clippy -p clinker-plan -p clinker-exec -p clinker --all-targets --locked --offline -- -D warnings`: passed.
- `cargo check --benches --workspace --locked --offline`: passed.
- `mdbook build docs/user` with an isolated output directory: passed.
- `mdbook build docs/engine` with an isolated output directory: passed.
- `cargo fmt --all --check`: passed.
- `git diff --check`: passed.

The two documented 1 GiB RSS proofs remained ignored; their non-ignored CI-sized variants passed.

## User-facing behavior

This adds no YAML, CXL, or CLI spelling. It follows the existing invariant-error convention: a runtime ownership defect aborts under either error strategy, while genuine zero-row stages remain successful. User documentation now describes the nonzero exit and the nodes named by the diagnostic.

## Risk and rollback

Risk is confined to dispatcher control flow when a planned materialized slot is absent. Successful reads still perform the same slot move and buffer drain, with only stage-level graph lookup added for diagnostic context. No reader counts, slot addressing, spill eligibility, reservation policy, dependencies, native build steps, or C code changed.

Rollback is the single commit in this PR. Reverting it restores the prior behavior, including the silent-empty defect.

## Follow-up issues

- #908, #996, and #1013 remain open for the correctness work that makes these valid fan-out and port-addressing DAGs execute successfully.
- #302 and #1028 retain the spillability and transient-clone accounting work.
- #1030 tracks composition-port versus top-level fusion identity.
- #1031 tracks exclusive Source ownership for Merge.interleave fusion.

## Post-implementation check

- No hidden product or public-surface decision was introduced.
- No required production read still maps an absent slot to an empty collection.
- Every remaining optional slot read was reviewed as an alternate path, certified bypass, or cleanup.
- Successful execution adds no clone, dependency, native requirement, or record-rate bookkeeping.
- Tests and documentation cover the changed behavior and the parked scenario now rejects a return to silent success.
