### PR TITLE
Fix Route and Cull successor slot reads

### DIFF
--- a/benches/pipelines/realistic/route_fanout.yaml
+++ b/benches/pipelines/realistic/route_fanout.yaml
@@ -34,9 +34,29 @@ nodes:
         medium: "priority == \"medium\""
       default: low
 
+  - type: aggregate
+    name: agg_high
+    input: split.high
+    config:
+      group_by: [priority]
+      strategy: hash
+      cxl: |
+        emit total = sum(value)
+        emit n = count(*)
+
+  - type: aggregate
+    name: agg_low
+    input: split.low
+    config:
+      group_by: [priority]
+      strategy: hash
+      cxl: |
+        emit total = sum(value)
+        emit n = count(*)
+
   - type: output
     name: high_out
-    input: split.high
+    input: agg_high
     config:
       name: high_out
       type: csv
@@ -54,7 +74,7 @@ nodes:
 
   - type: output
     name: low_out
-    input: split.low
+    input: agg_low
     config:
       name: low_out
       type: csv

--- a/crates/clinker-benchmarks/src/runner.rs
+++ b/crates/clinker-benchmarks/src/runner.rs
@@ -314,6 +314,18 @@ mod tests {
         assert!(!report.stages.is_empty());
     }
 
+    /// Runner executes Route branches that feed Aggregate consumers.
+    #[test]
+    fn test_runner_route_fanout_writes_records() {
+        let runner = test_runner();
+        let path = pipelines_dir().join("realistic/route_fanout.yaml");
+        let report = runner.run(&path, Scale::Small).unwrap();
+        assert!(
+            report.counters.records_written > 0,
+            "Route successor slots must reach Aggregate consumers"
+        );
+    }
+
     /// Runner executes a nested JSON pipeline.
     #[test]
     fn test_runner_nested_json() {

--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -19,8 +19,9 @@ use petgraph::graph::NodeIndex;
 use crate::executor::dispatch::{
     ExecutorContext, RetainedAggregatorState, admit_node_buffer, advance_cursor,
     finalize_node_rooted_windows, node_buffer_spill_allowed, project_rows_to_buffer_schema,
-    push_dlq, record_error_to_buffer_if_grouped, require_node_buffer_slot, source_file_arc_of,
-    source_name_arc_of, stream_linear_producer_emit, tee_emit_to_region_input_buffers,
+    push_dlq, record_error_to_buffer_if_grouped, require_single_input_node_buffer_slot,
+    source_file_arc_of, source_name_arc_of, stream_linear_producer_emit,
+    tee_emit_to_region_input_buffers,
 };
 use crate::executor::schema_check::check_input_schema;
 use crate::executor::{DlqEntry, parse_memory_limit, stage_metrics};
@@ -162,8 +163,9 @@ pub(crate) fn dispatch_aggregation(
         .find_edge(pred, node_idx)
         .and_then(|edge| current_dag.graph.edge_weight(edge))
         .and_then(|edge| edge.producer_port.as_deref());
-    let input_buffer = require_node_buffer_slot(
+    let input_buffer = require_single_input_node_buffer_slot(
         ctx,
+        node_idx,
         pred,
         name,
         current_dag.graph[pred].name(),

--- a/crates/clinker-exec/src/executor/cull_dispatch.rs
+++ b/crates/clinker-exec/src/executor/cull_dispatch.rs
@@ -68,7 +68,7 @@ use petgraph::visit::EdgeRef;
 
 use crate::executor::dispatch::{
     ExecutorContext, NodeBufferKey, admit_node_buffer, node_buffer_spill_allowed,
-    require_node_buffer_slot, source_file_arc_of, source_name_arc_of,
+    require_single_input_node_buffer_slot, source_file_arc_of, source_name_arc_of,
 };
 use crate::executor::{GroupedNodeKind, giant_group_error};
 use crate::pipeline::memory::{
@@ -172,8 +172,9 @@ pub(crate) fn dispatch_cull(
         .find_edge(pred, node_idx)
         .and_then(|edge| current_dag.graph.edge_weight(edge))
         .and_then(|edge| edge.producer_port.as_deref());
-    let input_buffer = require_node_buffer_slot(
+    let input_buffer = require_single_input_node_buffer_slot(
         ctx,
+        node_idx,
         pred,
         name,
         current_dag.graph[pred].name(),
@@ -483,15 +484,15 @@ fn compute_drop_decisions(
 /// `None`) draws kept rows.
 ///
 /// Where the records land depends on how the successor reads its input. A
-/// single-output consumer (Transform / Output / Reshape / Cull) checks its own
-/// `node_buffers` slot first, so its port-selected records go into the
-/// successor's own slot (`(succ, None)`). A multi-input consumer (Merge /
-/// Combine) reads its *predecessor's* slot directly, keyed by the incoming
-/// edge's producer port, so each distinct producer port lands in this Cull's
-/// own `(node_idx, Some(port))` slot — the `main` and `removed_to` ports stay
-/// separate, which a Combine build side depends on. Both ports broadcast
-/// `input_puncts` so each downstream subgraph drives its own per-document
-/// accumulators.
+/// single-output consumer (Transform / Output / Reshape / Cull / Sort /
+/// Aggregation) checks its own `node_buffers` slot first, so its port-selected
+/// records go into the successor's own slot (`(succ, None)`). A multi-input
+/// consumer (Merge / Combine) reads its *predecessor's* slot directly, keyed by
+/// the incoming edge's producer port, so each distinct producer port lands in
+/// this Cull's own `(node_idx, Some(port))` slot — the `main` and `removed_to`
+/// ports stay separate, which a Combine build side depends on. Both ports
+/// broadcast `input_puncts` so each downstream subgraph drives its own
+/// per-document accumulators.
 #[allow(clippy::too_many_arguments)]
 fn emit_ports(
     ctx: &mut ExecutorContext<'_>,

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1682,6 +1682,44 @@ pub(crate) fn require_node_buffer_slot(
         .ok_or_else(|| missing_node_buffer_input_error(consumer_name, producer_name, producer_port))
 }
 
+/// Drain a single-input consumer's materialized input using the executor's
+/// uniform slot-addressing rule.
+///
+/// Route and Cull publish directly into a single-input successor's own
+/// `(consumer, None)` slot. Other producers publish into their own
+/// `(producer, producer_port)` slot. Prefer the successor-local slot when it
+/// exists, including when it is explicitly empty, then require the incoming
+/// predecessor slot so absence still fails closed.
+pub(crate) fn require_single_input_node_buffer_slot(
+    ctx: &mut ExecutorContext<'_>,
+    consumer_idx: NodeIndex,
+    producer_idx: NodeIndex,
+    consumer_name: &str,
+    producer_name: &str,
+    producer_port: Option<&str>,
+) -> Result<NodeBuffer, PipelineError> {
+    let key =
+        single_input_node_buffer_key(&ctx.node_buffers, consumer_idx, producer_idx, producer_port);
+    require_node_buffer_slot(ctx, key, consumer_name, producer_name, producer_port)
+}
+
+/// Resolve the materialized slot key for a single-input consumer without
+/// changing either slot. Kept separate from the draining helper so the
+/// successor-local precedence can be tested for planner-synthesized nodes.
+pub(crate) fn single_input_node_buffer_key(
+    node_buffers: &HashMap<NodeBufferKey, NodeBuffer>,
+    consumer_idx: NodeIndex,
+    producer_idx: NodeIndex,
+    producer_port: Option<&str>,
+) -> NodeBufferKey {
+    let own_key = NodeBufferKey::from(consumer_idx);
+    if node_buffers.contains_key(&own_key) {
+        own_key
+    } else {
+        NodeBufferKey::with_port(producer_idx, producer_port)
+    }
+}
+
 #[cfg(test)]
 mod required_node_buffer_tests {
     use super::missing_node_buffer_input_error;

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -53,7 +53,7 @@ use petgraph::graph::NodeIndex;
 use crate::executor::DlqEntry;
 use crate::executor::dispatch::{
     ExecutorContext, admit_node_buffer, node_buffer_spill_allowed, push_dlq,
-    require_node_buffer_slot, source_file_arc_of, source_name_arc_of,
+    require_single_input_node_buffer_slot, source_file_arc_of, source_name_arc_of,
     tee_emit_to_region_input_buffers,
 };
 use crate::executor::{GroupedNodeKind, giant_group_error};
@@ -196,8 +196,9 @@ pub(crate) fn dispatch_reshape(
         .find_edge(pred, node_idx)
         .and_then(|edge| current_dag.graph.edge_weight(edge))
         .and_then(|edge| edge.producer_port.as_deref());
-    let input_buffer = require_node_buffer_slot(
+    let input_buffer = require_single_input_node_buffer_slot(
         ctx,
+        node_idx,
         pred,
         name,
         current_dag.graph[pred].name(),

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -10,8 +10,8 @@ use clinker_record::Record;
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
-    ExecutorContext, admit_node_buffer, node_buffer_spill_allowed, require_node_buffer_slot,
-    tee_emit_to_region_input_buffers,
+    ExecutorContext, admit_node_buffer, node_buffer_spill_allowed,
+    require_single_input_node_buffer_slot, tee_emit_to_region_input_buffers,
 };
 use crate::executor::{parse_memory_limit, stage_metrics};
 use crate::pipeline::spill_merge::merge_sorted_runs;
@@ -49,8 +49,9 @@ pub(crate) fn dispatch_sort(
         .find_edge(pred, node_idx)
         .and_then(|edge| current_dag.graph.edge_weight(edge))
         .and_then(|edge| edge.producer_port.as_deref());
-    let input_buffer = require_node_buffer_slot(
+    let input_buffer = require_single_input_node_buffer_slot(
         ctx,
+        node_idx,
         pred,
         name,
         current_dag.graph[pred].name(),
@@ -201,12 +202,35 @@ fn charge_enforcer_spill(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
+    use crate::executor::dispatch::{NodeBufferKey, single_input_node_buffer_key};
+    use crate::executor::node_buffer::NodeBuffer;
     use crate::pipeline::sort_buffer::SortBuffer;
     use clinker_plan::config::{SortField, SortOrder};
     use clinker_record::{Schema, Value};
     use rust_decimal::Decimal;
+
+    #[test]
+    fn sort_prefers_its_successor_local_slot() {
+        let producer_idx = NodeIndex::new(1);
+        let sort_idx = NodeIndex::new(2);
+        let mut buffers = HashMap::new();
+        buffers.insert(
+            NodeBufferKey::with_port(producer_idx, Some("selected")),
+            NodeBuffer::Memory(Vec::new()),
+        );
+        buffers.insert(
+            NodeBufferKey::from(sort_idx),
+            NodeBuffer::Memory(Vec::new()),
+        );
+
+        let selected =
+            single_input_node_buffer_key(&buffers, sort_idx, producer_idx, Some("selected"));
+
+        assert_eq!(selected, NodeBufferKey::from(sort_idx));
+    }
 
     fn schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec!["k".into(), "id".into()]))

--- a/crates/clinker-exec/tests/node_buffer_missing_fail_loud.rs
+++ b/crates/clinker-exec/tests/node_buffer_missing_fail_loud.rs
@@ -1,9 +1,10 @@
 //! End-to-end regressions for required materialized node-buffer inputs (#1029).
 //!
-//! The DAGs below are valid but expose the addressing/reader-count gaps tracked
-//! by #908, #996, and #1013. This safety landing does not make those shapes
-//! execute correctly; it guarantees that a missing planned slot aborts instead
-//! of becoming a successful empty stream.
+//! The DAGs below cover the addressing/reader-count gaps tracked by #908,
+//! #996, and #1013. Route/Cull successor-local slots now execute through the
+//! uniform own-slot-first lookup. The remaining #908 and #996 shapes stay here
+//! to guarantee that a missing planned slot aborts instead of becoming a
+//! successful empty stream.
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -131,6 +132,17 @@ fn assert_missing_input(
         detail.contains("run stopped instead of treating it as empty"),
         "the error must explain the fail-closed disposition: {detail}"
     );
+}
+
+fn assert_csv_rows(buffer: &SharedBuffer, expected_header: &str, expected_rows: &[&str]) {
+    let output = buffer.as_string();
+    let mut lines = output.lines();
+    assert_eq!(lines.next(), Some(expected_header));
+    let mut actual: Vec<&str> = lines.collect();
+    let mut expected = expected_rows.to_vec();
+    actual.sort_unstable();
+    expected.sort_unstable();
+    assert_eq!(actual, expected);
 }
 
 fn route_pipeline(name: &str, selected_consumer: &str) -> String {
@@ -360,7 +372,7 @@ fn first_of_two_direct_outputs_fails_loudly_in_beta_alpha_order() {
 }
 
 #[test]
-fn route_to_aggregate_names_the_route_branch_when_it_stops() {
+fn route_to_aggregate_delivers_the_selected_branch() {
     let yaml = route_pipeline(
         "route_to_aggregate_missing_input",
         r#"  - type: aggregate
@@ -381,16 +393,19 @@ fn route_to_aggregate_names_the_route_branch_when_it_stops() {
 "#,
     );
 
-    assert_missing_input(
-        run_pipeline(&yaml, CSV).0,
-        "summarize",
-        "split",
-        Some("keep"),
+    let (result, buffers) = run_pipeline(&yaml, CSV);
+    let report = result.expect("Route successor slot must feed Aggregate");
+    assert_eq!(report.counters.records_written, 3);
+    assert_csv_rows(&buffers["out"], "dept,n", &["eng,1", "sales,1"]);
+    assert_csv_rows(
+        &buffers["dropped"],
+        "id,dept,amount,status,label",
+        &["2,eng,200,bad,two"],
     );
 }
 
 #[test]
-fn route_to_reshape_names_the_route_branch_when_it_stops() {
+fn route_to_reshape_delivers_the_selected_branch() {
     let yaml = route_pipeline(
         "route_to_reshape_missing_input",
         r#"  - type: reshape
@@ -414,11 +429,23 @@ fn route_to_reshape_names_the_route_branch_when_it_stops() {
 "#,
     );
 
-    assert_missing_input(run_pipeline(&yaml, CSV).0, "relabel", "split", Some("keep"));
+    let (result, buffers) = run_pipeline(&yaml, CSV);
+    let report = result.expect("Route successor slot must feed Reshape");
+    assert_eq!(report.counters.records_written, 3);
+    assert_csv_rows(
+        &buffers["out"],
+        "id,dept,amount,status,label",
+        &["1,eng,100,keep,reshaped", "3,sales,50,keep,reshaped"],
+    );
+    assert_csv_rows(
+        &buffers["dropped"],
+        "id,dept,amount,status,label",
+        &["2,eng,200,bad,two"],
+    );
 }
 
 #[test]
-fn route_to_cull_names_the_route_branch_when_it_stops() {
+fn route_to_cull_delivers_the_selected_branch() {
     let yaml = route_pipeline(
         "route_to_cull_missing_input",
         r#"  - type: cull
@@ -447,16 +474,24 @@ fn route_to_cull_names_the_route_branch_when_it_stops() {
 "#,
     );
 
-    assert_missing_input(
-        run_pipeline(&yaml, CSV).0,
-        "filter_kept",
-        "split",
-        Some("keep"),
+    let (result, buffers) = run_pipeline(&yaml, CSV);
+    let report = result.expect("Route successor slot must feed Cull");
+    assert_eq!(report.counters.records_written, 3);
+    assert_csv_rows(
+        &buffers["out"],
+        "id,dept,amount,status,label",
+        &["1,eng,100,keep,one", "3,sales,50,keep,three"],
+    );
+    assert!(buffers["filtered"].as_string().is_empty());
+    assert_csv_rows(
+        &buffers["dropped"],
+        "id,dept,amount,status,label",
+        &["2,eng,200,bad,two"],
     );
 }
 
 #[test]
-fn cull_to_aggregate_stops_instead_of_treating_main_as_empty() {
+fn cull_to_aggregate_delivers_main_and_removed_ports() {
     let yaml = cull_pipeline(
         "cull_to_aggregate_missing_input",
         r#"  - type: aggregate
@@ -477,11 +512,19 @@ fn cull_to_aggregate_stops_instead_of_treating_main_as_empty() {
 "#,
     );
 
-    assert_missing_input(run_pipeline(&yaml, CSV).0, "summarize", "gate", None);
+    let (result, buffers) = run_pipeline(&yaml, CSV);
+    let report = result.expect("Cull successor slot must feed Aggregate");
+    assert_eq!(report.counters.records_written, 3);
+    assert_csv_rows(&buffers["out"], "dept,n", &["eng,1", "sales,1"]);
+    assert_csv_rows(
+        &buffers["removed"],
+        "id,dept,amount,status,label",
+        &["2,eng,200,bad,two"],
+    );
 }
 
 #[test]
-fn cull_to_reshape_stops_instead_of_treating_main_as_empty() {
+fn cull_to_reshape_delivers_main_and_removed_ports() {
     let yaml = cull_pipeline(
         "cull_to_reshape_missing_input",
         r#"  - type: reshape
@@ -505,7 +548,19 @@ fn cull_to_reshape_stops_instead_of_treating_main_as_empty() {
 "#,
     );
 
-    assert_missing_input(run_pipeline(&yaml, CSV).0, "relabel", "gate", None);
+    let (result, buffers) = run_pipeline(&yaml, CSV);
+    let report = result.expect("Cull successor slot must feed Reshape");
+    assert_eq!(report.counters.records_written, 3);
+    assert_csv_rows(
+        &buffers["out"],
+        "id,dept,amount,status,label",
+        &["1,eng,100,keep,reshaped", "3,sales,50,keep,reshaped"],
+    );
+    assert_csv_rows(
+        &buffers["removed"],
+        "id,dept,amount,status,label",
+        &["2,eng,200,bad,two"],
+    );
 }
 
 #[test]

--- a/docs/engine/src/execution-model.md
+++ b/docs/engine/src/execution-model.md
@@ -25,6 +25,15 @@ allocation, clone, or per-record bookkeeping. Optional lookup remains limited
 to body seeding, own-slot-versus-predecessor selection, and cleanup paths where
 absence has defined control-flow meaning.
 
+`Aggregate`, `Reshape`, `Cull`, and planner-synthesized `Sort` use one address
+rule: first check their own `(consumer, None)` slot, which is where a `Route`
+branch or `Cull` port publishes its selected records, then require the incoming
+`(producer, producer_port)` slot. A present empty own slot is still
+authoritative; only the absence of both valid addresses is an invariant
+failure. `Transform` and `Output` also recognize successor-local slots through
+their existing specialized input paths. `Merge` and `Combine` remain
+predecessor-slot readers because they select among multiple incoming edges.
+
 This distinction is what makes Clinker a bounded-memory executor: a pipeline's peak memory is set by its largest live blocking-or-non-fused-streaming stage plus one batch per fused streaming stage, not by the cumulative size of every stage at once. A streaming stage's output is never separately buffered between dispatch arms, so it is never charged twice: the arbitrator counts each in-flight batch once when the producer flushes it and discharges that charge as the consumer drains it. If RSS still crosses the soft threshold while a single-consumer streaming stage holds batches in flight, the engine spills those batches' records to disk one batch at a time — the streaming handoff is the per-batch counterpart of a blocking stage's full-stage spill, not an exemption from spilling.
 
 ## Which stages stream


### PR DESCRIPTION
## Summary

Fix single-input materialized consumers reading the wrong node-buffer slot after Route and Cull producers. Aggregate, Reshape, Cull, and planner-synthesized Sort now prefer their successor-local slot, including a present empty buffer, before requiring the incoming predecessor slot.

## Issue

Closes #1013

## Changes

- Add one shared slot-selection rule for single-input materialized consumers.
- Keep the existing fail-loud diagnostic when neither valid slot exists.
- Convert all five reported Route/Cull topologies into exact-output regressions while retaining the #908 and #996 fail-loud controls.
- Restore Aggregate consumers in the Route fan-out benchmark pipeline and execute that pipeline from the benchmark runner tests.
- Document the addressing rule and preserve Merge/Combine predecessor-slot behavior.

## Acceptance criteria

- [x] Route to Aggregate, Reshape, and Cull delivers every selected record.
- [x] Cull to Aggregate and Reshape delivers both main and removed-port records.
- [x] Multi-branch Route and Cull port-split cases have exact output assertions.
- [x] Aggregate, Reshape, Cull, and Sort prefer a present successor-local slot.
- [x] Missing inputs still abort through the existing typed diagnostic.
- [x] Existing #908 and #996 controls continue to fail loudly.
- [x] The Route fan-out benchmark executes Aggregate branches and reports written records.
- [x] Present-empty semantics, punctuation forwarding, ordering, memory accounting, and spill behavior are unchanged.
- [x] No dependency, native build step, C code, YAML schema, CXL, or CLI change is introduced.

## Verification

- `cargo test -p clinker-exec --test node_buffer_missing_fail_loud --locked --offline -- --test-threads=1`
- `cargo test -p clinker-exec --test aggregate_per_document_flush --locked --offline -- --test-threads=1`
- `cargo test -p clinker-benchmarks --locked --offline`
- `cargo test -p clinker-exec --locked --offline -- --test-threads=1`
- `cargo clippy -p clinker-exec -p clinker-benchmarks --all-targets --locked --offline -- -D warnings`
- `cargo check --workspace --locked --offline`
- `mdbook build docs/engine -d /tmp/clinker-mdbook-engine`
- `cargo fmt --all --check`
- `git diff --check`

Cross-platform CI remains required before merge because this is a high-risk executor correctness change.

## Risk / rollback

Risk is limited to materialized slot selection for four single-input consumers. The lookup is stage-level, does not allocate or clone per record, and reuses the existing buffer and spill paths. Reverting this commit restores the previous fail-loud behavior from #1029.

## Follow-up issues

No new follow-up was introduced. Shared-reader accounting and Output fan-out remain intentionally tracked by #908 and #996.

## Post-implementation check

The implementation stays within the issue boundary: it does not change reader counts, clone reservations, spill eligibility, re-readable slots, record emission, or any pipeline-author-facing surface.
