### PR TITLE
Fix composition source seed precedence

### DIFF
--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -661,14 +661,15 @@ pub(crate) struct ExecutorContext<'a> {
             std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
         ),
     >,
-    /// Source-node names whose receivers have been moved out of
-    /// `source_records` by a downstream Merge.interleave fusion. The
-    /// Source dispatch arm checks this set at entry and returns
-    /// cleanly without consuming when its name is present — the fused
-    /// Merge arm is now the sole consumer of those records. Empty for
-    /// pipelines whose Merge predecessors are not all Sources, or
-    /// whose Merge mode is concat (concat keeps today's
-    /// declaration-order drain through the Source arms).
+    /// Top-level Source-node names whose receivers have been moved out of
+    /// `source_records` by a downstream Merge.interleave or Transform fusion.
+    /// The Source dispatch arm returns cleanly without consuming when its name
+    /// is present and no seeded own slot exists — a composition body may use
+    /// the same bare name for an input-port Source, and that body-local seed
+    /// takes precedence without touching the top-level fused receiver. Empty
+    /// for pipelines whose Merge predecessors are not all Sources, or whose
+    /// Merge mode is concat (concat keeps today's declaration-order drain
+    /// through the Source arms).
     pub(crate) fused_sources: HashSet<String>,
 
     /// Transforms whose sole upstream is a `PlanNode::Source` and that

--- a/crates/clinker-exec/src/executor/source_dispatch.rs
+++ b/crates/clinker-exec/src/executor/source_dispatch.rs
@@ -40,16 +40,16 @@ pub(crate) fn dispatch_source(
     };
     // Three input paths feed a Source's emit:
     //
-    // 1. Source name in `ctx.fused_sources` — a downstream
-    //    `Merge.interleave` arm has taken ownership of this
-    //    Source's crossbeam `Receiver` and is consuming records
-    //    directly via `crossbeam_channel::Select`. This arm
-    //    returns cleanly without emitting; the fused Merge
-    //    populates the merge node's buffer.
-    // 2. Records already seeded into `ctx.node_buffers[node_idx]`
+    // 1. Records already seeded into `ctx.node_buffers[node_idx]`
     //    by the body executor at composition entry —
     //    composition input ports surface as synthetic Source
     //    nodes owning the records the parent scope harvested.
+    // 2. Source name in `ctx.fused_sources` with no seeded own
+    //    slot — a downstream top-level `Merge.interleave` or
+    //    Transform arm has taken ownership of this Source's
+    //    crossbeam `Receiver` and consumes it directly. This arm
+    //    returns cleanly without emitting; the fused consumer
+    //    owns the Source boundary work and downstream emission.
     // 3. The live crossbeam `Receiver` in `source_records[name]`,
     //    consumed via `recv` per record until the paired ingest
     //    thread drops its sender. Per record: canonicalize onto
@@ -65,7 +65,9 @@ pub(crate) fn dispatch_source(
     // `Arc<Schema>` so every downstream operator hits the
     // `Arc::ptr_eq` fast path on the first record. Structural
     // equality holds by construction.
-    if ctx.fused_sources.contains(name.as_str()) {
+    let source_slot_key = NodeBufferKey::from(node_idx);
+    let has_seeded_own_slot = ctx.node_buffers.contains_key(&source_slot_key);
+    if !has_seeded_own_slot && ctx.fused_sources.contains(name.as_str()) {
         return Ok(());
     }
     let source_schema = current_dag.graph[node_idx].stored_output_schema().cloned();
@@ -80,7 +82,6 @@ pub(crate) fn dispatch_source(
         }
     };
 
-    let source_slot_key = NodeBufferKey::from(node_idx);
     let (records, source_puncts, transferred_reservation): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,

--- a/crates/clinker-exec/src/executor/tests/transient_node_buffer_reservations.rs
+++ b/crates/clinker-exec/src/executor/tests/transient_node_buffer_reservations.rs
@@ -144,18 +144,36 @@ fn run(
     Result<ExecutionReport, PipelineError>,
     HashMap<String, SharedBuffer>,
 ) {
+    run_with_params(
+        yaml,
+        source_csv,
+        output_names,
+        arbitrator,
+        &PipelineRunParams {
+            execution_id: "transient-node-buffer-reservation".to_string(),
+            batch_id: "batch-0".to_string(),
+            ..Default::default()
+        },
+    )
+}
+
+fn run_with_params(
+    yaml: &str,
+    source_csv: &[(&str, &str)],
+    output_names: &[&str],
+    arbitrator: Arc<crate::pipeline::memory::MemoryArbitrator>,
+    params: &PipelineRunParams,
+) -> (
+    Result<ExecutionReport, PipelineError>,
+    HashMap<String, SharedBuffer>,
+) {
     let config = clinker_plan::config::parse_config(yaml).expect("parse pipeline YAML");
     let (writers, buffers) = writers(output_names);
-    let params = PipelineRunParams {
-        execution_id: "transient-node-buffer-reservation".to_string(),
-        batch_id: "batch-0".to_string(),
-        ..Default::default()
-    };
     let result = PipelineExecutor::run_with_readers_writers_with_arbitrator(
         &config,
         readers(source_csv),
         writers.into(),
-        &params,
+        params,
         fixture_compile_context(),
         arbitrator,
     );
@@ -360,6 +378,117 @@ fn direct_source_composition_transfer_restores_colliding_parent_registration() {
         0,
         "body transfer and parent restoration must leave no registration"
     );
+    assert_eq!(arbitrator.sum_consumer_usage(), 0);
+}
+
+const DIRECT_SOURCE_FUSION_NAME_COLLISION: &str = r#"
+pipeline:
+  name: direct_source_fusion_name_collision
+nodes:
+  - type: source
+    name: body_feed
+    config: { name: body_feed, type: csv, path: body-feed.csv, schema: [ { name: id, type: int } ] }
+  - type: composition
+    name: body_call
+    input: body_feed
+    use: ../compositions/source_boundary_collision.comp.yaml
+    inputs:
+      collision: body_feed
+  - type: output
+    name: body_out
+    input: body_call
+    config: { name: body_out, type: csv, path: body-out.csv, include_unmapped: false }
+  - type: source
+    name: collision
+    config: { name: collision, type: csv, path: collision.csv, schema: [ { name: id, type: int } ] }
+  - type: transform
+    name: top_transform
+    input: collision
+    config:
+      declares:
+        - { name: boundary, scope: record, type: string }
+      cxl: |
+        emit id = id
+        emit origin = "top-transform"
+        emit $record.boundary = $record.boundary
+  - type: output
+    name: top_out
+    input: top_transform
+    config: { name: top_out, type: csv, path: top-out.csv, include_unmapped: false }
+"#;
+
+#[test]
+fn direct_source_composition_seed_precedes_fused_name_and_releases_registration() {
+    let config = clinker_plan::config::parse_config(DIRECT_SOURCE_FUSION_NAME_COLLISION)
+        .expect("parse pipeline YAML");
+    let compiled = config
+        .compile(&fixture_compile_context())
+        .expect("compile pipeline");
+    let dag = compiled.dag();
+    let parent_source_idx = dag
+        .graph
+        .node_indices()
+        .find(|idx| dag.graph[*idx].name() == "body_feed")
+        .expect("parent Source exists");
+    let body_id = dag
+        .graph
+        .node_indices()
+        .find_map(|idx| match &dag.graph[idx] {
+            clinker_plan::plan::execution::PlanNode::Composition { name, body, .. }
+                if name == "body_call" =>
+            {
+                Some(*body)
+            }
+            _ => None,
+        })
+        .expect("composition body id exists");
+    let body = compiled
+        .composition_bodies()
+        .get(&body_id)
+        .expect("bound composition body exists");
+    let body_port_source_idx = *body
+        .port_name_to_node_idx
+        .get("collision")
+        .expect("body input port Source exists");
+    assert_eq!(
+        parent_source_idx, body_port_source_idx,
+        "this regression must exercise colliding parent/body NodeIndex spaces"
+    );
+
+    let merge_fused =
+        clinker_plan::plan::execution::compute_merge_interleave_fused_sources(dag, &config);
+    let init_phase = clinker_plan::plan::execution::compute_init_phase_node_set(dag);
+    let (transform_sources, _) = clinker_plan::plan::execution::compute_transform_fused_sources(
+        dag,
+        &merge_fused,
+        &init_phase,
+    );
+    assert!(transform_sources.contains("collision"));
+
+    let arbitrator = quiet_arbitrator();
+    let mut params = PipelineRunParams {
+        execution_id: "direct-source-fusion-name-collision".to_string(),
+        batch_id: "batch-0".to_string(),
+        ..Default::default()
+    };
+    params
+        .record_vars
+        .insert("boundary".to_string(), clinker_record::Value::from("body"));
+    let (result, outputs) = run_with_params(
+        DIRECT_SOURCE_FUSION_NAME_COLLISION,
+        &[("body_feed", "id\n7\n"), ("collision", "id\n9\n")],
+        &["body_out", "top_out"],
+        Arc::clone(&arbitrator),
+        &params,
+    );
+    result.expect("direct Source-to-Composition collision pipeline must run");
+
+    assert_eq!(outputs["body_out"].as_string(), "id,boundary\n7,body\n");
+    assert_eq!(
+        outputs["top_out"].as_string(),
+        "id,origin\n9,top-transform\n"
+    );
+    assert_eq!(arbitrator.consumer_count(), 0);
     assert_eq!(arbitrator.sum_consumer_usage(), 0);
 }
 

--- a/crates/clinker-exec/tests/composition_executor_test.rs
+++ b/crates/clinker-exec/tests/composition_executor_test.rs
@@ -15,6 +15,12 @@ use std::sync::{Arc, Mutex};
 
 use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
 use clinker_plan::config::{CompileContext, parse_config};
+use clinker_plan::plan::CompiledPlan;
+use clinker_plan::plan::execution::{
+    compute_init_phase_node_set, compute_merge_interleave_fused_sources,
+    compute_transform_fused_sources,
+};
+use clinker_record::Value;
 
 #[derive(Clone, Default)]
 struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
@@ -84,6 +90,245 @@ fn run_with_composition(
         PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &test_params())
             .expect("pipeline run");
     (report, buf.as_string())
+}
+
+fn run_source_collision_pipeline(
+    yaml: &str,
+    inputs: &[(&str, &str, &str)],
+) -> (CompiledPlan, HashMap<String, String>) {
+    let config = parse_config(yaml).expect("parse source-collision pipeline");
+    let root = fixture_workspace_root();
+    let ctx = CompileContext::with_pipeline_dir(&root, PathBuf::from("pipelines"));
+    let plan = config
+        .compile(&ctx)
+        .expect("compile source-collision pipeline");
+
+    let readers: clinker_exec::executor::SourceReaders = inputs
+        .iter()
+        .map(|(source, file, csv)| {
+            (
+                (*source).to_string(),
+                clinker_exec::executor::single_file_reader(
+                    *file,
+                    Box::new(Cursor::new(csv.as_bytes().to_vec())),
+                ),
+            )
+        })
+        .collect();
+    let buffers: HashMap<String, SharedBuffer> = config
+        .output_configs()
+        .map(|output| (output.name.clone(), SharedBuffer::new()))
+        .collect();
+    let writers: HashMap<String, Box<dyn Write + Send>> = buffers
+        .iter()
+        .map(|(name, buffer)| {
+            (
+                name.clone(),
+                Box::new(buffer.clone()) as Box<dyn Write + Send>,
+            )
+        })
+        .collect();
+    let mut params = test_params();
+    params
+        .record_vars
+        .insert("boundary".to_string(), Value::from("body"));
+
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run source-collision pipeline");
+    let outputs = buffers
+        .into_iter()
+        .map(|(name, buffer)| (name, buffer.as_string()))
+        .collect();
+    (plan, outputs)
+}
+
+#[test]
+fn composition_port_seed_wins_over_same_named_fused_transform_source() {
+    let yaml = r#"
+pipeline:
+  name: composition_source_collision_transform
+nodes:
+  - type: source
+    name: body_feed
+    config:
+      name: body_feed
+      type: csv
+      path: body-transform.csv
+      schema:
+        - { name: id, type: int }
+  - type: aggregate
+    name: body_group
+    input: body_feed
+    config:
+      group_by: [id]
+      strategy: hash
+      cxl: |
+        emit id = max(id)
+  - type: composition
+    name: body_call
+    input: body_group
+    use: ../compositions/source_boundary_collision.comp.yaml
+    inputs:
+      collision: body_group
+  - type: output
+    name: body_out
+    input: body_call
+    config:
+      name: body_out
+      type: csv
+      path: body-out.csv
+      include_unmapped: false
+  - type: source
+    name: collision
+    config:
+      name: collision
+      type: csv
+      path: collision-transform.csv
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: top_transform
+    input: collision
+    config:
+      declares:
+        - { name: boundary, scope: record, type: string }
+      cxl: |
+        emit id = id
+        emit origin = "top-transform"
+        emit $record.boundary = $record.boundary
+  - type: output
+    name: top_out
+    input: top_transform
+    config:
+      name: top_out
+      type: csv
+      path: top-out.csv
+      include_unmapped: false
+"#;
+    let (plan, outputs) = run_source_collision_pipeline(
+        yaml,
+        &[
+            ("body_feed", "body-transform.csv", "id\n7\n"),
+            ("collision", "collision-transform.csv", "id\n9\n"),
+        ],
+    );
+
+    let dag = plan.dag();
+    let merge_fused = compute_merge_interleave_fused_sources(dag, plan.config());
+    let init_phase = compute_init_phase_node_set(dag);
+    let (transform_sources, fused_transforms) =
+        compute_transform_fused_sources(dag, &merge_fused, &init_phase);
+    let top_transform = dag
+        .graph
+        .node_indices()
+        .find(|idx| dag.graph[*idx].name() == "top_transform")
+        .expect("top Transform present");
+    assert!(transform_sources.contains("collision"));
+    assert!(fused_transforms.contains(&top_transform));
+    assert_eq!(outputs["body_out"], "id,boundary\n7,body\n");
+    assert_eq!(outputs["top_out"], "id,origin\n9,top-transform\n");
+}
+
+#[test]
+fn composition_port_seed_wins_over_same_named_fused_merge_source() {
+    let yaml = r#"
+pipeline:
+  name: composition_source_collision_merge
+nodes:
+  - type: source
+    name: body_feed
+    config:
+      name: body_feed
+      type: csv
+      path: body-merge.csv
+      schema:
+        - { name: id, type: int }
+  - type: aggregate
+    name: body_group
+    input: body_feed
+    config:
+      group_by: [id]
+      strategy: hash
+      cxl: |
+        emit id = max(id)
+  - type: composition
+    name: body_call
+    input: body_group
+    use: ../compositions/source_boundary_collision.comp.yaml
+    inputs:
+      collision: body_group
+  - type: output
+    name: body_out
+    input: body_call
+    config:
+      name: body_out
+      type: csv
+      path: body-out.csv
+      include_unmapped: false
+  - type: source
+    name: collision
+    config:
+      name: collision
+      type: csv
+      path: collision-merge.csv
+      schema:
+        - { name: id, type: int }
+        - { name: origin, type: string }
+  - type: source
+    name: peer
+    config:
+      name: peer
+      type: csv
+      path: peer-merge.csv
+      schema:
+        - { name: id, type: int }
+        - { name: origin, type: string }
+  - type: merge
+    name: top_merge
+    inputs: [collision, peer]
+    config:
+      mode: interleave
+  - type: transform
+    name: top_passthrough
+    input: top_merge
+    config:
+      declares:
+        - { name: boundary, scope: record, type: string }
+      cxl: |
+        emit id = id
+        emit origin = origin
+        emit $record.boundary = $record.boundary
+  - type: output
+    name: top_out
+    input: top_passthrough
+    config:
+      name: top_out
+      type: csv
+      path: top-out.csv
+      include_unmapped: true
+"#;
+    let (plan, outputs) = run_source_collision_pipeline(
+        yaml,
+        &[
+            ("body_feed", "body-merge.csv", "id\n7\n"),
+            (
+                "collision",
+                "collision-merge.csv",
+                "id,origin\n11,collision\n",
+            ),
+            ("peer", "peer-merge.csv", "id,origin\n12,peer\n"),
+        ],
+    );
+
+    let fused = compute_merge_interleave_fused_sources(plan.dag(), plan.config());
+    assert!(fused.contains("collision"));
+    assert!(fused.contains("peer"));
+    assert_eq!(outputs["body_out"], "id,boundary\n7,body\n");
+    let top_output = &outputs["top_out"];
+    let mut top_rows: Vec<&str> = top_output.lines().skip(1).collect();
+    top_rows.sort_unstable();
+    assert_eq!(top_output.lines().next(), Some("id,origin"));
+    assert_eq!(top_rows, vec!["11,collision", "12,peer"]);
 }
 
 #[test]

--- a/crates/clinker-exec/tests/fixtures/compositions/source_boundary_collision.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/source_boundary_collision.comp.yaml
@@ -1,0 +1,26 @@
+# A body input port intentionally shares its name with a top-level Source in
+# the regression pipelines. The body Source boundary must seed the declared
+# record variable after its Aggregate input creates a fresh Record.
+_compose:
+  name: source_boundary_collision
+  inputs:
+    collision:
+      schema:
+        - { name: id, type: int }
+  outputs:
+    out: expose_boundary
+  config_schema: {}
+  scoped_vars:
+    record:
+      boundary: { type: string }
+
+nodes:
+  - type: transform
+    name: expose_boundary
+    input: collision
+    config:
+      declares:
+        - { name: boundary, scope: record, type: string }
+      cxl: |
+        emit id = id
+        emit boundary = $record.boundary


### PR DESCRIPTION
## Summary

Ensure a composition input-port Source consumes its seeded body-local buffer before any same-named top-level Source fusion shortcut. This preserves the synthetic Source boundary for schema canonicalization and scoped-variable seeding without taking or clearing the top-level fused receiver.

## Issue

Closes #1030

## Changes

- Check for a seeded Source own-slot before checking the run-global fused Source-name set.
- Keep the fused early return only when no body-local seed exists.
- Preserve the existing reservation-aware removal, canonicalization, variable seeding, admission, and registration-transfer path introduced by #1028.
- Clarify the three Source input paths and the top-level scope of fused receiver ownership.
- Add a composition fixture that observes record-variable reseeding after an Aggregate creates a fresh record.
- Cover same-name collisions against both the Source-to-Transform and all-Source Merge.interleave fusion classifiers.
- Cover the combined fused-name and parent/body node-index collision while checking that memory accounting returns to zero.

## Acceptance criteria

- [x] A top-level fused Source may share its name with a composition input port without changing body output.
- [x] The body boundary is proven through `$record.boundary` reseeding, not wider-schema passthrough.
- [x] Both fusion classifiers have explicit membership assertions and exact output checks.
- [x] The top-level fused Transform output proves its receiver remains owned and consumable.
- [x] The fused Merge output proves both Source receivers remain owned, with cross-source order treated as nondeterministic.
- [x] The #1028 continuous-reservation lifecycle remains intact across the body Source boundary.
- [x] Existing composition, fused Transform, fused Merge, and Aggregate document-boundary regressions remain green.
- [x] No record clone, source reread, dependency, native/C code, or public configuration surface was added.

## Verification

Commands run after rebasing onto current `main`:

- `cargo test -p clinker-exec --test transient_node_buffer_reservations --locked --offline -- --test-threads=1`
- `cargo test -p clinker-exec --test composition_executor_test --locked --offline -- --test-threads=1`
- `cargo test -p clinker-exec --test transform_stream_fusion --locked --offline -- --test-threads=1`
- `cargo test -p clinker-exec --test aggregate_per_document_flush --locked --offline -- --test-threads=1`
- `prlimit --nofile=4096:4096 cargo test -p clinker-exec --locked --offline -- --test-threads=1`
- `cargo clippy --workspace --all-targets --locked --offline -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

Results:

- All commands passed. The full executor run completed 913 unit tests plus all integration and doc-test targets without failures; documented heavy tests remained ignored.

Skipped checks:

- mdBook was not run because no documentation files changed.
- Cross-platform CI remains required before merge because this is a high-risk executor correctness change.

## Risk / rollback

The behavior change is limited to Source dispatch ordering. It adds one stage-level map lookup to the fused path and otherwise reuses the existing seeded-buffer lifecycle. Reverting this commit restores the previous name-first shortcut.

## Follow-up issues

- No new follow-up was introduced.

## Post-implementation check

- Acceptance criteria were checked against the runtime diff, both classifier-specific regressions, and the combined reservation regression.
- No reader ownership, fusion classifier, body scope swap, planning, YAML/CXL/CLI, dependency, memory accounting, or public API changes are present.
- No lint suppressions, ignored tests, weakened assertions, compatibility paths, or deferred TODOs were added.
