### PR TITLE
Fall back when Merge sources are shared

### DIFF
--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -801,9 +801,9 @@ pub(crate) struct ExecutorContext<'a> {
     /// is present and no seeded own slot exists — a composition body may use
     /// the same bare name for an input-port Source, and that body-local seed
     /// takes precedence without touching the top-level fused receiver. Empty
-    /// for pipelines whose Merge predecessors are not all Sources, or whose
-    /// Merge mode is concat (concat keeps today's declaration-order drain
-    /// through the Source arms).
+    /// for pipelines whose Merge predecessors are not all exclusively owned
+    /// Sources, or whose Merge mode is concat (concat keeps today's
+    /// declaration-order drain through the Source arms).
     pub(crate) fused_sources: HashSet<String>,
 
     /// Transforms whose sole upstream is a `PlanNode::Source` and that

--- a/crates/clinker-exec/src/executor/merge_dispatch.rs
+++ b/crates/clinker-exec/src/executor/merge_dispatch.rs
@@ -2,9 +2,9 @@
 //!
 //! Holds the streamwise-concatenation body lifted out of
 //! [`crate::executor::dispatch::dispatch_plan_node`]: declaration-order
-//! concat, round-robin interleave, and the fused all-Source interleave fast
-//! path that takes ownership of the parked source receivers and runs a fair
-//! `crossbeam_channel::Select` for end-to-end back-pressure. The
+//! concat, round-robin interleave, and the fused exclusively-owned all-Source
+//! interleave fast path that takes ownership of the parked source receivers
+//! and runs a fair `crossbeam_channel::Select` for end-to-end back-pressure. The
 //! dispatcher's `Merge` arm is a single delegating call into
 //! [`dispatch_merge`].
 
@@ -25,8 +25,9 @@ use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, matches_upstream
 
 /// Execute the `Merge` arm for `node_idx`: concatenate predecessor buffers
 /// in declaration order (Concat), round-robin across them (Interleave), or —
-/// when every predecessor is a Source under `mode: interleave` — drive the
-/// fused `crossbeam_channel::Select` path. Streaming concatenation; emits
+/// when every predecessor is an exclusively owned Source under
+/// `mode: interleave` — drive the fused `crossbeam_channel::Select` path.
+/// Streaming concatenation; emits
 /// every record onto the canonical merge output schema for `Arc::ptr_eq`.
 pub(crate) fn dispatch_merge(
     ctx: &mut ExecutorContext<'_>,
@@ -46,8 +47,8 @@ pub(crate) fn dispatch_merge(
     };
     // Two architectural modes for a Merge arm:
     //
-    // 1. **Fused** — every direct predecessor is a Source and
-    //    `mode: interleave`. The pre-pass at executor entry
+    // 1. **Fused** — every direct predecessor is a Source owned only by
+    //    this `mode: interleave` Merge. The pre-pass at executor entry
     //    marked each predecessor's source name in
     //    `ctx.fused_sources`, the Source dispatch arms
     //    returned cleanly without consuming, and the receivers
@@ -57,8 +58,8 @@ pub(crate) fn dispatch_merge(
     //    no longer blocks peers — back-pressure flows
     //    end-to-end.
     //
-    // 2. **Non-fused** — concat mode, or a mix of Source and
-    //    non-Source predecessors. Predecessor arms have
+    // 2. **Non-fused** — concat mode, a mix of Source and non-Source
+    //    predecessors, or any shared Source. Predecessor arms have
     //    already populated `ctx.node_buffers`; this arm
     //    consumes those buffers in declaration order (Concat)
     //    or round-robins across them (Interleave).

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1044,7 +1044,7 @@ impl PipelineExecutor {
             .collect();
 
         // Identify Merge.interleave nodes whose predecessors are all
-        // Sources. Those Source receivers move out of
+        // exclusively owned Sources. Those Source receivers move out of
         // `ctx.source_records` and into the fused Merge arm's
         // `crossbeam_channel::Select` so a slow upstream Source no longer
         // blocks peer Sources' channels from filling — back-pressure

--- a/crates/clinker-exec/tests/merge_interleave.rs
+++ b/crates/clinker-exec/tests/merge_interleave.rs
@@ -90,6 +90,65 @@ nodes:
     )
 }
 
+fn shared_source_two_interleaves_yaml() -> &'static str {
+    r#"
+pipeline:
+  name: shared_source_two_interleaves
+nodes:
+  - type: source
+    name: shared
+    config:
+      name: shared
+      type: csv
+      path: shared.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: left_only
+    config:
+      name: left_only
+      type: csv
+      path: left.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: right_only
+    config:
+      name: right_only
+      type: csv
+      path: right.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: merge
+    name: left_merge
+    inputs: [shared, left_only]
+    config:
+      mode: interleave
+  - type: merge
+    name: right_merge
+    inputs: [shared, right_only]
+    config:
+      mode: interleave
+  - type: output
+    name: left_out
+    input: left_merge
+    config:
+      name: left_out
+      type: csv
+      path: left_out.csv
+  - type: output
+    name: right_out
+    input: right_merge
+    config:
+      name: right_out
+      type: csv
+      path: right_out.csv
+"#
+}
+
 /// CSV body for `src_a`: ids 1..=count with a stable `a-N` tag.
 fn src_a_csv(count: u32) -> String {
     let mut s = String::from("id,tag\n");
@@ -174,6 +233,18 @@ fn assert_per_source_fifo(body: &[String]) {
 #[test]
 fn interleave_preserves_per_source_fifo() {
     let yaml = pipeline_yaml("mode: interleave");
+    let config = parse_config(&yaml).expect("parse exclusive interleave");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile exclusive interleave");
+    assert_eq!(
+        clinker_plan::plan::execution::compute_merge_interleave_fused_sources(plan.dag(), &config),
+        ["src_a".to_string(), "src_b".to_string()]
+            .into_iter()
+            .collect(),
+        "the exclusive control topology must retain live receiver fusion"
+    );
+
     let body = run_pipeline(&yaml, 3, 3);
     assert_eq!(body.len(), 6, "expected 6 records, got {body:?}");
     assert_per_source_fifo(&body);
@@ -507,6 +578,70 @@ fn tagged_csv(prefix: char, count: u32) -> String {
         s.push_str(&format!("{i},{prefix}-{i}\n"));
     }
     s
+}
+
+/// A Source shared by two all-Source, unseeded interleave Merges must stay
+/// materialized. Each Merge consumes its own sequential read of the shared
+/// slot, so both outputs receive the complete shared multiset plus their
+/// exclusive predecessor without rereading the source transport.
+#[test]
+fn shared_source_reaches_both_interleave_merges_completely() {
+    let yaml = shared_source_two_interleaves_yaml();
+    let config = parse_config(yaml).expect("parse shared-source interleaves");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile shared-source interleaves");
+    assert!(
+        clinker_plan::plan::execution::compute_merge_interleave_fused_sources(plan.dag(), &config)
+            .is_empty(),
+        "both interleaves must use materialized Source slots"
+    );
+
+    let readers: SourceReaders = HashMap::from([
+        (
+            "shared".to_string(),
+            SourceInput::Files(vec![slot("shared", &tagged_csv('s', 3))]),
+        ),
+        (
+            "left_only".to_string(),
+            SourceInput::Files(vec![slot("left", &tagged_csv('l', 2))]),
+        ),
+        (
+            "right_only".to_string(),
+            SourceInput::Files(vec![slot("right", &tagged_csv('r', 2))]),
+        ),
+    ]);
+    let left = SharedBuffer::new();
+    let right = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        ("left_out".to_string(), writer(&left)),
+        ("right_out".to_string(), writer(&right)),
+    ]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("shared-source interleaves execute through materialized slots");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let sorted_tags = |output: String| {
+        let mut tags: Vec<String> = output
+            .lines()
+            .skip(1)
+            .map(|row| tag_of(row).to_string())
+            .collect();
+        tags.sort();
+        tags
+    };
+    assert_eq!(
+        sorted_tags(left.as_string()),
+        ["l-1", "l-2", "s-1", "s-2", "s-3"],
+        "left Merge must receive every shared and left-only row"
+    );
+    assert_eq!(
+        sorted_tags(right.as_string()),
+        ["r-1", "r-2", "s-1", "s-2", "s-3"],
+        "right Merge must receive every shared and right-only row"
+    );
 }
 
 /// Generalized per-source FIFO check for an arbitrary set of tag

--- a/crates/clinker-plan/src/plan/execution/streaming_class.rs
+++ b/crates/clinker-plan/src/plan/execution/streaming_class.rs
@@ -10,6 +10,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use petgraph::visit::EdgeRef;
+
 use crate::config::PipelineConfig;
 use crate::plan::execution::{ExecutionPlanDag, PlanNode};
 
@@ -30,18 +32,21 @@ fn has_single_outgoing(plan: &ExecutionPlanDag, idx: petgraph::graph::NodeIndex)
 
 /// Identify Source-node names whose receivers are claimed by a
 /// downstream `Merge.mode: interleave` whose every direct predecessor
-/// is a `PlanNode::Source`. The Merge arm consumes those receivers
-/// via `crossbeam_channel::Select` so a slow Source no longer blocks
-/// peer Sources' channels from filling. Per-Source dispatch arms whose
-/// name is in this set return cleanly without touching
+/// is an exclusively-owned `PlanNode::Source`: each Source has exactly
+/// one outgoing edge, and it targets that Merge. The Merge arm consumes
+/// those receivers via `crossbeam_channel::Select` so a slow Source no
+/// longer blocks peer Sources' channels from filling. Per-Source dispatch
+/// arms whose name is in this set return cleanly without touching
 /// `ctx.source_records`.
 ///
 /// Only triggers when ALL predecessors are Sources. Mixed
-/// predecessors (Source + Transform + ...) keep today's per-arm
-/// drain path — the Merge arm reads from `node_buffers` for those.
-/// Concat-mode Merges keep the per-Source drain too: concat drains
-/// predecessors in declaration order, which the per-arm path
-/// already delivers.
+/// predecessors (Source + Transform + ...) and Merges with any shared
+/// Source keep today's per-arm drain path — the Merge arm reads from
+/// `node_buffers` for those. Eligibility is atomic per Merge: if one
+/// predecessor is shared, none of that Merge's otherwise-exclusive
+/// Source receivers are claimed. Concat-mode Merges keep the per-Source
+/// drain too: concat drains predecessors in declaration order, which the
+/// per-arm path already delivers.
 pub fn compute_merge_interleave_fused_sources(
     plan: &ExecutionPlanDag,
     config: &PipelineConfig,
@@ -90,11 +95,24 @@ pub fn compute_merge_interleave_fused_sources(
         if !matches!(mode, crate::config::MergeMode::Interleave) || seed.is_some() {
             continue;
         }
-        for pred in predecessors {
-            if let PlanNode::Source { name, .. } = &plan.graph[pred] {
-                fused.insert(name.clone());
-            }
+        let owns_sources_exclusively = predecessors.iter().all(|pred| {
+            let mut outgoing = plan
+                .graph
+                .edges_directed(*pred, petgraph::Direction::Outgoing);
+            matches!(outgoing.next(), Some(edge) if edge.target() == node_idx)
+                && outgoing.next().is_none()
+        });
+        if !owns_sources_exclusively {
+            continue;
         }
+        fused.extend(
+            predecessors
+                .iter()
+                .filter_map(|pred| match &plan.graph[*pred] {
+                    PlanNode::Source { name, .. } => Some(name.clone()),
+                    _ => None,
+                }),
+        );
     }
     fused
 }
@@ -856,6 +874,201 @@ nodes:
     type: csv
     path: out.csv
 "#;
+
+    const EXCLUSIVE_SOURCE_INTERLEAVE: &str = r#"
+pipeline:
+  name: exclusive_source_interleave
+nodes:
+- type: source
+  name: src_a
+  config:
+    name: src_a
+    type: csv
+    path: a.csv
+    schema:
+      - { name: id, type: int }
+- type: source
+  name: src_b
+  config:
+    name: src_b
+    type: csv
+    path: b.csv
+    schema:
+      - { name: id, type: int }
+- type: merge
+  name: merged
+  inputs: [src_a, src_b]
+  config:
+    mode: interleave
+- type: output
+  name: out
+  input: merged
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+
+    const SHARED_SOURCE_INTERLEAVE: &str = r#"
+pipeline:
+  name: shared_source_interleave
+nodes:
+- type: source
+  name: shared
+  config:
+    name: shared
+    type: csv
+    path: shared.csv
+    schema:
+      - { name: id, type: int }
+- type: source
+  name: exclusive
+  config:
+    name: exclusive
+    type: csv
+    path: exclusive.csv
+    schema:
+      - { name: id, type: int }
+- type: merge
+  name: merged
+  inputs: [shared, exclusive]
+  config:
+    mode: interleave
+- type: output
+  name: merged_out
+  input: merged
+  config:
+    name: merged_out
+    type: csv
+    path: merged.csv
+- type: output
+  name: sibling_out
+  input: shared
+  config:
+    name: sibling_out
+    type: csv
+    path: sibling.csv
+"#;
+
+    const TWO_INTERLEAVES_SHARING_SOURCE: &str = r#"
+pipeline:
+  name: two_interleaves_sharing_source
+nodes:
+- type: source
+  name: shared
+  config:
+    name: shared
+    type: csv
+    path: shared.csv
+    schema:
+      - { name: id, type: int }
+- type: source
+  name: left_only
+  config:
+    name: left_only
+    type: csv
+    path: left.csv
+    schema:
+      - { name: id, type: int }
+- type: source
+  name: right_only
+  config:
+    name: right_only
+    type: csv
+    path: right.csv
+    schema:
+      - { name: id, type: int }
+- type: merge
+  name: left_merge
+  inputs: [shared, left_only]
+  config:
+    mode: interleave
+- type: merge
+  name: right_merge
+  inputs: [shared, right_only]
+  config:
+    mode: interleave
+- type: output
+  name: left_out
+  input: left_merge
+  config:
+    name: left_out
+    type: csv
+    path: left.csv
+- type: output
+  name: right_out
+  input: right_merge
+  config:
+    name: right_out
+    type: csv
+    path: right.csv
+"#;
+
+    fn merge_fused_sources(yaml: &str) -> HashSet<String> {
+        let config = parse_config(yaml).expect("parse pipeline YAML");
+        let plan = config
+            .compile(&CompileContext::default())
+            .expect("compile pipeline");
+        compute_merge_interleave_fused_sources(plan.dag(), &config)
+    }
+
+    #[test]
+    fn exclusive_source_interleave_claims_every_source_receiver() {
+        assert_eq!(
+            merge_fused_sources(EXCLUSIVE_SOURCE_INTERLEAVE),
+            HashSet::from(["src_a".to_string(), "src_b".to_string()])
+        );
+    }
+
+    #[test]
+    fn shared_predecessor_rejects_merge_fusion_atomically() {
+        let fused = merge_fused_sources(SHARED_SOURCE_INTERLEAVE);
+        assert!(
+            fused.is_empty(),
+            "a shared predecessor must also leave the otherwise-exclusive predecessor unclaimed: \
+             {fused:?}"
+        );
+    }
+
+    #[test]
+    fn interleave_merges_sharing_source_claim_no_receivers() {
+        let fused = merge_fused_sources(TWO_INTERLEAVES_SHARING_SOURCE);
+        assert!(
+            fused.is_empty(),
+            "neither Merge may partially claim receiver ownership: {fused:?}"
+        );
+    }
+
+    #[test]
+    fn parallel_source_edges_reject_merge_fusion_atomically() {
+        let config = parse_config(EXCLUSIVE_SOURCE_INTERLEAVE).expect("parse pipeline YAML");
+        let compiled = config
+            .compile(&CompileContext::default())
+            .expect("compile pipeline");
+        let mut dag = compiled.dag().clone();
+        let source = find_node(
+            &dag,
+            "src_a Source",
+            |node| matches!(node, PlanNode::Source { name, .. } if name == "src_a"),
+        );
+        let merge = find_node(
+            &dag,
+            "merged Merge",
+            |node| matches!(node, PlanNode::Merge { name, .. } if name == "merged"),
+        );
+        let edge_idx = dag
+            .graph
+            .find_edge(source, merge)
+            .expect("source -> Merge edge");
+        let duplicate = dag.graph[edge_idx].clone();
+        dag.graph.add_edge(source, merge, duplicate);
+
+        let fused = compute_merge_interleave_fused_sources(&dag, &config);
+        assert!(
+            fused.is_empty(),
+            "parallel edges must also leave the other predecessor unclaimed: {fused:?}"
+        );
+    }
 
     /// Compile `yaml`, then run the exact fused-set + init-phase setup that
     /// [`classify_stream_nodes`] uses at runtime, invoking the closure with

--- a/crates/clinker-plan/src/plan/tests/explain_buffer_class.rs
+++ b/crates/clinker-plan/src/plan/tests/explain_buffer_class.rs
@@ -180,3 +180,84 @@ fn buffer_class_marks_route_materialized_and_sinks_streaming() {
     assert_eq!(buffer_class_for(block, "output.out_high"), "streaming");
     assert_eq!(buffer_class_for(block, "output.out_low"), "streaming");
 }
+
+fn shared_source_interleaves_yaml() -> &'static str {
+    r#"
+pipeline:
+  name: shared-source-interleaves
+nodes:
+  - type: source
+    name: shared
+    config:
+      name: shared
+      type: csv
+      path: shared.csv
+      schema:
+        - { name: id, type: int }
+
+  - type: source
+    name: left_only
+    config:
+      name: left_only
+      type: csv
+      path: left.csv
+      schema:
+        - { name: id, type: int }
+
+  - type: source
+    name: right_only
+    config:
+      name: right_only
+      type: csv
+      path: right.csv
+      schema:
+        - { name: id, type: int }
+
+  - type: merge
+    name: left_merge
+    inputs: [shared, left_only]
+    config:
+      mode: interleave
+
+  - type: merge
+    name: right_merge
+    inputs: [shared, right_only]
+    config:
+      mode: interleave
+
+  - type: output
+    name: left_out
+    input: left_merge
+    config:
+      name: left_out
+      type: csv
+      path: left_out.csv
+
+  - type: output
+    name: right_out
+    input: right_merge
+    config:
+      name: right_out
+      type: csv
+      path: right_out.csv
+"#
+}
+
+/// Sharing one Source makes both all-Source interleave Merges ineligible for
+/// receiver fusion. Classification is atomic per Merge, so their otherwise-
+/// exclusive Source predecessors materialize as well. Each Merge can still
+/// stream its own output to its sole Output consumer after reading the
+/// predecessor slots.
+#[test]
+fn buffer_class_marks_shared_source_interleaves_materialized_atomically() {
+    let config = parse_fixture(shared_source_interleaves_yaml());
+    let dag = compile(&config);
+    let text = dag.explain_text(&config);
+    let block = physical_properties_block(&text);
+
+    assert_eq!(buffer_class_for(block, "source.shared"), "materialized");
+    assert_eq!(buffer_class_for(block, "source.left_only"), "materialized");
+    assert_eq!(buffer_class_for(block, "source.right_only"), "materialized");
+    assert_eq!(buffer_class_for(block, "merge.left_merge"), "streaming");
+    assert_eq!(buffer_class_for(block, "merge.right_merge"), "streaming");
+}

--- a/docs/engine/src/merge-internals.md
+++ b/docs/engine/src/merge-internals.md
@@ -1,16 +1,16 @@
 # Merge & Back-pressure
 
-Merge concatenates upstream branches that share a schema into a single stream. For the engine, the interesting surface is not the YAML — it is where Merge *fuses* into the Source ingest loop, where the seeded-interleave path deliberately opts out of that fused channel topology, and how back-pressure propagates (or fails to) through the bounded `mpsc` channels behind each mode. This page covers those mechanics.
+Merge concatenates upstream branches that share a schema into a single stream. For the engine, the interesting surface is not the YAML — it is where Merge *fuses* into the Source ingest loop, where the seeded-interleave path deliberately opts out of that fused channel topology, and how back-pressure propagates (or fails to) through the bounded crossbeam channels behind each mode. This page covers those mechanics.
 
 *User-facing view: the User Guide's "Merge Nodes" page.*
 
 ## Fusion of `interleave` over Sources
 
-When every direct predecessor of an **unseeded** `interleave` Merge is a `Source` node, the executor **fuses** the Merge into the source ingest loop. The predecessor channels are polled directly and Merge consumption proceeds at live ingest rate, with no intermediate buffering tier between the Source readers and the Merge arm.
+When every direct predecessor of an **unseeded** `interleave` Merge is an exclusively owned `Source` node, the executor **fuses** the Merge into the source ingest loop. Exclusive ownership means that each Source has exactly one outgoing edge and that edge targets this Merge. The predecessor channels are polled directly and Merge consumption proceeds at live ingest rate, with no intermediate buffering tier between the Source readers and the Merge arm.
 
-This fused live-channel path is what makes end-to-end back-pressure possible across the Merge boundary (see [Back-pressure semantics](#back-pressure-semantics) below). It is also the same predicate the streaming-output path checks before it engages — see [Streaming Output Writes](output-internals.md).
+This fused live-channel path is what makes end-to-end back-pressure possible across the Source-to-Merge boundary (see [Back-pressure semantics](#back-pressure-semantics) below). The separate Merge-to-Output streaming predicate can avoid materializing the Merge's own output whether or not its inputs are fused. Only when both boundaries qualify does back-pressure extend from the writer through the Merge to the Source readers; see [Streaming Output Writes](output-internals.md).
 
-When the predecessors are not *all* Sources (e.g. `Transform → Merge`), fusion does not apply: the Merge consumes pre-buffered predecessor outputs in round-robin order, and live back-pressure across the Merge boundary itself is unavailable in that shape (though the upstream operator's own bounded buffer still throttles *its* predecessors).
+When the predecessors are not *all* Sources (e.g. `Transform → Merge`) or any predecessor Source also feeds another consumer, fusion does not apply. Eligibility is atomic: one shared Source sends every predecessor of that Merge through the materialized path rather than partially claiming the otherwise-exclusive receivers. The Merge consumes pre-buffered predecessor outputs in round-robin order, and live back-pressure across the Merge boundary itself is unavailable in that shape (though the upstream operator's own bounded buffer still throttles *its* predecessors).
 
 ## Seeded interleave
 
@@ -38,24 +38,24 @@ How a slow consumer or a slow upstream reader propagates back through the DAG de
 
 ### `concat`
 
-Each Source ingest task pushes into its own **bounded `mpsc` channel, capacity 1024 records per Source**. Peer sources produce *concurrently* up to that capacity — the dispatch arm consumes from `inputs[0]`'s channel before turning to `inputs[1]`'s.
+Each Source ingest thread pushes into its own **bounded crossbeam channel, capacity 1024 events per Source**. Peer sources produce *concurrently* up to that capacity — the dispatch arm consumes from `inputs[0]`'s channel before turning to `inputs[1]`'s.
 
 Consequences:
 
 - **Memory.** A non-leading input can hold up to one channel's worth of buffered records (1024) before its producer blocks. Multi-input `concat` over `N` Sources may carry up to `(N − 1) × 1024` records in flight even while only one input is being drained.
 - **Latency.** A record produced by `inputs[1]` while `inputs[0]` is still draining will not reach output until `inputs[0]` finishes, regardless of how fast it was produced.
-- **Producer-side back-pressure.** When a non-leading input's channel fills, its reader blocks at **`blocking_send`**, propagating pressure back to the upstream file/network reader. The upstream is throttled even though it is not the currently-consumed input.
+- **Producer-side back-pressure.** When a non-leading input's channel fills, its reader blocks at **`Sender::send`**, propagating pressure back to the upstream file/network reader. The upstream is throttled even though it is not the currently-consumed input.
 
 `concat` is the right choice when downstream consumers depend on declaration-ordered records (snapshot tests asserting byte-identical output) or when inputs represent ordered time partitions that must remain contiguous.
 
 ### `interleave` (unseeded)
 
-Fused with Source predecessors, the Merge arm **polls every predecessor's channel concurrently**. Live back-pressure flows end-to-end:
+Fused with exclusively owned Source predecessors, the Merge arm **polls every predecessor's channel concurrently**. Live back-pressure flows end-to-end:
 
 - A slow downstream operator delays Merge consumption → the predecessor channels fill → the Source reader tasks block.
 - A fast input does not wait on a slow peer — the Merge schedules whichever channel has a ready record.
 
-When predecessors are not all Sources, fusion does not apply: the Merge consumes pre-buffered predecessor outputs in round-robin order, and live back-pressure across the Merge boundary itself is unavailable, though each upstream operator's own bounded buffer still throttles its predecessors.
+When predecessors are not all Sources or any Source has another outgoing edge, fusion does not apply: the Merge consumes pre-buffered predecessor outputs in round-robin order, and live back-pressure across the Merge boundary itself is unavailable, though each upstream operator's own bounded buffer still throttles its predecessors.
 
 Unseeded `interleave` is the right choice when end-to-end latency matters and the downstream consumer is order-insensitive (an aggregator grouping on a key, or a writer that does not assert on row sequencing).
 

--- a/docs/engine/src/output-internals.md
+++ b/docs/engine/src/output-internals.md
@@ -1,14 +1,16 @@
 # Streaming Output Writes
 
-Output nodes are the terminal sinks of a pipeline. For most topologies the Output arm runs *buffered*: the upstream stage accumulates every record before the writer fires. But when a single Output sits directly downstream of a fused `Merge.interleave` of Sources, the executor takes a **streaming path** that wires the Merge arm to the writer task through a bounded `tokio::sync::mpsc` channel and fires `Writer::write_record` per record, concurrent with Merge production. This page covers the topology that selects that path, the exact eligibility predicate, the end-to-end back-pressure chain, the counter semantics that must match the buffered arm, and the writer contract that rejects `Value::Map` payloads.
+Output nodes are the terminal sinks of a pipeline. When the planner certifies a single linear producer feeding one Output, the executor can take a **streaming handoff** that wires the producer arm to a dedicated writer thread through a bounded crossbeam channel and fires `Writer::write_record` per record, concurrent with producer emission. Other producer shapes materialize their output before the writer fires. This page covers the topology that selects the streaming handoff, its relationship to Source-to-Merge fusion, the back-pressure chain, the counter semantics that must match the buffered arm, and the writer contract that rejects `Value::Map` payloads.
 
 *User-facing view: the User Guide's "Output Nodes" page.*
 
 ## Streaming vs. buffered
 
-When a single Output sits directly downstream of a `Merge` whose mode is `interleave` and whose every direct predecessor is a `Source`, the executor takes the streaming path: a bounded `tokio::sync::mpsc::channel` connects the Merge arm to the writer task, and `Writer::write_record` fires **per record** as Merge emits, concurrent with Merge production.
+When a single Output sits directly downstream of an eligible linear producer, a bounded crossbeam channel connects the producer arm to the writer thread, and `Writer::write_record` fires **per record** as the producer emits. For a `Merge.interleave` whose direct predecessors are exclusively owned Sources, this combines with Source-to-Merge receiver fusion to form an end-to-end live path. Each Source must have exactly one outgoing edge, targeting that Merge; sharing any predecessor rejects receiver fusion for the whole Merge.
 
-The buffered alternative — which still runs for every other Output topology — waits until the Merge arm has accumulated *every* record before invoking the writer. With a slow upstream Source that defeats the live back-pressure the `Merge.interleave` fusion provides at the Source-channel layer: each record sits in `node_buffers[merge]` until the slow Source finishes. The streaming path exists precisely to preserve that fused back-pressure all the way to the sink.
+A shared Source does not necessarily materialize the Merge's *output*. After the Source inputs materialize and the non-fused Merge reads those slots, an otherwise-eligible Merge with one downstream Output can still hand its result to the writer without admitting a `node_buffers[merge]` slot. Explain therefore reports the shared Sources as `materialized` while the Merge may remain `streaming`; that label does not claim live back-pressure across the Source-to-Merge boundary.
+
+When the producer-to-Output edge is not certified for streaming, the producer's output materializes before the Output arm invokes the writer. With a fused `Merge.interleave`, that extra slot would break the live back-pressure chain at the Merge output. The streaming handoff avoids that slot. For a non-fused Merge, it still avoids materializing the Merge's own output, but the already-materialized Merge inputs mean back-pressure cannot extend through to the Source readers.
 
 The streaming path is selected **automatically** — there is no opt-in setting. Pipelines that don't match the topology keep the buffered path.
 
@@ -37,28 +39,30 @@ The streaming path is selected **automatically** — there is no opt-in setting.
 
 ### Eligibility
 
-Every condition must hold for the streaming path to engage; if any fails, the buffered path runs:
+Every condition must hold for the producer-to-Output streaming handoff to engage. Source exclusivity is a separate condition for the Source-to-Merge boundary: if it fails, the Merge inputs materialize even though an eligible Merge-to-Output handoff may still stream.
 
-- The Output has exactly **one incoming edge**, and that predecessor is a `Merge` with `mode: interleave`.
-- **Every direct predecessor of that Merge is a `Source`** — the same predicate the fused `Merge.interleave` arm uses for its live `tokio::select!` (see [Merge & Back-pressure](merge-internals.md)).
-- The Merge has **no other downstream consumer** besides this one Output (no fan-out).
+- The Output has exactly **one incoming edge**.
+- Its producer is a supported linear producer: a Merge, fused Source-to-Transform, single-branch Route, streaming Aggregate, or an eligible streaming-output Combine strategy.
+- The producer has **no other downstream consumer** besides this Output, roots no node-anchored window arena, and satisfies its producer-specific streaming requirements.
 - The Output is **not in the init-phase ancestor closure**.
 - The `OutputConfig` has **no `split:` block** — splitting writers manage their own file rotation lifecycle.
 - The writer is registered in the **single-file writer registry** (not `fan_out_per_source_file`).
-- **No `Source` in the pipeline declares a correlation key** — the correlation-buffered output path defers writes to `CorrelationCommit` and is incompatible with per-record write.
+- **No `Source` in the pipeline declares a correlation key or document-level DLQ**, and no Output reconstructs envelopes. Those paths own deferred or document-scoped writer lifecycles that are incompatible with the per-record writer thread.
+
+For a Merge to receive directly from live Source channels as well, it must be an unseeded `interleave` and **every direct predecessor must be a Source exclusively owned by that Merge**. Eligibility is atomic, so one shared predecessor rejects receiver fusion for all of that Merge's Sources (see [Merge & Back-pressure](merge-internals.md)).
 
 ### Back-pressure flow
 
-Under the streaming path, back-pressure flows end-to-end:
+Across a certified producer-to-Output handoff, back-pressure flows toward the producer. When the upstream boundaries are also streaming or fused, the chain continues to the Source reader:
 
 ```
-writer slow → mpsc::Sender::send().await yields
-             → Merge arm yields
-             → Source mpsc::Receiver fills
-             → Source ingest task blocks on send
+writer slow → bounded crossbeam Sender::send blocks
+             → producer arm blocks
+             → Source channel fills (when the upstream boundary is fused)
+             → Source ingest thread blocks on send
 ```
 
-The bounded handoff channel between Merge and Output (**256 slots**) and the existing per-Source ingest channels form a single pace-bound chain from the underlying `Write` sink back to the source reader. A slow file system, a saturated network sink, or a deliberately-paced writer no longer accumulates records in pipeline-internal `Vec`s; the upstream readers slow down to match.
+The bounded handoff channel between the producer and Output (**256 events**) limits that edge's in-flight data. With a fused Source-to-Merge boundary, it joins the existing bounded Source channels into a single pace-bound chain from the underlying `Write` sink back to the source reader. A slow file system, a saturated network sink, or a deliberately paced writer then slows the upstream readers rather than accumulating the producer's whole output in a pipeline-internal `Vec`. When an earlier boundary is materialized, back-pressure stops at that boundary.
 
 ### Counter semantics
 


### PR DESCRIPTION
## Summary

- certify `Merge.interleave` Source receiver ownership only when every predecessor has exactly one outgoing edge to that Merge
- reject fusion atomically when any predecessor is shared or has a duplicate outgoing edge
- keep explain classification and runtime ownership on the same planner-derived decision
- document the separate Source-to-Merge fusion and producer-to-Output streaming boundaries

Closes #1031

## Acceptance evidence

- An exclusive all-Source, unseeded interleave still claims every Source receiver.
- A Merge with one shared predecessor claims none of its otherwise-exclusive predecessors.
- Two interleave Merges sharing a Source claim no Source receivers.
- The runtime regression delivers the exact shared and branch-specific row multisets to both outputs through materialized slots.
- The exclusive runtime control retains live fusion, while the shared explain regression reports materialized Source inputs and a separately streaming Merge output.
- Existing executor back-pressure and document-boundary coverage remains green.

## Verification

- `cargo test -p clinker-plan --locked --offline`
- `cargo test -p clinker-exec --locked --offline -- --test-threads=1` with the file-descriptor soft limit raised
- `cargo check --benches --workspace --locked --offline`
- `cargo clippy --workspace --locked --offline -- -D warnings`
- `cargo clippy --workspace --all-targets --locked --offline -- -D warnings`
- `cargo fmt --all --check`
- `mdbook build docs/engine`
- `git diff --check origin/main`

All commands passed. No CLI or scenario-specific gate was needed because the change does not cross the CLI boundary or alter pipeline syntax.

## Surface and scope

- No public YAML, CXL, or CLI change.
- No dependency, native build, C implementation, or BLAKE3 change.
- No source reread, tee, unbounded buffer, or asynchronous runtime behavior.
- The post-implementation scan found no lint suppression, ignored test, manifest change, generated footer, or unrelated refactor.

## Risk and rollback

Shared Source inputs now take the existing materialized fallback. Multi-consumer node buffers remain non-spillable until #302, so the fallback preserves correctness but does not yet improve that topology's memory ceiling. Rollback is a straight revert of this commit; no data or configuration migration is involved.
