### PR TITLE
Scope the dependency approval gate to the capability, not the manifest diff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,17 @@ Anything a pipeline author writes by hand — a YAML key, a CXL construct, a CLI
 
 ## Dependencies And Approval
 
+Approval is gated on the capability, not on the manifest diff. It covers development, test, benchmark, CI, and release tooling as well as the shipped runtime: being "only tooling" changes which manifest an edge belongs in and how it is verified, never whether approval is needed.
+
 - Do not add dependencies, native toolchain requirements, async runtimes, C build steps, OpenSSL/native-tls, or cargo-deny exceptions without approval.
 - Keep benchmark/test helpers out of default runtime paths.
 - If a command needs network, writes outside the workspace, or needs elevated permissions, ask for approval through the tool flow and explain why.
+- When a task needs a capability an established crate already provides, raise it for approval. Review covers architectural fit and the crate's maintenance status, so asking is the cheap path; work done to avoid the conversation is not a saving.
+- Do not substitute any of these to keep the manifest unchanged: hand-rolling the capability (parsers, lexers, tokenizers, serializers, encoders, date/time arithmetic, cryptography); implementing it outside Rust; vendoring or copying third-party source into the tree; or shelling out to an undeclared external binary.
+- Hand-rolling what a vetted crate provides is a dependency decision taken without review. Raise it rather than growing it, and treat an implementation that needs repeated adversarial repair as evidence the decision was wrong rather than as a reason to keep patching.
+- Adding a non-Rust language to the build, test, or release path is an approval-gated architectural decision in its own right. Committed tooling is Rust; the only committed non-Rust sources are the vendored mdBook theme assets under `docs/theme/`.
+- Not asking is not approval. The absence of a request is not evidence that a dependency was considered and rejected.
+- If approval is refused or deferred, reduce scope or record the gap in [docs/ai/80_OPEN_QUESTIONS.md](docs/ai/80_OPEN_QUESTIONS.md); do not ship a hand-rolled substitute instead.
 
 ## Documentation Rules
 

--- a/docs/ai/30_DESIGN_RULES.md
+++ b/docs/ai/30_DESIGN_RULES.md
@@ -177,6 +177,20 @@ adding, renaming, or narrowing anything a pipeline author writes by hand.
 - Network transport currently uses blocking `ureq` over rustls. Adding async
   clients or a Tokio-driven runtime would be an architecture change, not a
   local connector tweak.
+- The dependency gate is scoped to the capability, not to the manifest diff, and
+  it covers development, test, benchmark, and release tooling as well as runtime
+  crates. Hand-rolling a capability an established crate provides — a parser,
+  lexer, serializer, or encoder — is a dependency decision taken without review,
+  as is implementing it in another language, vendoring third-party source, or
+  calling an undeclared external binary. `AGENTS.md` carries the normative rule.
+- Adding a non-Rust language to the build, test, or release path is an
+  architectural decision requiring approval. The committed tree is Rust plus
+  documentation assets: `git ls-files` matches no `.py`, `.sh`, or `.rb`
+  sources, and the only committed JavaScript is the vendored mdBook theme under
+  `docs/theme/`.
+- Repeated adversarial repair of a hand-written substitute is evidence that the
+  dependency decision was wrong, not a reason to keep patching. Reopen the
+  approval question instead of growing the substitute.
 
 ## Documentation Rules
 


### PR DESCRIPTION
## Summary

The dependency-approval rule named its trigger as "adding a dependency". In practice that made the *manifest diff* the thing under review, not the decision. A capability that an established crate already provides could instead be hand-written, implemented in another language, vendored, or shelled out to — and because no manifest changed, approval was never requested. Not because the trade-off was weighed and rejected, but because the gate never fired.

That is the wrong incentive: avoiding the approval conversation looks free at the moment of the decision and expensive only much later.

This change scopes the gate to the **capability** rather than the manifest diff.

## What changed

`AGENTS.md` — normative rule:

- The gate covers development, test, benchmark, CI, and release tooling as well as the shipped runtime. Being "only tooling" changes which manifest an edge belongs in and how it is verified, never whether approval is needed.
- Enumerates the substitutions that do **not** exempt a change: hand-rolling the capability (parsers, lexers, tokenizers, serializers, encoders, date/time arithmetic, cryptography), implementing it outside Rust, vendoring third-party source, or shelling out to an undeclared external binary.
- Adding a non-Rust language to the build, test, or release path is an approval-gated architectural decision in its own right.
- "Not asking is not approval" — the absence of a request is not evidence that a dependency was considered and rejected.
- Repeated adversarial repair of a hand-written substitute is evidence the original decision was wrong, not a reason to keep patching it.
- If approval is refused or deferred, the outcome is reduced scope or a recorded gap in `docs/ai/80_OPEN_QUESTIONS.md`, not a hand-rolled substitute.

`docs/ai/30_DESIGN_RULES.md` — evidence-anchored expansion under Dependency Rules, pointing at `AGENTS.md` for the normative text.

## Why now

A release-boundary checker was recently built as a ~2,900-line hand-written source scanner in a non-Rust language, specifically because that approach left every manifest untouched and so never triggered review. It went through four rounds of adversarial repair, ended each round with a passing test suite, and still accepted valid programs it could not analyse correctly — including constructs present in the very code it was meant to gate. A well-maintained parser crate was available the whole time and was never proposed, because proposing it was the only option that required asking.

The rule now names that path explicitly so the trade-off is made in the open.

## Verification

- `git diff --check` — clean.
- Documentation-only change; no Rust source, manifests, or lockfile touched.
- `docs/ai/` is not part of either mdBook (`docs/user`, `docs/engine`), so no book build is affected.
- Factual claims in the new text verified against this base: `git ls-files` matches no `.py`, `.sh`, or `.rb` sources, and the only committed JavaScript is the vendored mdBook theme under `docs/theme/`.
