### PR TITLE
test: fail when a scenario directory is absent from the registry

### DIFF
--- a/crates/clinker/tests/scenarios.rs
+++ b/crates/clinker/tests/scenarios.rs
@@ -601,6 +601,41 @@ fn every_registered_scenario_has_a_gate() {
 }
 
 #[test]
+fn every_scenario_directory_is_registered() {
+    // The one direction the pair above cannot see. Between them they close the
+    // loop between the two *lists*, proving REGISTRY and GATES name exactly the
+    // same scenarios — but both start from a list, and neither looks at the
+    // corpus on disk. A directory holding a pipeline, a README and committed
+    // goldens that no list names is invisible to all of it: `gen` never
+    // materialises its input, no gate ever runs it, and the suite stays fully
+    // green while the golden inside states a correct answer nothing checks.
+    //
+    // The shape arises whenever a scenario exists on one branch and not
+    // another: the files linger untracked in a shared checkout, one `git add`
+    // away from being committed into a tree that does not register them.
+    let corpus = repo_root().join("examples/scenarios");
+    let mut unregistered: Vec<String> = std::fs::read_dir(&corpus)
+        .unwrap_or_else(|e| panic!("read {}: {e}", corpus.display()))
+        .map(|entry| entry.expect("scenario corpus entry"))
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| !REGISTRY.iter().any(|scenario| scenario.id == *name))
+        .collect();
+    // `read_dir` order is arbitrary; sort so the message is reproducible.
+    unregistered.sort();
+
+    assert!(
+        unregistered.is_empty(),
+        "examples/scenarios/ holds directories absent from the generator \
+         registry: {}. An unregistered directory is never generated and never \
+         executed, so any committed golden inside it asserts nothing. Either \
+         add a `Scenario` entry to `clinker_scenarios::REGISTRY` — the sibling \
+         guard will then require its `Gate` — or delete the directory.",
+        unregistered.join(", "),
+    );
+}
+
+#[test]
 fn blanking_leaves_later_columns_untouched() {
     // The DLQ's trailing columns embed the original record and may contain
     // quoted commas; blanking must not disturb them.


### PR DESCRIPTION
## Problem

The scenario harness has two guards that check `REGISTRY` against `GATES` in both directions. Together they prove the two lists name exactly the same scenarios — but both start from a *list*, and neither consults the corpus on disk.

That leaves one direction uncovered. A directory under `examples/scenarios/` holding a `pipeline.yaml`, a `README.md` and committed goldens that neither list names is invisible to the entire harness:

- `clinker-scenarios -- gen` never materialises its input, because generation iterates `REGISTRY`
- no gate ever executes it
- the suite stays fully green while the golden inside states a correct answer that nothing checks

A committed golden that asserts nothing is worse than no golden, because the directory looks like coverage under review.

The shape is not hypothetical. It arises whenever a scenario exists on one branch and not another: the files linger untracked in a shared checkout, one `git add` away from being committed into a tree that does not register them.

## Change

Adds `every_scenario_directory_is_registered`, which walks `examples/scenarios/` and requires a `REGISTRY` entry for every directory it finds. Results are sorted so the message is reproducible regardless of `read_dir` order.

The failure names the offending directory and both corrective actions:

```
examples/scenarios/ holds directories absent from the generator registry:
07-multi-record-csv. An unregistered directory is never generated and never
executed, so any committed golden inside it asserts nothing. Either add a
`Scenario` entry to `clinker_scenarios::REGISTRY` — the sibling guard will
then require its `Gate` — or delete the directory.
```

The two gitignored subdirectories (`*/data/`, `*/output/`) live *inside* each scenario directory rather than beside them, so top-level enumeration only ever sees scenario directories.

## Validation

Verified in all three states rather than only the passing one:

| State | Result |
|---|---|
| Clean corpus | new guard passes; full suite 6/6 |
| Unregistered directory planted | new guard fails with the message above |
| Same, existing guards | `every_registered_scenario_has_a_gate` still **passes** |

That third row is the justification for the test: the planted defect is invisible to the guards already present, and caught only by this one. With the defect planted the full suite reports 5 passed / 1 failed, the single failure being this guard — `every_scenario_matches_its_golden` still passes, so all three scenarios continue to execute end to end and match their goldens.

`cargo fmt` and `git diff --check` are clean.

## Scope

Purely additive — one test function, no production code, no change to any existing test or golden. It asserts a structural invariant of the corpus rather than any engine behaviour, so it holds independently of in-flight execution and ordering work.