### PR TITLE
Read a declared source order together with the scope it was proven over

### DIFF
--- a/crates/clinker-exec/tests/combine_per_document_flush.rs
+++ b/crates/clinker-exec/tests/combine_per_document_flush.rs
@@ -17,6 +17,12 @@
 //! streaming-probe tests are the load-bearing ones — they exercise the
 //! forwarded-boundary path that previously dropped punctuations; the
 //! materialized-strategy tests are regression guards proving no break.
+//!
+//! The sort-merge guard is the one exception to the multi-document driver
+//! shape: SortMerge requires an unpartitioned — hence single-file — input,
+//! and a source that may declare `sort_order` at all contributes at most one
+//! record-bearing document per file, so its case is single-document by
+//! construction. See the comment on that test.
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -511,11 +517,12 @@ fn grace_hash_combine_preserves_document_boundaries() {
     );
 }
 
-/// Single-range join with `sort_order` on both inputs' range key, forcing
-/// SortMerge over IEJoin.
-const SORT_MERGE_RANGE_YAML: &str = r#"
+/// Single-range join whose driver is a multi-file glob declaring
+/// `sort_order` on the range key, and whose lookup is a single sorted file.
+/// The declaration is per-file, so it does not license SortMerge.
+const FILE_PARTITIONED_SORTED_RANGE_YAML: &str = r#"
 pipeline:
-  name: sort_merge_combine_per_doc
+  name: file_partitioned_sorted_range_combine_per_doc
 nodes:
   - type: source
     name: driver
@@ -574,18 +581,31 @@ nodes:
 "#;
 
 #[test]
-fn sort_merge_combine_preserves_document_boundaries() {
-    assert_combine_strategy(SORT_MERGE_RANGE_YAML, "sort_merge");
+fn file_partitioned_sort_order_does_not_license_sort_merge() {
+    // A sort proof is exactly as wide as the stream it was proven over. A
+    // Source matching several files verifies its `sort_order` inside each
+    // file, so the promise is "each file ascends", never "the concatenation
+    // ascends" — the fixture below is two individually ascending files whose
+    // ranges descend across the match, which satisfies the declaration and
+    // violates the joint order. SortMerge's kernel is handed
+    // `presorted: true` and walks two cursors forward in place, so a stream
+    // that only ascends within each file breaks the promise it was handed.
+    // The kernel re-checks that certification before emitting and ends the
+    // run naming the planner, so the cost of accepting the declaration here
+    // is a valid pipeline that cannot run rather than a wrong answer. The
+    // declaration is not sufficient on a partitioned input, and the join
+    // routes to IEJoin, which sorts what it reads.
+    assert_combine_strategy(FILE_PARTITIONED_SORTED_RANGE_YAML, "iejoin");
 
-    // Each file is pre-sorted on v (ascending). The lookup cap=100 matches
-    // every driver record. The materialized SortMerge arm forwards reconciled
-    // boundaries → per-document flush.
+    // a.csv holds the HIGH range and b.csv the LOW one, each ascending. The
+    // lookup cap=100 matches every driver record, so a correct join emits all
+    // six rows and the per-document flush splits them by driver document.
     let (body, dlq) = run_combine(
-        SORT_MERGE_RANGE_YAML,
+        FILE_PARTITIONED_SORTED_RANGE_YAML,
         "driver",
         &[
-            ("a.csv", "category,v\nx,1\nx,2\ny,3\n"),
-            ("b.csv", "category,v\nx,4\nx,5\nx,6\n"),
+            ("a.csv", "category,v\nx,4\nx,5\ny,6\n"),
+            ("b.csv", "category,v\nx,1\nx,2\nx,3\n"),
         ],
         "lookup",
         ("lookup.csv", "cap,label\n100,hi\n"),
@@ -594,8 +614,105 @@ fn sort_merge_combine_preserves_document_boundaries() {
     assert_eq!(
         body,
         vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
-        "a SortMerge Combine must preserve document boundaries → per-document \
-         flush (x=2,y=1; x=3)"
+        "a per-file `sort_order` must route to IEJoin and still preserve \
+         document boundaries → per-document flush (x=2,y=1; x=3)"
+    );
+}
+
+/// Single-range join whose two inputs are each a literal `path:` — the only
+/// source shape that is unpartitioned, so its `sort_order` orders the whole
+/// edge and SortMerge's two-cursor scan applies.
+const SORT_MERGE_RANGE_YAML: &str = r#"
+pipeline:
+  name: sort_merge_combine_per_doc
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      path: ./driver.csv
+      sort_order:
+        - field: v
+      schema:
+        - { name: category, type: string }
+        - { name: v, type: int }
+  - type: source
+    name: lookup
+    config:
+      name: lookup
+      type: csv
+      path: ./lookup.csv
+      sort_order:
+        - field: cap
+      schema:
+        - { name: cap, type: int }
+        - { name: label, type: string }
+  - type: combine
+    name: j
+    input:
+      driver: driver
+      lookup: lookup
+    config:
+      where: "driver.v < lookup.cap"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit category = driver.category
+        emit v = driver.v
+  - type: aggregate
+    name: by_category
+    input: j
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn sort_merge_combine_preserves_document_boundaries() {
+    assert_combine_strategy(SORT_MERGE_RANGE_YAML, "sort_merge");
+
+    // SortMerge is reachable only from unpartitioned inputs, and an
+    // unpartitioned input is one physical file, so this case carries one
+    // driver document rather than several. That is a real limit of the
+    // configuration space, not of the fixture: a source may declare
+    // `sort_order` only when its format's `SortableEventShape` is `Flat` or
+    // `SingleFramePerPhysicalFile` — both of which contribute at most one
+    // record-bearing document per file — and the formats that do emit
+    // sibling document frames inside one file are refused the declaration
+    // outright. So "orders one whole sequence" and "carries several
+    // documents in one file" cannot hold together, and the multi-document
+    // SortMerge flush has no expressible pipeline to test.
+    //
+    // What this case still proves: the SortMerge arm's boundary
+    // reconciliation forwards a single driver document's close intact, so
+    // its one group set flushes exactly once and is neither dropped nor
+    // doubled.
+    let (body, dlq) = run_combine(
+        SORT_MERGE_RANGE_YAML,
+        "driver",
+        &[("driver.csv", "category,v\nx,1\nx,2\nx,3\ny,4\n")],
+        "lookup",
+        ("lookup.csv", "cap,label\n100,hi\n"),
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["x,3".to_string(), "y,1".to_string()],
+        "a SortMerge Combine must forward its driver document's close so the \
+         per-document Aggregate flushes it exactly once (x=3, y=1)"
     );
 }
 

--- a/crates/clinker-exec/tests/ordering_contract.rs
+++ b/crates/clinker-exec/tests/ordering_contract.rs
@@ -1432,6 +1432,24 @@ fn a_descending_order_does_not_license_the_sort_merge_scan() {
         "IEJoin",
         "a descending range axis cannot license a forward two-cursor walk"
     );
+
+    // The input is one ordered sequence, so its scope reads global — and it
+    // still did not get the scan. Without the direction on the page, that
+    // pairing is unreadable: an author sees a globally ordered input next to
+    // the strategy for inputs that are not.
+    let explained = explain_of(&descending);
+    let drivers = explain_block(&explained, "source.drivers:");
+    assert!(
+        drivers.contains("ordering: val desc")
+            && drivers.contains("ordering_scope: global (one ordered sequence across the input)"),
+        "a descending single-file source is globally ordered AND descending; \
+         explain must say both:\n{drivers}"
+    );
+    let combine = explain_block(&explained, "Combine 'banded':");
+    assert!(
+        combine.contains("order val desc — global (one ordered sequence across the input))"),
+        "the Combine input line must show the direction that disqualified it:\n{combine}"
+    );
 }
 
 /// The other half of the same rule: an input that really is one ordered
@@ -1799,11 +1817,14 @@ fn explain_names_the_scope_an_order_was_proven_over() {
 
     let combine = explain_block(&per_file, "Combine 'banded':");
     assert!(
-        combine.contains(", order per partition on $source.file (not one ordered sequence))"),
-        "the Combine input line must carry the scope that decided its strategy:\n{combine}"
+        combine.contains(
+            ", order val asc — per partition on $source.file (not one ordered sequence))"
+        ),
+        "the Combine input line must carry both facts eligibility reads — what the \
+         order is and how wide it was proven:\n{combine}"
     );
     assert!(
-        combine.contains(", order global (one ordered sequence across the input))"),
+        combine.contains(", order threshold asc — global (one ordered sequence across the input))"),
         "and must distinguish the input whose order is global:\n{combine}"
     );
 

--- a/crates/clinker-exec/tests/ordering_contract.rs
+++ b/crates/clinker-exec/tests/ordering_contract.rs
@@ -2,7 +2,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use std::io::{Cursor, Write};
+use std::io::{Cursor, Read, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -1301,6 +1301,530 @@ nodes:
     assert_eq!(requirement.scope, OrderScope::PerPhysicalFile);
     assert_eq!(requirement.fields, source_order.fields);
     assert_eq!(requirement.verified_sources, vec![source_order.source_id]);
+}
+
+/// A single-inequality range join whose two sides each declare a sort on
+/// the range axis, with each side's file matcher chosen by the caller.
+///
+/// `path:` resolves to one file and carries a global order; `paths:`
+/// resolves to several and orders each of them independently.
+fn range_join_over(driver_matcher: &str, build_matcher: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: range_scope
+nodes:
+  - type: source
+    name: drivers
+    config:
+      name: drivers
+      type: csv
+      {driver_matcher}
+      sort_order:
+        - field: val
+      schema:
+        - {{ name: did, type: int }}
+        - {{ name: val, type: int }}
+  - type: source
+    name: builds
+    config:
+      name: builds
+      type: csv
+      {build_matcher}
+      sort_order:
+        - field: threshold
+      schema:
+        - {{ name: tid, type: int }}
+        - {{ name: threshold, type: int }}
+  - type: combine
+    name: banded
+    input:
+      drivers: drivers
+      builds: builds
+    config:
+      where: "drivers.val < builds.threshold"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit did = drivers.did
+        emit tid = builds.tid
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: banded
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+/// The strategy the planner picked for the single combine in `yaml`,
+/// as its `Debug` discriminant — `CombineStrategy` carries no `PartialEq`,
+/// so the sibling routing tests compare it this way too.
+fn combine_strategy_of(yaml: &str) -> String {
+    compile(yaml)
+        .dag()
+        .graph
+        .node_weights()
+        .find_map(|node| match node {
+            PlanNode::Combine { strategy, .. } => Some(format!("{strategy:?}")),
+            _ => None,
+        })
+        .expect("fixture contains one combine")
+}
+
+/// A sort-merge scan walks each input as one sequence, so a sort proven
+/// only inside each file cannot license it. Two files that each ascend
+/// may still descend across the boundary between them — `100,101,102`
+/// followed by `1,2,3` satisfies every per-file check and is not one
+/// ordered run. Reading the declaration without its scope took the
+/// in-place fast path over exactly that input.
+#[test]
+fn a_per_file_order_does_not_license_the_sort_merge_scan() {
+    for (case, driver, build) in [
+        (
+            "driver side matches several files",
+            "paths: [drivers-a.csv, drivers-b.csv]",
+            "path: builds.csv",
+        ),
+        (
+            "build side matches several files",
+            "path: drivers.csv",
+            "paths: [builds-a.csv, builds-b.csv]",
+        ),
+        (
+            "both sides match several files",
+            "paths: [drivers-a.csv, drivers-b.csv]",
+            "paths: [builds-a.csv, builds-b.csv]",
+        ),
+        (
+            "a glob resolves at runtime and is per-file for the same reason",
+            "glob: ./drivers-*.csv",
+            "path: builds.csv",
+        ),
+    ] {
+        assert_eq!(
+            combine_strategy_of(&range_join_over(driver, build)),
+            "IEJoin",
+            "{case}: a per-file order must not satisfy a scan that reads one sequence"
+        );
+    }
+}
+
+/// The scan is handed `presorted: true` and walks both cursors forward,
+/// so what licenses it is an ascending order — not merely a sorted one.
+/// A descending declaration on the range axis is the same broken promise
+/// as an unsorted input: the kernel checks the certification it was given
+/// and ends the run naming the planner. Such a join is still perfectly
+/// valid, so it belongs to the strategy that sorts for itself.
+#[test]
+fn a_descending_order_does_not_license_the_sort_merge_scan() {
+    let descending = runnable_range_join(
+        "path: drivers.csv",
+        "{ field: val, order: desc, null_order: last }",
+        "path: builds.csv",
+        "{ field: threshold, order: asc, null_order: last }",
+    );
+    assert_eq!(
+        combine_strategy_of(&descending),
+        "IEJoin",
+        "a descending range axis cannot license a forward two-cursor walk"
+    );
+}
+
+/// The other half of the same rule: an input that really is one ordered
+/// sequence still takes the fast path. A fix that refused every declared
+/// order would pass the test above and cost every correct pipeline its
+/// strategy.
+#[test]
+fn a_global_order_still_licenses_the_sort_merge_scan() {
+    assert_eq!(
+        combine_strategy_of(&range_join_over("path: drivers.csv", "path: builds.csv")),
+        "SortMerge",
+        "one file per side is one ordered sequence per side"
+    );
+}
+
+/// One record of a range-join fixture: its id and its range-axis key.
+/// `None` writes an empty cell, which reads back as NULL and — under CXL
+/// ternary comparison — matches nothing.
+type RangeRow = (i64, Option<i64>);
+
+fn range_csv(key_column: &str, rows: &[RangeRow]) -> Vec<u8> {
+    let mut out = format!("id,{key_column}\n");
+    for (id, key) in rows {
+        match key {
+            Some(key) => out.push_str(&format!("{id},{key}\n")),
+            None => out.push_str(&format!("{id},\n")),
+        }
+    }
+    out.into_bytes()
+}
+
+/// A runnable `drivers.val < builds.threshold` join, with each side's file
+/// matcher and declared sort supplied by the caller.
+///
+/// `match: all` so every satisfying pair reaches the output: the failure
+/// this fixture exists to catch is a scan that stops finding matches, and
+/// `first` would hide a lost pair behind a surviving one.
+///
+/// Both range keys are declared `{ nullable: int }` so a fixture may place a
+/// NULL on the axis; that makes the comparison itself nullable, which is why
+/// the `where:` carries the `?? false` an author has to write.
+fn runnable_range_join(
+    driver_matcher: &str,
+    driver_sort: &str,
+    build_matcher: &str,
+    build_sort: &str,
+) -> String {
+    format!(
+        r#"
+pipeline:
+  name: range_scope_runtime
+nodes:
+  - type: source
+    name: drivers
+    config:
+      name: drivers
+      type: csv
+      {driver_matcher}
+      sort_order:
+        - {driver_sort}
+      schema:
+        - {{ name: id, type: int }}
+        - {{ name: val, type: {{ nullable: int }} }}
+  - type: source
+    name: builds
+    config:
+      name: builds
+      type: csv
+      {build_matcher}
+      sort_order:
+        - {build_sort}
+      schema:
+        - {{ name: id, type: int }}
+        - {{ name: threshold, type: {{ nullable: int }} }}
+  - type: combine
+    name: banded
+    input:
+      drivers: drivers
+      builds: builds
+    config:
+      where: "(drivers.val < builds.threshold) ?? false"
+      match: all
+      on_miss: skip
+      cxl: |
+        emit did = drivers.id
+        emit tid = builds.id
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: banded
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+/// Run the fixture and return its emitted `did,tid` pairs, sorted.
+///
+/// Sorted because the assertion is about which pairs the join found, not
+/// the sequence it emitted them in: the emit order is a function of the
+/// arrival order, which differs between the strategies under comparison.
+fn run_range_join(
+    yaml: &str,
+    driver_files: &[(&str, &[RangeRow])],
+    build_files: &[(&str, &[RangeRow])],
+) -> Vec<String> {
+    let plan = compile(yaml);
+    let slots = |files: &[(&str, &[RangeRow])], key_column: &str| {
+        SourceInput::Files(
+            files
+                .iter()
+                .map(|(path, rows)| {
+                    FileSlot::new(
+                        PathBuf::from(path),
+                        Box::new(Cursor::new(range_csv(key_column, rows))) as Box<dyn Read + Send>,
+                    )
+                })
+                .collect(),
+        )
+    };
+    let readers: SourceReaders = HashMap::from([
+        ("drivers".to_string(), slots(driver_files, "val")),
+        ("builds".to_string(), slots(build_files, "threshold")),
+    ]);
+    let out = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(out.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams::default(),
+    )
+    .expect("range-join fixture must run");
+
+    let text = out.as_string();
+    let mut rows: Vec<String> = text
+        .lines()
+        .skip(1)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect();
+    rows.sort();
+    rows
+}
+
+/// Every `did,tid` pair satisfying `val < threshold`, by nested loop over
+/// the union of each side's files — an independent answer that owes
+/// nothing to the join strategy, the declared sorts, or the file split.
+fn nested_loop_oracle(
+    driver_files: &[(&str, &[RangeRow])],
+    build_files: &[(&str, &[RangeRow])],
+) -> Vec<String> {
+    let flatten = |files: &[(&str, &[RangeRow])]| -> Vec<RangeRow> {
+        files
+            .iter()
+            .flat_map(|(_, rows)| rows.iter().copied())
+            .collect()
+    };
+    let mut pairs = Vec::new();
+    for (did, val) in flatten(driver_files) {
+        for (tid, threshold) in flatten(build_files) {
+            // A NULL on either side of the comparison is neither true nor
+            // false, and `on_miss: skip` drops the driver that produced it.
+            let (Some(val), Some(threshold)) = (val, threshold) else {
+                continue;
+            };
+            if val < threshold {
+                pairs.push(format!("{did},{tid}"));
+            }
+        }
+    }
+    pairs.sort();
+    pairs
+}
+
+/// Two files whose key ranges descend across the match: the first holds
+/// the high range, the second the low one.
+///
+/// Each file ascends internally, so per-file verification passes on both;
+/// the sequence a scan reads runs `100,101,102` then `1,2,3` and is not
+/// ordered. This is the input the planner rule exists to keep away from a
+/// two-cursor scan. Running it, rather than only inspecting the plan,
+/// is what proves the rule matters to a result: the scan's kernel
+/// re-checks the ascending certification it was handed, so routing this
+/// input to it ends the run instead of finishing it.
+const REVERSED_RANGE_HIGH_FILE: &[RangeRow] = &[(1, Some(100)), (2, Some(101)), (3, Some(102))];
+const REVERSED_RANGE_LOW_FILE: &[RangeRow] = &[(4, Some(1)), (5, Some(2)), (6, Some(3))];
+
+#[test]
+fn a_range_join_over_two_files_finds_every_pair_a_nested_loop_finds() {
+    let drivers: &[(&str, &[RangeRow])] = &[
+        ("drivers-a.csv", REVERSED_RANGE_HIGH_FILE),
+        ("drivers-b.csv", REVERSED_RANGE_LOW_FILE),
+    ];
+    let builds: &[(&str, &[RangeRow])] = &[(
+        "builds.csv",
+        &[
+            (10, Some(2)),
+            (11, Some(3)),
+            (12, Some(4)),
+            (13, Some(101)),
+            (14, Some(102)),
+            (15, Some(103)),
+        ],
+    )];
+
+    // Hand-counted: every driver matches every build above it, which is
+    // 3+2+1 for the high-range file and 6+5+4 for the low-range one. An
+    // oracle that silently went empty would agree with any broken run.
+    let oracle = nested_loop_oracle(drivers, builds);
+    assert_eq!(oracle.len(), 21);
+
+    let yaml = runnable_range_join(
+        "paths: [drivers-a.csv, drivers-b.csv]",
+        "{ field: val }",
+        "path: builds.csv",
+        "{ field: threshold }",
+    );
+    assert_eq!(
+        run_range_join(&yaml, drivers, builds),
+        oracle,
+        "a join over files that are individually sorted must still find every pair"
+    );
+}
+
+#[test]
+fn a_range_join_finds_every_pair_across_sort_directions_and_null_placement() {
+    // Descending files reverse which one has to come first for the
+    // concatenation to break: the low range descends before the high one
+    // does. Nulls sit at the end the declaration puts them at, so each
+    // file satisfies its own declaration.
+    let desc_high: &[RangeRow] = &[(1, Some(102)), (2, Some(101)), (3, Some(100))];
+    let desc_low: &[RangeRow] = &[(4, Some(3)), (5, Some(2)), (6, Some(1)), (7, None)];
+    let asc_nulls_first: &[RangeRow] = &[(1, None), (2, Some(100)), (3, Some(101))];
+    let asc_low: &[RangeRow] = &[(4, Some(1)), (5, Some(2))];
+    // Duplicate boundary keys on both sides: several drivers sit exactly
+    // at a threshold, where a strict `<` must exclude the equal build and
+    // admit the next one, once per duplicate.
+    let dup_builds: &[RangeRow] = &[
+        (10, Some(2)),
+        (11, Some(2)),
+        (12, Some(3)),
+        (13, Some(100)),
+        (14, Some(100)),
+        (15, Some(101)),
+    ];
+
+    for (case, driver_files, driver_sort, build_files, build_sort) in [
+        (
+            "descending files, nulls last, duplicate boundary keys",
+            vec![("drivers-a.csv", desc_low), ("drivers-b.csv", desc_high)],
+            "{ field: val, order: desc, null_order: last }",
+            vec![("builds.csv", dup_builds)],
+            "{ field: threshold }",
+        ),
+        (
+            "ascending files, nulls first, duplicate boundary keys",
+            vec![
+                ("drivers-a.csv", asc_nulls_first),
+                ("drivers-b.csv", asc_low),
+            ],
+            "{ field: val, order: asc, null_order: first }",
+            vec![("builds.csv", dup_builds)],
+            "{ field: threshold }",
+        ),
+        (
+            "the multi-file side is the build side",
+            vec![("drivers.csv", asc_low)],
+            "{ field: val }",
+            vec![
+                ("builds-a.csv", REVERSED_RANGE_HIGH_FILE),
+                ("builds-b.csv", REVERSED_RANGE_LOW_FILE),
+            ],
+            "{ field: threshold }",
+        ),
+    ] {
+        let driver_matcher = if driver_files.len() == 1 {
+            format!("path: {}", driver_files[0].0)
+        } else {
+            format!(
+                "paths: [{}]",
+                driver_files
+                    .iter()
+                    .map(|(path, _)| *path)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        };
+        let build_matcher = if build_files.len() == 1 {
+            format!("path: {}", build_files[0].0)
+        } else {
+            format!(
+                "paths: [{}]",
+                build_files
+                    .iter()
+                    .map(|(path, _)| *path)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        };
+        let yaml = runnable_range_join(&driver_matcher, driver_sort, &build_matcher, build_sort);
+        assert_eq!(
+            run_range_join(&yaml, &driver_files, &build_files),
+            nested_loop_oracle(&driver_files, &build_files),
+            "{case}: every satisfying pair must reach the output"
+        );
+    }
+}
+
+/// The `--explain` block for one node, from its header line to the blank
+/// line that closes it.
+fn explain_block<'a>(text: &'a str, header: &str) -> &'a str {
+    let start = text
+        .find(&format!("\n{header}\n"))
+        .unwrap_or_else(|| panic!("explain output has no '{header}' block:\n{text}"))
+        + 1;
+    let rest = &text[start..];
+    let end = rest.find("\n\n").map(|at| start + at).unwrap_or(text.len());
+    &text[start..end]
+}
+
+/// Rendered with the statistics catalog, because the Combine detail block
+/// — where the per-input order scope appears — renders only when the
+/// catalog is threaded through.
+fn explain_of(yaml: &str) -> String {
+    let plan = compile(yaml);
+    plan.dag()
+        .explain_text_with_statistics(plan.config(), plan.statistics())
+}
+
+/// An author reading `--explain` has to be able to tell the two apart:
+/// "sorted" that holds across the whole input and "sorted" that holds
+/// only inside each file read the same in a pipeline's YAML, and only the
+/// first licenses a consumer that walks one sequence. So the scope is
+/// named where the order is named — on the node's properties, and again
+/// on each Combine input, where it is the reason a strategy was or was
+/// not available.
+#[test]
+fn explain_names_the_scope_an_order_was_proven_over() {
+    let per_file = explain_of(&runnable_range_join(
+        "paths: [drivers-a.csv, drivers-b.csv]",
+        "{ field: val }",
+        "path: builds.csv",
+        "{ field: threshold }",
+    ));
+    let drivers = explain_block(&per_file, "source.drivers:");
+    assert!(
+        drivers.contains("ordering: val")
+            && drivers.contains(
+                "ordering_scope: per partition on $source.file (not one ordered sequence)"
+            ),
+        "a multi-file source must name the key its order is proven inside:\n{drivers}"
+    );
+    let builds = explain_block(&per_file, "source.builds:");
+    assert!(
+        builds.contains("ordering_scope: global (one ordered sequence across the input)"),
+        "the single-file side of the same plan must still read as global:\n{builds}"
+    );
+
+    let combine = explain_block(&per_file, "Combine 'banded':");
+    assert!(
+        combine.contains(", order per partition on $source.file (not one ordered sequence))"),
+        "the Combine input line must carry the scope that decided its strategy:\n{combine}"
+    );
+    assert!(
+        combine.contains(", order global (one ordered sequence across the input))"),
+        "and must distinguish the input whose order is global:\n{combine}"
+    );
+
+    // The same pipeline with one file per side: the scope changes, and it
+    // is the only thing about the declared order that changed.
+    let global = explain_of(&runnable_range_join(
+        "path: drivers.csv",
+        "{ field: val }",
+        "path: builds.csv",
+        "{ field: threshold }",
+    ));
+    let drivers = explain_block(&global, "source.drivers:");
+    assert!(
+        drivers.contains("ordering: val")
+            && drivers.contains("ordering_scope: global (one ordered sequence across the input)"),
+        "a single-file source declares an order over the whole input:\n{drivers}"
+    );
+    assert!(
+        !global.contains("per partition"),
+        "no input in this plan is partitioned:\n{global}"
+    );
 }
 
 #[test]

--- a/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
+++ b/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
@@ -43,6 +43,7 @@ source.orders:
 
 sort.__correlation_sort_orders:
   ordering: order_id
+  ordering_scope: global (one ordered sequence across the input)
   ordering_provenance: Preserved { from_node: "__correlation_sort_orders" }
   partitioning: Single
   partitioning_provenance: SingleStream

--- a/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
+++ b/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
@@ -42,7 +42,7 @@ source.orders:
   arbitration: spill_priority=N/A, can_back_pressure=true, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
 sort.__correlation_sort_orders:
-  ordering: order_id
+  ordering: order_id asc
   ordering_scope: global (one ordered sequence across the input)
   ordering_provenance: Preserved { from_node: "__correlation_sort_orders" }
   partitioning: Single

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -1340,10 +1340,30 @@ fn pure_range_inputs_presorted(
         let Some(props) = node_properties.get(&upstream_idx) else {
             return false;
         };
+        // A sort-merge scan advances two cursors over two sequences, so
+        // the proof it needs is about the sequence it will read. A
+        // declared `sort_order` on a partitioned input is proven inside
+        // each partition instead: a Source matching two files verifies
+        // each file separately, and files whose key ranges descend across
+        // the match are individually sorted and jointly not. Reading the
+        // declaration without its scope accepted exactly that input and
+        // advanced the cursors past matching rows.
+        if !props.partitioning.kind.carries_global_order() {
+            return false;
+        }
         let Some(sort_order) = props.ordering.sort_order.as_ref() else {
             return false;
         };
-        sort_order.first().is_some_and(|sf| sf.field == field)
+        // Ascending specifically, not merely sorted. The kernel is handed
+        // `presorted: true` and walks two cursors forward, and it verifies
+        // that certification before emitting: a descending declaration on
+        // the range axis is the same broken promise as an unsorted one and
+        // ends the run naming the planner. A descending input is still a
+        // correct range join, so it routes to the strategy that sorts for
+        // itself rather than being refused.
+        sort_order
+            .first()
+            .is_some_and(|sf| sf.field == field && sf.order == crate::config::SortOrder::Asc)
     };
 
     // For each side, find the predecessor whose name matches the

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -61,6 +61,25 @@ fn transform_cxl_sources(config: &PipelineConfig) -> Vec<(String, String)> {
     out
 }
 
+/// How wide an ordering fact holds on a stream with this partitioning.
+///
+/// Names the partition keys when there are any, because "per file" is
+/// only useful to an author who can see which key splits the stream.
+fn order_scope_label(kind: &crate::plan::properties::PartitioningKind) -> String {
+    if kind.carries_global_order() {
+        return "global (one ordered sequence across the input)".to_string();
+    }
+    let keys = kind.partition_keys();
+    if keys.is_empty() {
+        "per partition (not one ordered sequence)".to_string()
+    } else {
+        format!(
+            "per partition on {} (not one ordered sequence)",
+            keys.join(", ")
+        )
+    }
+}
+
 /// Human-readable strategy label for the multi-line `--explain` block.
 /// `GraceHash` appends its `1 << partition_bits` partition count, since it
 /// really does hash-partition its build side into that many on-disk buckets.
@@ -491,6 +510,19 @@ impl ExecutionPlanDag {
                     Some(order) => {
                         let fields: Vec<String> = order.iter().map(|s| s.field.clone()).collect();
                         out.push_str(&format!("  ordering: {}\n", fields.join(", ")));
+                        // How wide the order above was proven, which is what
+                        // decides whether a consumer needing one sequence may
+                        // rely on it. Printed next to the order rather than
+                        // left to be inferred from the partitioning line
+                        // below it — and only where something is actually
+                        // ordered, since a scope for an empty order names the
+                        // width of nothing.
+                        if !order.is_empty() {
+                            out.push_str(&format!(
+                                "  ordering_scope: {}\n",
+                                order_scope_label(&props.partitioning.kind)
+                            ));
+                        }
                     }
                     None => out.push_str("  ordering: <none>\n"),
                 }
@@ -969,6 +1001,25 @@ impl ExecutionPlanDag {
             combine_strategy_display(strategy)
         ));
 
+        // The scope of each input's declared order, reported from the same
+        // property the strategy choice consulted. A sort-merge scan needs
+        // one ordered sequence per input, so an input reading "per
+        // partition" here is the reason a range join it would otherwise
+        // have qualified for is running another strategy instead.
+        let input_order_scope = |input_name: &str| -> Option<String> {
+            self.graph
+                .neighbors_directed(idx, petgraph::Direction::Incoming)
+                .find(|&pred| self.graph[pred].name() == input_name)
+                .and_then(|pred| self.node_properties.get(&pred))
+                .filter(|props| props.ordering.sort_order.is_some())
+                .map(|props| order_scope_label(&props.partitioning.kind))
+        };
+        let order_note = |input_name: &str| -> String {
+            input_order_scope(input_name)
+                .map(|scope| format!(", order {scope}"))
+                .unwrap_or_default()
+        };
+
         let drive_label = if driving_input.is_empty() {
             "<unselected>"
         } else {
@@ -977,7 +1028,8 @@ impl ExecutionPlanDag {
         let drive_rows =
             format_estimated_rows(inputs_for_node.and_then(|m| m.get(drive_label)), statistics);
         out.push_str(&format!(
-            "  Driving input: {drive_label} (probe, est. {drive_rows} rows)\n",
+            "  Driving input: {drive_label} (probe, est. {drive_rows} rows{})\n",
+            order_note(drive_label),
         ));
 
         for build_name in build_inputs {
@@ -987,7 +1039,8 @@ impl ExecutionPlanDag {
                 statistics,
             );
             out.push_str(&format!(
-                "  Build input: {build_name} ({role}, est. {rows} rows)\n",
+                "  Build input: {build_name} ({role}, est. {rows} rows{})\n",
+                order_note(build_name.as_str()),
             ));
         }
 

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -61,6 +61,28 @@ fn transform_cxl_sources(config: &PipelineConfig) -> Vec<(String, String)> {
     out
 }
 
+/// A declared order written the way its author wrote it — field and
+/// direction, in key order.
+///
+/// Direction is part of the order, not decoration: a forward two-cursor scan
+/// needs an ascending key, so a descending declaration is disqualifying for
+/// the same consumers a per-partition scope disqualifies. Printing the fields
+/// alone left an author looking at a global, sorted input that did not get the
+/// scan, with nothing on the page to say why.
+fn order_fields_label(order: &[crate::config::SortField]) -> String {
+    order
+        .iter()
+        .map(|field| {
+            let direction = match field.order {
+                crate::config::SortOrder::Asc => "asc",
+                crate::config::SortOrder::Desc => "desc",
+            };
+            format!("{} {direction}", field.field)
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// The scope of a node's declared order, or `None` where it declares none.
 ///
 /// The one place this file decides whether there is an order to qualify.
@@ -533,8 +555,7 @@ impl ExecutionPlanDag {
                 out.push_str(&format!("{}:\n", node.id_slug()));
                 match &props.ordering.sort_order {
                     Some(order) => {
-                        let fields: Vec<String> = order.iter().map(|s| s.field.clone()).collect();
-                        out.push_str(&format!("  ordering: {}\n", fields.join(", ")));
+                        out.push_str(&format!("  ordering: {}\n", order_fields_label(order)));
                         // How wide the order above was proven, which is what
                         // decides whether a consumer needing one sequence may
                         // rely on it. Printed next to the order rather than
@@ -1026,17 +1047,29 @@ impl ExecutionPlanDag {
         // one ordered sequence per input, so an input reading "per
         // partition" here is the reason a range join it would otherwise
         // have qualified for is running another strategy instead.
-        let input_order_scope = |input_name: &str| -> Option<String> {
-            self.graph
+        let order_note = |input_name: &str| -> String {
+            let Some(props) = self
+                .graph
                 .neighbors_directed(idx, petgraph::Direction::Incoming)
                 .find(|&pred| self.graph[pred].name() == input_name)
                 .and_then(|pred| self.node_properties.get(&pred))
-                .and_then(declared_order_scope)
-        };
-        let order_note = |input_name: &str| -> String {
-            input_order_scope(input_name)
-                .map(|scope| format!(", order {scope}"))
-                .unwrap_or_default()
+            else {
+                return String::new();
+            };
+            let Some(scope) = declared_order_scope(props) else {
+                return String::new();
+            };
+            // Both facts eligibility reads, side by side: what the order is,
+            // and how wide it was proven. Reported, not judged — the rule that
+            // turns them into a strategy lives in the planner, and a second
+            // copy of it here would be free to disagree with the first.
+            let fields = props
+                .ordering
+                .sort_order
+                .as_ref()
+                .map(|order| order_fields_label(order))
+                .unwrap_or_default();
+            format!(", order {fields} — {scope}")
         };
 
         let drive_label = if driving_input.is_empty() {

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -61,10 +61,35 @@ fn transform_cxl_sources(config: &PipelineConfig) -> Vec<(String, String)> {
     out
 }
 
+/// The scope of a node's declared order, or `None` where it declares none.
+///
+/// The one place this file decides whether there is an order to qualify.
+/// `sort_order` says "no order" two ways — absent, and present but empty —
+/// and a streaming aggregate produces the second, so a site testing only
+/// for presence labels a node that orders nothing as ordering everything.
+/// Every reader goes through here so the two spellings cannot be handled
+/// differently in different blocks.
+fn declared_order_scope(props: &crate::plan::properties::NodeProperties) -> Option<String> {
+    props
+        .ordering
+        .sort_order
+        .as_ref()
+        .filter(|order| !order.is_empty())
+        .map(|_| order_scope_label(&props.partitioning.kind))
+}
+
 /// How wide an ordering fact holds on a stream with this partitioning.
 ///
 /// Names the partition keys when there are any, because "per file" is
 /// only useful to an author who can see which key splits the stream.
+///
+/// This reads the partitioning shape, which is what the range-join
+/// eligibility rule reads too. It is not a claim about what a node
+/// physically emits: a planner-synthesized Sort inherits its parent's
+/// partitioning while draining and ordering the whole input, so its scope
+/// is reported as the narrower of the two. The engine's edge-level
+/// `OrderScope` in the compiled order contract answers the same question
+/// for verified source order; the two are separate vocabularies today.
 fn order_scope_label(kind: &crate::plan::properties::PartitioningKind) -> String {
     if kind.carries_global_order() {
         return "global (one ordered sequence across the input)".to_string();
@@ -514,14 +539,9 @@ impl ExecutionPlanDag {
                         // decides whether a consumer needing one sequence may
                         // rely on it. Printed next to the order rather than
                         // left to be inferred from the partitioning line
-                        // below it — and only where something is actually
-                        // ordered, since a scope for an empty order names the
-                        // width of nothing.
-                        if !order.is_empty() {
-                            out.push_str(&format!(
-                                "  ordering_scope: {}\n",
-                                order_scope_label(&props.partitioning.kind)
-                            ));
+                        // below it.
+                        if let Some(scope) = declared_order_scope(props) {
+                            out.push_str(&format!("  ordering_scope: {scope}\n"));
                         }
                     }
                     None => out.push_str("  ordering: <none>\n"),
@@ -1011,8 +1031,7 @@ impl ExecutionPlanDag {
                 .neighbors_directed(idx, petgraph::Direction::Incoming)
                 .find(|&pred| self.graph[pred].name() == input_name)
                 .and_then(|pred| self.node_properties.get(&pred))
-                .filter(|props| props.ordering.sort_order.is_some())
-                .map(|props| order_scope_label(&props.partitioning.kind))
+                .and_then(declared_order_scope)
         };
         let order_note = |input_name: &str| -> String {
             input_order_scope(input_name)
@@ -2240,6 +2259,67 @@ fn combine_operand_qualified(expr: &cxl::ast::Expr, input: &std::sync::Arc<str>)
             .collect::<Vec<_>>()
             .join("."),
         _ => format!("{}.<expr>", input),
+    }
+}
+
+#[cfg(test)]
+mod order_scope_tests {
+    use super::*;
+    use crate::config::{SortField, SortOrder};
+    use crate::plan::properties::{NodeProperties, PartitioningKind};
+
+    fn ordered_by(fields: Option<Vec<SortField>>) -> NodeProperties {
+        let mut props = NodeProperties::unordered_single();
+        props.ordering.sort_order = fields;
+        props
+    }
+
+    /// `sort_order` says "no order" two ways, and only one of them is
+    /// absence. A streaming aggregate carries `Some(vec![])`, so a reader
+    /// that tests for presence alone reports the width of a sequence that
+    /// was never ordered — and reports it as `global`, the widest claim
+    /// available, on the line an author reads to understand why a join
+    /// chose its strategy.
+    #[test]
+    fn an_order_of_no_fields_has_no_scope_to_report() {
+        assert_eq!(ordered_by(None).ordering.sort_order, None);
+        assert!(
+            declared_order_scope(&ordered_by(None)).is_none(),
+            "a node declaring no order has no scope"
+        );
+        assert!(
+            declared_order_scope(&ordered_by(Some(Vec::new()))).is_none(),
+            "an order over no fields is not an order, however it is spelled"
+        );
+    }
+
+    /// The other half: a real order still reports one, and reports the
+    /// width its partitioning actually gives it.
+    #[test]
+    fn a_real_order_reports_the_width_its_partitioning_gives_it() {
+        let one_field = || {
+            Some(vec![SortField {
+                field: "key".to_string(),
+                order: SortOrder::Asc,
+                null_order: None,
+            }])
+        };
+
+        let global = ordered_by(one_field());
+        assert!(
+            declared_order_scope(&global).is_some_and(|scope| scope.starts_with("global")),
+            "an unpartitioned stream orders the whole edge"
+        );
+
+        let mut per_file = ordered_by(one_field());
+        per_file.partitioning.kind = PartitioningKind::FilePartitioned {
+            keys: vec!["$source.file".to_string()],
+        };
+        let scope = declared_order_scope(&per_file).expect("a declared order reports a scope");
+        assert!(
+            scope.contains("per partition") && scope.contains("$source.file"),
+            "a partitioned stream names the key its order is scoped to: {scope}"
+        );
     }
 }
 

--- a/crates/clinker-plan/src/plan/properties.rs
+++ b/crates/clinker-plan/src/plan/properties.rs
@@ -253,6 +253,33 @@ pub enum PartitioningProvenance {
 }
 
 impl PartitioningKind {
+    /// Whether a sort declared on this stream orders the whole edge, or
+    /// only the inside of each partition.
+    ///
+    /// A sort proof is exactly as wide as the stream it was proven over.
+    /// A multi-file Source verifies its `sort_order` within each physical
+    /// file, so two files that each ascend say nothing about their
+    /// concatenation — the second may open below where the first closed.
+    /// Every partitioned shape shares that gap: what holds inside a
+    /// partition is not a claim about the sequence a consumer reads. Only
+    /// an unpartitioned stream carries one ordered sequence, and `Merge`
+    /// is what produces one from partitioned inputs.
+    ///
+    /// Consumers whose contract is per-partition read the sort order
+    /// directly and do not ask this; it answers for the ones that need a
+    /// single sequence, such as a sort-merge scan.
+    pub fn carries_global_order(&self) -> bool {
+        match self {
+            PartitioningKind::Single => true,
+            // Enumerated rather than matched by wildcard: a partitioning
+            // shape added later must state whether a sort over it means
+            // the whole edge, instead of inheriting an answer.
+            PartitioningKind::HashPartitioned { .. }
+            | PartitioningKind::RoundRobin { .. }
+            | PartitioningKind::FilePartitioned { .. } => false,
+        }
+    }
+
     /// Borrow the partition keys (if any) carried by a partitioned
     /// stream. Returns an empty slice for `Single` and `RoundRobin`.
     pub fn partition_keys(&self) -> &[String] {


### PR DESCRIPTION
A sort-merge scan walks one cursor forward along each of its inputs, so the planner may choose it only when each input is genuinely one ordered sequence. It decided that from a Source's declared `sort_order` and nothing else.

A Source matching several files verifies that declaration **inside each file**. The promise is "every file ascends", never "their concatenation ascends" — two files whose key ranges descend across the match each satisfy the declaration and jointly violate the order the scan requires.

## What actually happened before this change

Not a wrong answer. The kernel does not take the planner's certification on trust: it rechecks the sequence while charging the input and refuses to emit, returning

```
Internal { op: "combine", node: "...", detail: "sort-merge phase A: pre-sorted driver
input is not ascending on the range key; the planner certified an out-of-order input
as pre-sorted" }
```

So the cost was a legitimately joinable pipeline that could not run, ending in an internal error about a promise its author never made. Confirmed empirically by reverting the guard and observing the abort, on both the driver and the build side.

## The fix

`PartitioningKind::carries_global_order()` answers whether a declared order covers the whole edge. It is true only for an unpartitioned stream, and enumerates every partitioning shape rather than matching a wildcard, so a shape added later has to state its own answer instead of inheriting one. Range-join eligibility now consults it, and a join that does not qualify takes the strategy that orders what it reads.

The same predicate closes a second case found while testing this one: the scan advances forward, and a declaration may name a **descending** axis. Certifying that broke the identical promise from a single file, with the identical abort. Eligibility now requires the range axis to be ascending as well as declared.

`Merge` already reasoned this way — it drops authored ordering outright, on the grounds that independently sorted inputs do not form one sorted sequence. The Source door was the one left open.

## Explain

`--explain` prints the scope beside the order it qualifies, and names it on each Combine input, so the strategy a range join received can be read against the property that selected it:

```
source.drivers:
  ordering: val
  ordering_scope: per partition on $source.file (not one ordered sequence)
```

Printed only where something is ordered — a scope for an empty order names the width of nothing.

## Tests

- Planner selection across four matcher shapes, driver side, build side, both sides, and a glob.
- A runtime oracle: real two-file ingest with the high range in the first file and the low range in the second, joined against a brute-force nested-loop evaluation of the same predicate over the union. Covers ascending and descending, duplicate boundary keys, null placement first and last, and the multi-file side on both inputs.
- Single-file ascending input still selects the scan, so the change is not over-broad.
- Explain output distinguishes the two scopes.

Every new guard was verified to fail with the guard removed; the single-file case passes with and without it.

One existing test asserted the scan over a multi-file driver, and passed only because its fixture data happened to be globally ordered. Its fixture is now the adversarial shape, and it asserts the strategy that shape legitimately gets. Its document-boundary coverage is preserved on the input shape that genuinely selects the scan — declaring `sort_order` requires a format whose event shape carries at most one record-bearing document per file, so a multi-document scan input cannot exist by construction rather than by omission.

## Baselines

One snapshot line added, reviewed: an unpartitioned node carrying a real order gains `global`, which is a correct new fact about it. A second baseline is unchanged — its ordering is empty, and the scope line is suppressed there.

Closes #1040
