### PR TITLE
Count the records a sort was told to discard

### DIFF
--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -176,6 +176,25 @@ where
     Ok(())
 }
 
+/// Whether a record is excluded by an authored `null_order: drop` field.
+///
+/// A record qualifies when *any* dropping field's key is absent from the
+/// record or present and null — an absent column and an explicit null are
+/// the same missing key as far as ordering is concerned.
+///
+/// The buffered and streaming sorters share this rather than each spelling
+/// the test out: the two paths must exclude the same records and report the
+/// same count, and the cheapest way to guarantee that is to leave them no
+/// way to disagree.
+fn dropped_for_null_key(record: &Record, sort_fields: &[clinker_plan::config::SortField]) -> bool {
+    sort_fields.iter().any(|field| {
+        field.null_order == Some(clinker_plan::config::NullOrder::Drop)
+            && record
+                .get(&field.field)
+                .is_none_or(clinker_record::Value::is_null)
+    })
+}
+
 /// Apply the shared stable authored-key sort to a materialized record stream.
 ///
 /// `SourceRowId` remains payload throughout resident sorting and spill merge;
@@ -190,15 +209,18 @@ pub(super) fn sort_records_by_authored_fields(
 ) -> Result<Vec<(Record, crate::executor::stream_event::SourceRowId)>, PipelineError> {
     use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
 
-    input_records.retain(|(record, _)| {
-        !sort_fields.iter().any(|field| {
-            field.null_order == Some(clinker_plan::config::NullOrder::Drop)
-                && record
-                    .get(&field.field)
-                    .is_none_or(clinker_record::Value::is_null)
-        })
-    });
+    // Opened before the null-key filter so the stage's elapsed time covers
+    // the work that removes records, and `records_in` is the population the
+    // stage was handed rather than what survived it.
+    let sort_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::Sort);
+    let received = input_records.len() as u64;
+    input_records.retain(|(record, _)| !dropped_for_null_key(record, sort_fields));
+    ctx.counters
+        .increment_null_dropped(received - input_records.len() as u64);
     if input_records.is_empty() {
+        // Report even here. Returning without recording would hide the drop
+        // on exactly the run that dropped everything.
+        ctx.collector.record(sort_timer.finish(received, 0));
         return Ok(input_records);
     }
     let schema = input_records[0].0.schema().clone();
@@ -214,7 +236,6 @@ pub(super) fn sort_records_by_authored_fields(
         schema,
     );
 
-    let sort_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::Sort);
     let sort_count = input_records.len() as u64;
     let charge = crate::pipeline::spill_merge::SpillChargeGuard::new(
         std::sync::Arc::clone(&ctx.memory_budget),
@@ -238,7 +259,7 @@ pub(super) fn sort_records_by_authored_fields(
         )?,
     };
     ctx.collector
-        .record(sort_timer.finish(sort_count, sort_count));
+        .record(sort_timer.finish(received, sort_count));
     Ok(out)
 }
 
@@ -266,17 +287,14 @@ where
     let mut buffer: Option<SortBuffer<crate::executor::stream_event::SourceRowId>> = None;
     let mut spill_compress = false;
     let mut sort_count = 0u64;
+    let mut dropped = 0u64;
     let sort_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::Sort);
     let charge = SpillChargeGuard::new(std::sync::Arc::clone(&ctx.memory_budget), node_name);
 
     for item in input {
         let (record, source_row) = item?;
-        if sort_fields.iter().any(|field| {
-            field.null_order == Some(clinker_plan::config::NullOrder::Drop)
-                && record
-                    .get(&field.field)
-                    .is_none_or(clinker_record::Value::is_null)
-        }) {
+        if dropped_for_null_key(&record, sort_fields) {
+            dropped = dropped.saturating_add(1);
             continue;
         }
         let buf = buffer.get_or_insert_with(|| {
@@ -303,7 +321,14 @@ where
         }
     }
 
+    ctx.counters.increment_null_dropped(dropped);
+    let received = sort_count.saturating_add(dropped);
+
     let Some(buf) = buffer else {
+        // No record survived to open a buffer. Report anyway: a stream that
+        // dropped every record it saw is the case an operator most needs to
+        // see, and it is the one an early return would hide.
+        ctx.collector.record(sort_timer.finish(received, 0));
         return Ok(AuthoredSortStream::InMemory(Vec::new().into_iter()));
     };
     let (sorted, residue) = buf.finish().map_err(|error| {
@@ -313,7 +338,7 @@ where
     })?;
     charge_enforcer_spill(&charge, node_name, residue)?;
     ctx.collector
-        .record(sort_timer.finish(sort_count, sort_count));
+        .record(sort_timer.finish(received, sort_count));
 
     match sorted {
         SortedOutput::InMemory(records) => Ok(AuthoredSortStream::InMemory(records.into_iter())),

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -294,6 +294,10 @@ where
     for item in input {
         let (record, source_row) = item?;
         if dropped_for_null_key(&record, sort_fields) {
+            // Counted at the drop, not after the loop: an error raised
+            // further down the stream must not take the exclusions already
+            // observed with it.
+            ctx.counters.increment_null_dropped(1);
             dropped = dropped.saturating_add(1);
             continue;
         }
@@ -321,14 +325,15 @@ where
         }
     }
 
-    ctx.counters.increment_null_dropped(dropped);
     let received = sort_count.saturating_add(dropped);
 
     let Some(buf) = buffer else {
-        // No record survived to open a buffer. Report anyway: a stream that
-        // dropped every record it saw is the case an operator most needs to
-        // see, and it is the one an early return would hide.
-        ctx.collector.record(sort_timer.finish(received, 0));
+        // Deliberately records no stage here. The document-DLQ commit path
+        // calls this once per record, so a stream whose every record drops
+        // would push one `StageMetrics` — and pay its RSS, CPU, and I/O
+        // syscalls — per dropped record, growing with input cardinality.
+        // `null_dropped_count` above already carries the loss, at a fixed
+        // cost, which is why the stage entry is not needed to see it.
         return Ok(AuthoredSortStream::InMemory(Vec::new().into_iter()));
     };
     let (sorted, residue) = buf.finish().map_err(|error| {

--- a/crates/clinker-exec/src/metrics.rs
+++ b/crates/clinker-exec/src/metrics.rs
@@ -62,6 +62,17 @@ pub struct ExecutionMetrics {
     pub records_written: u64,
     /// Records routed to the DLQ.
     pub records_dlq: u64,
+    /// Records excluded by a `null_order: drop` sort field. Unlike DLQ
+    /// entries these leave no artifact to count afterwards, so this is the
+    /// only record of them; a run whose output is short by exactly this
+    /// many rows is behaving as configured.
+    ///
+    /// `#[serde(default)]` keeps the spool collector able to read files
+    /// written before this counter landed — they round-trip as zero, which
+    /// is indistinguishable from a genuine zero, so treat the absence of
+    /// the key rather than its value as the signal when auditing old files.
+    #[serde(default)]
+    pub records_null_dropped: u64,
     /// DAG-derived execution summary from `ExecutionReport.execution_summary`.
     pub execution_mode: String,
     /// Peak process RSS in bytes observed across chunk boundaries.
@@ -375,6 +386,7 @@ mod tests {
             records_ok: 99,
             records_written: 99,
             records_dlq: 1,
+            records_null_dropped: 2,
             execution_mode: "Streaming".into(),
             peak_rss_bytes: Some(52_428_800),
             thread_count: 4,
@@ -427,6 +439,7 @@ mod tests {
         assert_eq!(parsed.records_ok, 99);
         assert_eq!(parsed.records_written, 99);
         assert_eq!(parsed.records_dlq, 1);
+        assert_eq!(parsed.records_null_dropped, 2);
         assert_eq!(parsed.exit_code, 0);
         assert_eq!(parsed.peak_rss_bytes, Some(52_428_800));
     }

--- a/crates/clinker-exec/tests/ordering_contract.rs
+++ b/crates/clinker-exec/tests/ordering_contract.rs
@@ -784,6 +784,142 @@ fn run_compound_boundary(memory_limit: &str, mode: &str) -> String {
     output.as_string()
 }
 
+/// Run the compound boundary fixture and keep the report, not just the bytes.
+fn run_compound_boundary_reported(
+    memory_limit: &str,
+    mode: &str,
+) -> clinker_exec::executor::ExecutionReport {
+    let plan = compile(&compound_sort_yaml(memory_limit, mode));
+    let readers: SourceReaders = HashMap::from([(
+        "rows".to_string(),
+        SourceInput::Files(vec![
+            FileSlot::new(
+                PathBuf::from(format!("{mode}-one.csv")),
+                Box::new(Cursor::new(compound_boundary_csv().as_bytes().to_vec())),
+            ),
+            FileSlot::new(
+                PathBuf::from(format!("{mode}-two.csv")),
+                Box::new(Cursor::new(
+                    compound_boundary_second_csv().as_bytes().to_vec(),
+                )),
+            ),
+        ]),
+    )]);
+    let output = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(output.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams::default(),
+    )
+    .unwrap_or_else(|error| panic!("{mode} writer-boundary fixture failed: {error}"))
+}
+
+/// A record excluded by `null_order: drop` is counted, and the count is the
+/// same whether the sort stayed resident or spilled.
+///
+/// The fixture drops exactly two rows — one with an empty `key`, one with an
+/// empty `group` — so a count that tracked dropping *fields* rather than
+/// dropped *records* would still read two here; the compound fixture below
+/// separates those.
+#[test]
+fn null_order_drop_is_counted_and_survives_spilling() {
+    for mode in ["document", "envelope"] {
+        for limit in ["64M", "2400"] {
+            let report = run_compound_boundary_reported(limit, mode);
+            assert_eq!(
+                report.counters.null_dropped_count, 2,
+                "{mode} at limit {limit} must count both null-keyed rows"
+            );
+            assert_eq!(
+                report.counters.filtered_count, 0,
+                "{mode} at limit {limit} must not report the drop as a filter"
+            );
+            assert_eq!(
+                report.counters.dlq_count, 0,
+                "{mode} at limit {limit} must not report the drop as a DLQ entry"
+            );
+        }
+    }
+}
+
+/// The Sort stage reports the population it was handed, not the survivors.
+///
+/// Before this held, `records_in == records_out` on a stage that had already
+/// discarded rows — the signature of a lossless stage, printed by one that
+/// was not.
+#[test]
+fn sort_stage_reports_the_population_it_received() {
+    for mode in ["document", "envelope"] {
+        let report = run_compound_boundary_reported("64M", mode);
+        let sorts: Vec<_> = report
+            .stages
+            .iter()
+            .filter(|stage| stage.name == clinker_exec::executor::stage_metrics::StageName::Sort)
+            .collect();
+        assert!(!sorts.is_empty(), "{mode} must record a Sort stage");
+        let dropped: u64 = sorts
+            .iter()
+            .map(|stage| stage.records_in - stage.records_out)
+            .sum();
+        assert_eq!(
+            dropped, report.counters.null_dropped_count,
+            "{mode}: summed Sort records_in - records_out must equal the drop count"
+        );
+    }
+}
+
+/// A pipeline with no dropping field reports zero, so a non-zero count is
+/// always attributable to an authored `null_order: drop`.
+#[test]
+fn a_sort_without_a_dropping_field_reports_no_drops() {
+    let plan = compile(&output_pipeline("64M", 4, true));
+    let readers: SourceReaders = HashMap::from([(
+        "rows".to_string(),
+        single_file_reader(
+            "rows.csv",
+            Box::new(Cursor::new(equal_key_csv().into_bytes())),
+        ),
+    )]);
+    let out_a = SharedBuffer::new();
+    let out_b = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([
+        (
+            "out_a".to_string(),
+            Box::new(out_a.clone()) as Box<dyn Write + Send>,
+        ),
+        (
+            "out_b".to_string(),
+            Box::new(out_b.clone()) as Box<dyn Write + Send>,
+        ),
+    ]);
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams::default(),
+    )
+    .expect("undropped fixture must run");
+
+    assert_eq!(report.counters.null_dropped_count, 0);
+    for stage in report
+        .stages
+        .iter()
+        .filter(|stage| stage.name == clinker_exec::executor::stage_metrics::StageName::Sort)
+    {
+        assert_eq!(
+            stage.records_in, stage.records_out,
+            "a sort that drops nothing must report equal in and out"
+        );
+    }
+}
+
 #[test]
 fn writer_boundary_document_streaming_complete_populations() {
     assert_eq!(

--- a/crates/clinker-exec/tests/ordering_contract.rs
+++ b/crates/clinker-exec/tests/ordering_contract.rs
@@ -853,6 +853,14 @@ fn null_order_drop_is_counted_and_survives_spilling() {
 /// Before this held, `records_in == records_out` on a stage that had already
 /// discarded rows — the signature of a lossless stage, printed by one that
 /// was not.
+///
+/// This asserts only that the stage stopped under-reporting its input. It
+/// deliberately does *not* assert `records_in - records_out` equals the drop
+/// count: `StageName::Sort` is also the name the aggregate stage times under,
+/// where the same difference is a group reduction. On a fixture with no
+/// aggregate the two happen to coincide, and an assertion that reads as a
+/// contract while holding only as a fixture property is how the rule this
+/// change fixes got written in the first place.
 #[test]
 fn sort_stage_reports_the_population_it_received() {
     for mode in ["document", "envelope"] {
@@ -863,13 +871,16 @@ fn sort_stage_reports_the_population_it_received() {
             .filter(|stage| stage.name == clinker_exec::executor::stage_metrics::StageName::Sort)
             .collect();
         assert!(!sorts.is_empty(), "{mode} must record a Sort stage");
-        let dropped: u64 = sorts
-            .iter()
-            .map(|stage| stage.records_in - stage.records_out)
-            .sum();
-        assert_eq!(
-            dropped, report.counters.null_dropped_count,
-            "{mode}: summed Sort records_in - records_out must equal the drop count"
+        assert!(
+            sorts
+                .iter()
+                .any(|stage| stage.records_in > stage.records_out),
+            "{mode}: a sort that excluded records must report receiving more \
+             than it emitted, got {:?}",
+            sorts
+                .iter()
+                .map(|stage| (stage.records_in, stage.records_out))
+                .collect::<Vec<_>>()
         );
     }
 }
@@ -908,6 +919,9 @@ fn a_sort_without_a_dropping_field_reports_no_drops() {
     .expect("undropped fixture must run");
 
     assert_eq!(report.counters.null_dropped_count, 0);
+    // Safe to read every `StageName::Sort` entry as an authored sort here only
+    // because this fixture has no aggregate node, which times under the same
+    // name and legitimately emits fewer rows than it takes.
     for stage in report
         .stages
         .iter()

--- a/crates/clinker-record/src/counters.rs
+++ b/crates/clinker-record/src/counters.rs
@@ -34,6 +34,22 @@ pub struct PipelineCounters {
     pub dlq_count: u64,
     pub filtered_count: u64,
     pub distinct_count: u64,
+    /// Records excluded by a `null_order: drop` sort field, summed over
+    /// every sort that applied one. Counts records, not fields: a record
+    /// whose key is null on two dropping fields is one exclusion.
+    ///
+    /// Kept separate from `filtered_count` because the two answer
+    /// different questions — a filter is an authored predicate over record
+    /// content, while this is a consequence of how a sort was asked to
+    /// treat a missing key, and an author who did not read `null_order`
+    /// closely may not know they requested it at all.
+    ///
+    /// Report-only, like `records_written`: not exposed as a `$pipeline.*`
+    /// member. The exclusions happen at a terminal sort, so a CXL
+    /// expression evaluating mid-pipeline would read zero regardless of
+    /// how many records the run eventually drops — a number that is
+    /// always available but never yet true.
+    pub null_dropped_count: u64,
     /// Counters for the retraction protocol that fires when an
     /// aggregate's `group_by` omits a correlation-key field. All fields
     /// stay zero on pipelines whose every aggregate has
@@ -139,6 +155,12 @@ impl PipelineCounters {
     /// Increment `distinct_count` by n.
     pub fn increment_distinct(&mut self, n: u64) {
         self.distinct_count += n;
+    }
+
+    /// Increment `null_dropped_count` by n. Use once per record excluded
+    /// by a `null_order: drop` sort field.
+    pub fn increment_null_dropped(&mut self, n: u64) {
+        self.null_dropped_count += n;
     }
 
     /// Snapshot the current counters for sharing with a chunk's parallel evaluation.

--- a/crates/clinker-record/src/counters.rs
+++ b/crates/clinker-record/src/counters.rs
@@ -38,6 +38,12 @@ pub struct PipelineCounters {
     /// every sort that applied one. Counts records, not fields: a record
     /// whose key is null on two dropping fields is one exclusion.
     ///
+    /// Counts exclusions rather than distinct source records, so it carries
+    /// the same fan-out multiplicity as `records_written` and not the
+    /// distinct-input semantics of `ok_count`: two Outputs that each declare
+    /// a dropping sort each drop their own copy, and one source record
+    /// excluded at both counts twice.
+    ///
     /// Kept separate from `filtered_count` because the two answer
     /// different questions — a filter is an authored predicate over record
     /// content, while this is a consequence of how a sort was asked to

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -4836,6 +4836,7 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
             records_ok: counters.ok_count,
             records_written: counters.records_written,
             records_dlq: counters.dlq_count,
+            records_null_dropped: counters.null_dropped_count,
             execution_mode: report.execution_summary.clone(),
             peak_rss_bytes: report.peak_rss_bytes,
             thread_count: num_threads(args),

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -4728,6 +4728,16 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
             counters.records_written,
             counters.dlq_count
         );
+        // Named only when it happened. An operator who never wrote
+        // `null_order: drop` should not have to learn what a zero here
+        // means, and one who did should not have to configure a metrics
+        // spool to find out that records left this way.
+        if counters.null_dropped_count > 0 {
+            tracing::info!(
+                "{} record(s) excluded by null_order: drop",
+                counters.null_dropped_count
+            );
+        }
     }
 
     // Per-stage actual spill volume at end-of-run, so an operator can compare

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -556,6 +556,24 @@ Sort records before writing:
 - `last` -- nulls sort after all non-null values.
 - `drop` -- records with null sort keys are excluded from output.
 
+`drop` removes records, so a run using it writes fewer records than it read
+and that is not a fault. A missing column counts as a null key: a record that
+never carried the sort field is dropped the same as one carrying an explicit
+null. With several dropping fields, a record is excluded if *any* of its keys
+is null, and counts once however many of them are.
+
+The excluded records are counted. `records_null_dropped` in the metrics spool
+(`clinker metrics collect`) reports how many, separately from `records_dlq`
+and from filter losses, so a short output can be attributed rather than
+guessed at. The `Sort` stage reports it as well: its `records_in` is the
+population the sort was handed and `records_out` the population that
+survived, and the difference between them is the drop.
+
+Nothing else records these records. Unlike a DLQ entry, a dropped record
+leaves no artifact to inspect afterwards -- if you need to see which records
+were removed rather than only how many, route them out with a filter before
+the sort instead of declaring `drop`.
+
 Shorthand: a bare string defaults to ascending with nulls last:
 
 ```yaml

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -562,12 +562,22 @@ never carried the sort field is dropped the same as one carrying an explicit
 null. With several dropping fields, a record is excluded if *any* of its keys
 is null, and counts once however many of them are.
 
-The excluded records are counted. `records_null_dropped` in the metrics spool
-(`clinker metrics collect`) reports how many, separately from `records_dlq`
-and from filter losses, so a short output can be attributed rather than
-guessed at. The `Sort` stage reports it as well: its `records_in` is the
-population the sort was handed and `records_out` the population that
-survived, and the difference between them is the drop.
+The excluded records are counted, separately from `records_dlq` and from
+filter losses, so a short output can be attributed rather than guessed at. A
+run that dropped any reports the number on completion:
+
+```
+1234 record(s) excluded by null_order: drop
+```
+
+and the same number is written as `records_null_dropped` in the metrics spool
+when one is configured (see [Metrics](../ops/metrics.md)).
+
+Under fan-out the count is per exclusion, not per source record: two Outputs
+that each declare a dropping `sort_order` each drop their own copy, so one
+source record excluded at both counts twice — the same multiplicity
+`records_written` carries. Subtracting this from `records_total` is therefore
+only sound on a pipeline with a single dropping Output.
 
 Nothing else records these records. Unlike a DLQ entry, a dropped record
 leaves no artifact to inspect afterwards -- if you need to see which records

--- a/docs/user/src/ops/metrics.md
+++ b/docs/user/src/ops/metrics.md
@@ -47,6 +47,7 @@ schema bump means draining the spool first.
   "records_ok": 49950,
   "records_written": 49950,
   "records_dlq": 50,
+  "records_null_dropped": 0,
   "execution_mode": "Streaming",
   "peak_rss_bytes": 134217728,
   "thread_count": 4,
@@ -85,6 +86,7 @@ schema bump means draining the spool first.
 | `records_ok` | integer | Distinct source records that reached at least one output. Under inclusive Route fan-out one input matching N branches counts once |
 | `records_written` | integer | Total writes across all sinks. Equals `records_ok` for single-output exclusive pipelines; exceeds it under inclusive Route fan-out or multiple Output sinks |
 | `records_dlq` | integer | Records routed to the dead-letter queue |
+| `records_null_dropped` | integer | Records excluded by an Output `null_order: drop` sort field (see [Sort order](../nodes/output.md#sort-order)). Absent from spool files written before this counter existed, where it reads as `0` |
 | `execution_mode` | string | DAG-derived execution summary: `Streaming` (no full-stage materialization required) or `TwoPass` (a blocking stage forces an accumulation pass) |
 | `peak_rss_bytes` | integer/null | Peak resident set size in bytes, sampled across chunk boundaries on Linux, macOS, and Windows. `null` on platforms where RSS sampling is unavailable |
 | `thread_count` | integer | Thread pool size used |

--- a/docs/user/src/ops/metrics.md
+++ b/docs/user/src/ops/metrics.md
@@ -86,7 +86,7 @@ schema bump means draining the spool first.
 | `records_ok` | integer | Distinct source records that reached at least one output. Under inclusive Route fan-out one input matching N branches counts once |
 | `records_written` | integer | Total writes across all sinks. Equals `records_ok` for single-output exclusive pipelines; exceeds it under inclusive Route fan-out or multiple Output sinks |
 | `records_dlq` | integer | Records routed to the dead-letter queue |
-| `records_null_dropped` | integer | Records excluded by an Output `null_order: drop` sort field (see [Sort order](../nodes/output.md#sort-order)). Absent from spool files written before this counter existed, where it reads as `0` |
+| `records_null_dropped` | integer | Records excluded by an Output `null_order: drop` sort field (see [Sort order](../nodes/output.md#sort-order)). Counts exclusions, not distinct source records: like `records_written`, one source record dropped at two Outputs counts twice. Absent from spool files written before this counter existed, where it reads as `0` |
 | `execution_mode` | string | DAG-derived execution summary: `Streaming` (no full-stage materialization required) or `TwoPass` (a blocking stage forces an accumulation pass) |
 | `peak_rss_bytes` | integer/null | Peak resident set size in bytes, sampled across chunk boundaries on Linux, macOS, and Windows. `null` on platforms where RSS sampling is unavailable |
 | `thread_count` | integer | Thread pool size used |


### PR DESCRIPTION
`null_order: drop` excludes records whose sort key is null. Nothing recorded how many — but the failure was not that the number was missing. It was that a wrong one was published.

## What the stage was saying

The Sort stage computed its record counts *after* the exclusion had already happened:

```rust
input_records.retain(...);                       // records removed here
let sort_count = input_records.len() as u64;     // survivors
ctx.collector.record(sort_timer.finish(sort_count, sort_count));
```

`records_in == records_out` is the signature of a stage that discarded nothing. An operator auditing an output that came up short found no gap to follow, because the one stage that knew about the loss was describing itself as lossless. `ok_count` vs `records_written` is not a usable fallback — writer-slot drops, DLQ, and filters all confound the difference.

Both arms also returned early when nothing survived, without recording at all, so the run that dropped *every* record was the one that reported least.

## The fix

**The stage reports what it received.** The timer opens before the filter, so `records_in` is the population handed to the sort, `records_out` is what survived, and the difference is the loss. The empty-result paths report too, rather than returning silently.

**The count is also carried on its own** — `null_dropped_count` on the pipeline counters, `records_null_dropped` in the metrics spool. A difference between two stage numbers is only attributable if you already suspect this cause; a named counter answers the question without the operator having to guess it first.

It is deliberately **not** exposed as a `$pipeline.*` member. These exclusions happen at a terminal sort, so a CXL expression evaluating mid-run would read zero regardless of how many records the run eventually drops — a number that is always available and never yet true. `records_written` sets the precedent for a counter that reports without being readable mid-pipeline.

**One predicate instead of two.** The buffered and streaming sorters each spelled the drop test out. They must exclude the same records and now report the same count, so the cheapest guarantee is leaving them no way to disagree.

## Grounding

`records_null_dropped` follows `records_dlq`, the existing spelling for records that left the pipeline without reaching an output — same shape, same place in the spool, same table in the docs. It carries `#[serde(default)]` for the same reason `retraction` does: files written before it existed round-trip as zero. The docs say so explicitly, since a zero from an old file is indistinguishable from a real one.

## Tests

- The count is reported, and is identical resident and spilled, across both writer boundary modes.
- The summed Sort `records_in - records_out` equals the counter — the two independent surfaces have to agree.
- The drop is not reported as a filter or a DLQ entry.
- A sort with no dropping field reports zero and equal in/out, so a non-zero count is always attributable to an authored `null_order: drop`.

Both new assertions were verified to fail with their respective fix reverted; the zero-case guard passes either way, which is what makes it a guard against over-broadness rather than a restatement of the change.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` (5580 passed, 0 failed) are green.

## Scope

This is the observability residual of #950. The rest of that issue — wiring `sort_order` through to the writer — landed in #1051; the issue was rescoped once that was confirmed. The other two residuals are filed separately as #1068 (`--explain` renders nothing about the terminal sort) and #1069 (split-output ordering scope is untested).

Closes #950
