### PR TITLE
Stop offering dependencies the architecture forbids

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi"] }
 arc-swap = "1.9"
 static_assertions = "1"
-rfd = "0.15"
 # `pure` is misleadingly named: on blake3 1.x it does NOT mean scalar. It
 # compiles the SSE2/SSE4.1/AVX2 paths as Rust `std::arch` intrinsics and
 # dispatches them at runtime via `cpufeatures`, so source-staging copies hash
@@ -74,10 +73,7 @@ rfd = "0.15"
 # for this repo, not a performance compromise.
 blake3 = { version = "1", default-features = false, features = ["pure"] }
 uuid = { version = "1", features = ["v4"] }
-dirs = "6"
-tokio = { version = "1", features = ["time", "rt", "rt-multi-thread", "macros", "sync"] }
 crossbeam-channel = "0.5"
-notify = "7"
 # Cross-platform free-space query for the spill-volume startup preflight.
 # `available_space` wraps statvfs on unix and GetDiskFreeSpaceExW on Windows,
 # returning the bytes available to a non-privileged user. The maintained


### PR DESCRIPTION
Four `[workspace.dependencies]` entries are referenced by no crate in the workspace: `tokio`, `notify`, `rfd`, `dirs`.

None of them reaches `Cargo.lock` — a workspace declaration nothing uses is never resolved — so this removes no package from the graph and changes no build output. The lockfile is byte-identical.

## Why remove them anyway

They are not inert. They are what the next person finds already provisioned.

Clinker is finite-batch and synchronous, and `AGENTS.md` makes adding an async runtime an approval-gated architectural decision. A pre-declared `tokio` — with `rt-multi-thread`, `macros`, and `sync` already chosen — reduces that decision to `tokio = { workspace = true }`. One line in a crate manifest, no new dependency for a reviewer to notice, and the approval conversation never happens. The gate is not bypassed so much as never reached.

`notify` sets up the same move for watching a directory, which a finite-batch engine does not do. `rfd` opens a native GUI file dialog from a batch CLI.

These look like leftovers from work that went a different way. Left in place they are indistinguishable from deliberate provisioning, and that is the whole problem: a reviewer seeing `tokio = { workspace = true }` in a diff has no way to tell whether the async decision was made and approved earlier, or is being made right now.

## On the rest of the lockfile

Worth stating, since it is the obvious next question: 44 packages appear in `Cargo.lock` with no edge in any build graph — including `ring`, `rkyv`, `borsh`, and a `wasm-bindgen`/`wit-*` cluster. Those are **not** removable here. They are optional dependencies declared by third-party crates and never activated; cargo records the full resolution, not the compiled subset. `cargo tree --workspace --all-features --edges all --target all` finds none of them.

The lever that does work is `default-features = false` on our direct dependencies, which this workspace already applies to `blake3`, `smol_str`, `rust_decimal`, `fs4`, `postcard`, and `ureq` — each with a comment saying what it drops and why.

This is also why `grep ring Cargo.lock` is the wrong check for the no-C-toolchain guarantee and the `Build portability` job is the right one: one tests a proxy that is wrong in a predictable direction, the other tests the property.

## Validation

- `cargo metadata` resolves
- `cargo build --workspace --locked` clean
- `cargo test --workspace --locked` — 5581 passed, 0 failed
- `cargo run -p clinker-dependency-policy -- --scope final --root .` — passed
- `Cargo.lock` unchanged
- `git diff --check` clean
