### PR TITLE
Add bounded nested construction to CXL

### DIFF
--- a/crates/clinker-channel/src/selector.rs
+++ b/crates/clinker-channel/src/selector.rs
@@ -237,6 +237,34 @@ fn reject_non_label(expr: &Expr) -> Result<(), SelectorError> {
             reject_non_label(rhs)
         }
         Expr::Unary { operand, .. } => reject_non_label(operand),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                reject_non_label(element)?;
+            }
+            Ok(())
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    reject_non_label(key)?;
+                }
+                reject_non_label(&entry.value)?;
+            }
+            Ok(())
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            reject_non_label(source)?;
+            reject_non_label(item)?;
+            if let Some(predicate) = predicate {
+                reject_non_label(predicate)?;
+            }
+            Ok(())
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -555,6 +583,20 @@ mod tests {
         // recursive walk must still find it.
         let err = LabelSelector::compile(r#"region == "west" and $source.row == 1"#).unwrap_err();
         assert!(matches!(err, SelectorError::ForbiddenReference(_)));
+    }
+
+    #[test]
+    fn forbidden_reference_inside_nested_constructor_is_rejected() {
+        for source in [
+            r#"{ok: true, leak: $source.row} == {ok: true, leak: 1}"#,
+            r#"[item for item in [1, $record.secret]] == [1]"#,
+        ] {
+            let err = LabelSelector::compile(source).unwrap_err();
+            assert!(
+                matches!(err, SelectorError::ForbiddenReference(_)),
+                "expected nested forbidden reference in {source:?}, got {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/clinker-exec/src/aggregation/error.rs
+++ b/crates/clinker-exec/src/aggregation/error.rs
@@ -30,6 +30,19 @@ pub enum AggregateEvalError {
     /// reported via this variant rather than panicking.
     #[error("unsupported aggregate residual construct: {what}")]
     UnsupportedResidual { what: &'static str },
+    #[error("aggregate residual type mismatch: expected {expected}, got {got}")]
+    TypeMismatch {
+        expected: &'static str,
+        got: &'static str,
+    },
+    #[error("duplicate map key '{key}' in aggregate residual")]
+    DuplicateMapKey { key: String },
+    #[error("invalid nested map key '{key}' in aggregate residual: {message}")]
+    InvalidNestedKey { key: String, message: String },
+    #[error("aggregate residual nested-value construction exceeds {limit} bytes")]
+    ConstructionLimitExceeded { limit: usize },
+    #[error("aggregate residual nested-value construction exceeds depth {limit}")]
+    ConstructionDepthExceeded { limit: usize },
 }
 
 /// Errors raised by the hash aggregator hot loop. The 16.3.13 dispatch

--- a/crates/clinker-exec/src/aggregation/mod.rs
+++ b/crates/clinker-exec/src/aggregation/mod.rs
@@ -42,6 +42,7 @@ pub use spill::{AggSpillFile, SpillState};
 
 pub(crate) use hash::{empty_global_fold_row, finalize_group_inner, group_by_sort_fields};
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -50,7 +51,7 @@ use clinker_record::accumulator::{AccumulatorEnum, AccumulatorRow};
 use clinker_record::group_key::value_to_group_key;
 use clinker_record::schema::Schema;
 use clinker_record::{GroupByKey, Record, Value};
-use cxl::ast::{BinOp, Expr, LiteralValue, UnaryOp};
+use cxl::ast::{BinOp, Expr, LiteralValue, MapKey, UnaryOp};
 use cxl::eval::{CompiledScalar, EvalContext, EvalError, ProgramEvaluator, compare_values};
 use cxl::plan::{AggregateBinding, BindingArg, CompiledAggregate};
 
@@ -99,6 +100,55 @@ pub fn eval_expr_in_agg_scope(
     expr: &Expr,
     scope: &AggregateEvalScope<'_>,
 ) -> Result<Value, AggregateEvalError> {
+    let mut env = HashMap::new();
+    let mut constructed_bytes = 0;
+    let mut construction_depth = 0;
+    eval_expr_in_agg_scope_inner(
+        expr,
+        scope,
+        &mut env,
+        &mut constructed_bytes,
+        &mut construction_depth,
+    )
+}
+
+const MAX_AGG_CONSTRUCTED_BYTES: usize = 10 * 1024 * 1024;
+
+fn charge_aggregate_construction(
+    constructed_bytes: &mut usize,
+    bytes: usize,
+) -> Result<(), AggregateEvalError> {
+    let next = constructed_bytes.checked_add(bytes).ok_or(
+        AggregateEvalError::ConstructionLimitExceeded {
+            limit: MAX_AGG_CONSTRUCTED_BYTES,
+        },
+    )?;
+    if next > MAX_AGG_CONSTRUCTED_BYTES {
+        return Err(AggregateEvalError::ConstructionLimitExceeded {
+            limit: MAX_AGG_CONSTRUCTED_BYTES,
+        });
+    }
+    *constructed_bytes = next;
+    Ok(())
+}
+
+fn enter_aggregate_construction(depth: &mut usize) -> Result<(), AggregateEvalError> {
+    if *depth >= clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+        return Err(AggregateEvalError::ConstructionDepthExceeded {
+            limit: clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH,
+        });
+    }
+    *depth += 1;
+    Ok(())
+}
+
+fn eval_expr_in_agg_scope_inner(
+    expr: &Expr,
+    scope: &AggregateEvalScope<'_>,
+    env: &mut HashMap<String, Value>,
+    constructed_bytes: &mut usize,
+    construction_depth: &mut usize,
+) -> Result<Value, AggregateEvalError> {
     match expr {
         Expr::AggSlot { slot, .. } => {
             scope
@@ -119,19 +169,206 @@ pub fn eval_expr_in_agg_scope(
                 key_count: scope.key.len(),
             }),
         Expr::Literal { value, .. } => Ok(literal_to_value(value)),
+        Expr::ArrayLiteral { elements, .. } => {
+            enter_aggregate_construction(construction_depth)?;
+            let result = (|| {
+                charge_aggregate_construction(
+                    constructed_bytes,
+                    elements.len() * std::mem::size_of::<Value>(),
+                )?;
+                let mut values = Vec::with_capacity(elements.len());
+                for element in elements {
+                    let value = eval_expr_in_agg_scope_inner(
+                        element,
+                        scope,
+                        env,
+                        constructed_bytes,
+                        construction_depth,
+                    )?;
+                    charge_aggregate_construction(constructed_bytes, value.heap_size())?;
+                    values.push(value);
+                }
+                Ok(Value::Array(values))
+            })();
+            *construction_depth -= 1;
+            result
+        }
+        Expr::MapLiteral { entries, .. } => {
+            enter_aggregate_construction(construction_depth)?;
+            let result = (|| {
+                let entry_bytes = std::mem::size_of::<Box<str>>()
+                    + std::mem::size_of::<Value>()
+                    + std::mem::size_of::<u64>()
+                    + std::mem::size_of::<usize>();
+                charge_aggregate_construction(constructed_bytes, entries.len() * entry_bytes)?;
+                let mut values: indexmap::IndexMap<Box<str>, Value> =
+                    indexmap::IndexMap::with_capacity(entries.len());
+                for entry in entries {
+                    let key: Box<str> = match &entry.key {
+                        MapKey::Static(key) => key.clone(),
+                        MapKey::Computed(key) => match eval_expr_in_agg_scope_inner(
+                            key,
+                            scope,
+                            env,
+                            constructed_bytes,
+                            construction_depth,
+                        )? {
+                            Value::String(key) => key.as_str().into(),
+                            other => {
+                                return Err(AggregateEvalError::TypeMismatch {
+                                    expected: "non-null String map key",
+                                    got: other.type_name(),
+                                });
+                            }
+                        },
+                    };
+                    charge_aggregate_construction(constructed_bytes, key.len())?;
+                    let decoded =
+                        clinker_record::nested_key::NestedKey::decode(&key).map_err(|error| {
+                            AggregateEvalError::InvalidNestedKey {
+                                key: key.to_string(),
+                                message: error.to_string(),
+                            }
+                        })?;
+                    let logical_key = decoded.text.as_ref();
+                    if values.keys().any(|prior| {
+                        clinker_record::nested_key::NestedKey::decode(prior)
+                            .expect("previous keys were validated before insertion")
+                            .text
+                            == logical_key
+                    }) {
+                        return Err(AggregateEvalError::DuplicateMapKey {
+                            key: logical_key.to_string(),
+                        });
+                    }
+                    let value = eval_expr_in_agg_scope_inner(
+                        &entry.value,
+                        scope,
+                        env,
+                        constructed_bytes,
+                        construction_depth,
+                    )?;
+                    charge_aggregate_construction(constructed_bytes, value.heap_size())?;
+                    values.insert(key, value);
+                }
+                Ok(Value::Map(Box::new(values)))
+            })();
+            *construction_depth -= 1;
+            result
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            enter_aggregate_construction(construction_depth)?;
+            let source = eval_expr_in_agg_scope_inner(
+                source,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            );
+            let source = match source {
+                Ok(source) => source,
+                Err(error) => {
+                    *construction_depth -= 1;
+                    return Err(error);
+                }
+            };
+            let Value::Array(source_values) = source else {
+                *construction_depth -= 1;
+                return Err(AggregateEvalError::TypeMismatch {
+                    expected: "Array comprehension source",
+                    got: source.type_name(),
+                });
+            };
+            charge_aggregate_construction(
+                constructed_bytes,
+                source_values.len() * std::mem::size_of::<Value>(),
+            )?;
+            let previous = env.remove(binding.as_ref());
+            let result = (|| {
+                let mut values = Vec::with_capacity(source_values.len());
+                for source_value in source_values {
+                    env.insert(binding.to_string(), source_value);
+                    if let Some(predicate) = predicate {
+                        match eval_expr_in_agg_scope_inner(
+                            predicate,
+                            scope,
+                            env,
+                            constructed_bytes,
+                            construction_depth,
+                        )? {
+                            Value::Bool(true) => {}
+                            Value::Bool(false) => continue,
+                            other => {
+                                return Err(AggregateEvalError::TypeMismatch {
+                                    expected: "Bool comprehension predicate",
+                                    got: other.type_name(),
+                                });
+                            }
+                        }
+                    }
+                    let value = eval_expr_in_agg_scope_inner(
+                        item,
+                        scope,
+                        env,
+                        constructed_bytes,
+                        construction_depth,
+                    )?;
+                    charge_aggregate_construction(constructed_bytes, value.heap_size())?;
+                    values.push(value);
+                }
+                Ok(Value::Array(values))
+            })();
+            if let Some(previous) = previous {
+                env.insert(binding.to_string(), previous);
+            } else {
+                env.remove(binding.as_ref());
+            }
+            *construction_depth -= 1;
+            result
+        }
         Expr::Binary { op, lhs, rhs, .. } => {
-            let l = eval_expr_in_agg_scope(lhs, scope)?;
-            let r = eval_expr_in_agg_scope(rhs, scope)?;
+            let l = eval_expr_in_agg_scope_inner(
+                lhs,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
+            let r = eval_expr_in_agg_scope_inner(
+                rhs,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
             eval_binary(*op, l, r)
         }
         Expr::Unary { op, operand, .. } => {
-            let v = eval_expr_in_agg_scope(operand, scope)?;
+            let v = eval_expr_in_agg_scope_inner(
+                operand,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
             eval_unary(*op, v)
         }
         Expr::Coalesce { lhs, rhs, .. } => {
-            let l = eval_expr_in_agg_scope(lhs, scope)?;
+            let l = eval_expr_in_agg_scope_inner(
+                lhs,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
             if matches!(l, Value::Null) {
-                eval_expr_in_agg_scope(rhs, scope)
+                eval_expr_in_agg_scope_inner(rhs, scope, env, constructed_bytes, construction_depth)
             } else {
                 Ok(l)
             }
@@ -142,17 +379,33 @@ pub fn eval_expr_in_agg_scope(
             else_branch,
             ..
         } => {
-            let c = eval_expr_in_agg_scope(condition, scope)?;
+            let c = eval_expr_in_agg_scope_inner(
+                condition,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
             if matches!(c, Value::Bool(true)) {
-                eval_expr_in_agg_scope(then_branch, scope)
+                eval_expr_in_agg_scope_inner(
+                    then_branch,
+                    scope,
+                    env,
+                    constructed_bytes,
+                    construction_depth,
+                )
             } else if let Some(e) = else_branch {
-                eval_expr_in_agg_scope(e, scope)
+                eval_expr_in_agg_scope_inner(e, scope, env, constructed_bytes, construction_depth)
             } else {
                 Ok(Value::Null)
             }
         }
         Expr::Now { .. } => Err(AggregateEvalError::UnsupportedResidual { what: "now" }),
-        Expr::FieldRef { .. } | Expr::QualifiedFieldRef { .. } => {
+        Expr::FieldRef { name, .. } => env
+            .get(name.as_ref())
+            .cloned()
+            .ok_or(AggregateEvalError::UnsupportedResidual { what: "field-ref" }),
+        Expr::QualifiedFieldRef { .. } => {
             Err(AggregateEvalError::UnsupportedResidual { what: "field-ref" })
         }
         Expr::PipelineAccess { .. }
@@ -1170,9 +1423,99 @@ impl<Op: AccumulatorOp> StreamingAggregator<Op> {
 mod accumulator_op_tests {
     use super::*;
     use clinker_record::accumulator::{AccumulatorEnum, AggregateType};
+    use cxl::ast::Statement;
+    use cxl::parser::Parser;
+
+    fn parsed_emit_expr(source: &str) -> Expr {
+        let parsed = Parser::parse(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let Statement::Emit { expr, .. } = parsed.ast.statements.into_iter().next().unwrap() else {
+            panic!("expected emit statement");
+        };
+        expr
+    }
 
     fn state_with_row(row: AccumulatorRow) -> AggregatorGroupState {
         AggregatorGroupState::new(row)
+    }
+
+    #[test]
+    fn aggregate_residual_nested_constructors_preserve_order_and_bindings() {
+        let expr = parsed_emit_expr(
+            "emit payload = {items: [item * 2 for item in [3, -1, 2] if item > 0], tail: null}",
+        );
+        let value = eval_expr_in_agg_scope(
+            &expr,
+            &AggregateEvalScope {
+                key: &[],
+                slots: &[],
+            },
+        )
+        .unwrap();
+        let Value::Map(map) = value else {
+            panic!("expected map");
+        };
+        assert_eq!(
+            map.keys().map(|key| key.as_ref()).collect::<Vec<_>>(),
+            vec!["items", "tail"]
+        );
+        assert_eq!(
+            map["items"],
+            Value::Array(vec![Value::Integer(6), Value::Integer(4)])
+        );
+    }
+
+    #[test]
+    fn aggregate_residual_rejects_duplicate_logical_computed_key() {
+        let expr = parsed_emit_expr(r#"emit payload = {"@id": 1, ["\\@id"]: 2}"#);
+        let error = eval_expr_in_agg_scope(
+            &expr,
+            &AggregateEvalScope {
+                key: &[],
+                slots: &[],
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            AggregateEvalError::DuplicateMapKey { ref key } if key == "@id"
+        ));
+    }
+
+    #[test]
+    fn aggregate_residual_enforces_construction_depth_and_byte_caps() {
+        let source = format!(
+            "emit payload = {}null{}",
+            "[".repeat(clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH + 1),
+            "]".repeat(clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH + 1)
+        );
+        let expr = parsed_emit_expr(&source);
+        let error = eval_expr_in_agg_scope(
+            &expr,
+            &AggregateEvalScope {
+                key: &[],
+                slots: &[],
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            AggregateEvalError::ConstructionDepthExceeded { limit }
+                if limit == clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH
+        ));
+
+        let mut bytes = 0;
+        charge_aggregate_construction(&mut bytes, MAX_AGG_CONSTRUCTED_BYTES).unwrap();
+        assert!(matches!(
+            charge_aggregate_construction(&mut bytes, 1),
+            Err(AggregateEvalError::ConstructionLimitExceeded { limit })
+                if limit == MAX_AGG_CONSTRUCTED_BYTES
+        ));
+        assert_eq!(bytes, MAX_AGG_CONSTRUCTED_BYTES);
     }
 
     // ----- merge_group_sidecars -----

--- a/crates/clinker-exec/src/pipeline/combine.rs
+++ b/crates/clinker-exec/src/pipeline/combine.rs
@@ -412,7 +412,7 @@ pub enum CombineError {
     /// Key-expression evaluation failed. `side` is `"driving"` or
     /// `"build"` so the executor can produce an accurate diagnostic.
     KeyEvalFailed {
-        source: EvalError,
+        source: Box<EvalError>,
         side: &'static str,
     },
 
@@ -447,7 +447,7 @@ impl std::fmt::Display for CombineError {
 impl std::error::Error for CombineError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            CombineError::KeyEvalFailed { source, .. } => Some(source),
+            CombineError::KeyEvalFailed { source, .. } => Some(source.as_ref()),
             _ => None,
         }
     }
@@ -712,7 +712,7 @@ impl CombineHashTable {
             let keys = extractor
                 .extract(ctx, &rec)
                 .map_err(|e| CombineError::KeyEvalFailed {
-                    source: e,
+                    source: Box::new(e),
                     side: "build",
                 })?;
 

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -1579,6 +1579,31 @@ fn collect_agg_leaves<'a>(expr: &'a Expr, out: &mut Vec<AggLeaf<'a>>) {
             collect_agg_leaves(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_agg_leaves(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_agg_leaves(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_agg_leaves(key, out);
+                }
+                collect_agg_leaves(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_agg_leaves(source, out);
+            collect_agg_leaves(item, out);
+            if let Some(predicate) = predicate {
+                collect_agg_leaves(predicate, out);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -1714,6 +1739,31 @@ fn collect_field_refs(expr: &Expr, out: &mut Vec<QualifiedField>) {
             collect_field_refs(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_field_refs(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_field_refs(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_field_refs(key, out);
+                }
+                collect_field_refs(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_field_refs(source, out);
+            collect_field_refs(item, out);
+            if let Some(predicate) = predicate {
+                collect_field_refs(predicate, out);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -1793,6 +1843,31 @@ fn collect_doc_paths_in_expr(expr: &Expr, out: &mut Vec<DocPath>) {
             collect_doc_paths_in_expr(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_doc_paths_in_expr(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_doc_paths_in_expr(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_doc_paths_in_expr(key, out);
+                }
+                collect_doc_paths_in_expr(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_doc_paths_in_expr(source, out);
+            collect_doc_paths_in_expr(item, out);
+            if let Some(predicate) = predicate {
+                collect_doc_paths_in_expr(predicate, out);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -2530,6 +2605,52 @@ nodes:
                 namespace: "file".to_string(),
                 name: src.to_string(),
             }]
+        );
+    }
+
+    #[test]
+    fn transform_nested_constructor_dependencies_are_direct_lineage() {
+        let yaml = r#"
+pipeline: { name: nested_lineage }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: data/rows.csv
+      schema:
+        - { name: dept, type: string }
+        - { name: amount, type: int }
+        - { name: score, type: int }
+        - { name: region, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        emit payload = {
+          dept: dept,
+          values: [item + amount for item in [score] if region == "west"],
+        }
+  - type: output
+    name: out
+    input: construct
+    config: { name: out, type: json, path: out/nested.json, include_unmapped: false }
+"#;
+        let lineage = lineage_of(yaml);
+        let source = "/w/data/rows.csv";
+        let fields = &only_output(&lineage).facet.fields;
+        use TransformationSubtype::Transformation;
+        assert_field(
+            fields,
+            "payload",
+            &[
+                direct(source, "amount", Transformation),
+                direct(source, "dept", Transformation),
+                direct(source, "region", Transformation),
+                direct(source, "score", Transformation),
+            ],
         );
     }
 

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1082,6 +1082,31 @@ fn collect_scope_reads_in_expr(expr: &Expr, out: &mut Vec<(crate::config::VarSco
             collect_scope_reads_in_expr(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_scope_reads_in_expr(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_scope_reads_in_expr(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_scope_reads_in_expr(key, out);
+                }
+                collect_scope_reads_in_expr(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_scope_reads_in_expr(source, out);
+            collect_scope_reads_in_expr(item, out);
+            if let Some(predicate) = predicate {
+                collect_scope_reads_in_expr(predicate, out);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -5441,6 +5466,22 @@ fn first_body_field_ref(expr: &Expr) -> Option<String> {
             first_body_field_ref(lhs).or_else(|| first_body_field_ref(rhs))
         }
         Expr::Unary { operand, .. } => first_body_field_ref(operand),
+        Expr::ArrayLiteral { elements, .. } => elements.iter().find_map(first_body_field_ref),
+        Expr::MapLiteral { entries, .. } => entries.iter().find_map(|entry| {
+            match &entry.key {
+                cxl::ast::MapKey::Computed(key) => first_body_field_ref(key),
+                cxl::ast::MapKey::Static(_) => None,
+            }
+            .or_else(|| first_body_field_ref(&entry.value))
+        }),
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => first_body_field_ref(source)
+            .or_else(|| first_body_field_ref(item))
+            .or_else(|| predicate.as_deref().and_then(first_body_field_ref)),
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -6445,6 +6486,31 @@ fn walk_for_unknown_refs(expr: &Expr, cx: CombineWalkContext<'_>, diags: &mut Ve
             walk_for_unknown_refs(rhs, cx, diags);
         }
         Expr::Unary { operand, .. } => walk_for_unknown_refs(operand, cx, diags),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                walk_for_unknown_refs(element, cx, diags);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    walk_for_unknown_refs(key, cx, diags);
+                }
+                walk_for_unknown_refs(&entry.value, cx, diags);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            walk_for_unknown_refs(source, cx, diags);
+            walk_for_unknown_refs(item, cx, diags);
+            if let Some(predicate) = predicate {
+                walk_for_unknown_refs(predicate, cx, diags);
+            }
+        }
         Expr::Coalesce { lhs, rhs, .. } => {
             walk_for_unknown_refs(lhs, cx, diags);
             walk_for_unknown_refs(rhs, cx, diags);

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -458,6 +458,31 @@ fn collect_qualifiers_inner(expr: &Expr, out: &mut HashSet<Arc<str>>) {
             collect_qualifiers_inner(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_qualifiers_inner(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_qualifiers_inner(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_qualifiers_inner(key, out);
+                }
+                collect_qualifiers_inner(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_qualifiers_inner(source, out);
+            collect_qualifiers_inner(item, out);
+            if let Some(predicate) = predicate {
+                collect_qualifiers_inner(predicate, out);
+            }
+        }
         Expr::Coalesce { lhs, rhs, .. } => {
             collect_qualifiers_inner(lhs, out);
             collect_qualifiers_inner(rhs, out);

--- a/crates/clinker-plan/src/resources/mod.rs
+++ b/crates/clinker-plan/src/resources/mod.rs
@@ -936,6 +936,46 @@ impl SemanticModuleHasher {
                 self.tag(2);
                 self.literal(value);
             }
+            Expr::ArrayLiteral { elements, .. } => {
+                self.tag(24);
+                self.expression_list(elements);
+            }
+            Expr::MapLiteral { entries, .. } => {
+                self.tag(25);
+                self.usize(entries.len());
+                for entry in entries {
+                    match &entry.key {
+                        cxl::ast::MapKey::Static(key) => {
+                            self.tag(0);
+                            self.string(key);
+                        }
+                        cxl::ast::MapKey::Computed(key) => {
+                            self.tag(1);
+                            self.expression(key);
+                        }
+                    }
+                    self.expression(&entry.value);
+                }
+            }
+            Expr::ArrayComprehension {
+                item,
+                binding,
+                source,
+                predicate,
+                ..
+            } => {
+                self.tag(26);
+                self.expression(item);
+                self.string(binding);
+                self.expression(source);
+                match predicate {
+                    Some(predicate) => {
+                        self.tag(1);
+                        self.expression(predicate);
+                    }
+                    None => self.tag(0),
+                }
+            }
             Expr::FieldRef { name, .. } => {
                 self.tag(3);
                 self.string(name);
@@ -1143,4 +1183,30 @@ fn semantic_module_digest(module: &Module) -> [u8; 32] {
     }
 
     hasher.finish()
+}
+
+#[cfg(test)]
+mod semantic_nested_value_tests {
+    use super::*;
+    use cxl::parser::Parser;
+
+    fn digest(source: &str) -> [u8; 32] {
+        let parsed = Parser::parse_module(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        semantic_module_digest(&parsed.module)
+    }
+
+    #[test]
+    fn nested_constructor_identity_ignores_layout_but_preserves_author_order() {
+        let compact = digest("let PAYLOAD = {first: [1, 2], last: [x for x in [3, 4]]}");
+        let multiline =
+            digest("let PAYLOAD = {\n  first: [1, 2],\n  last: [x for x in [3, 4]],\n}");
+        let reordered = digest("let PAYLOAD = {last: [x for x in [3, 4]], first: [1, 2]}");
+        assert_eq!(compact, multiline);
+        assert_ne!(compact, reordered, "map insertion order is semantic");
+    }
 }

--- a/crates/clinker-record/src/lib.rs
+++ b/crates/clinker-record/src/lib.rs
@@ -7,6 +7,7 @@ pub mod field_path;
 pub mod field_str;
 pub mod group_key;
 pub mod minimal;
+pub mod nested_key;
 pub mod provenance;
 pub mod record;
 pub mod record_view;

--- a/crates/clinker-record/src/nested_key.rs
+++ b/crates/clinker-record/src/nested_key.rs
@@ -1,0 +1,222 @@
+//! Canonical escaping and depth limits for nested neutral values.
+
+use std::borrow::Cow;
+
+use crate::Value;
+
+/// Maximum number of nested array/map containers accepted by CXL and native
+/// recursive writers.
+pub const MAX_NESTED_VALUE_DEPTH: usize = 64;
+
+/// A decoded neutral map key. `escaped` distinguishes a literal key from an
+/// unescaped spelling that a format may assign a structural role.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NestedKey<'a> {
+    pub text: Cow<'a, str>,
+    pub escaped: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NestedKeyError {
+    NonCanonicalEscape { key: String },
+    DuplicateLogicalKey { key: String },
+    DepthExceeded { depth: usize, limit: usize },
+}
+
+impl std::fmt::Display for NestedKeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonCanonicalEscape { key } => write!(
+                f,
+                "non-canonical nested key escape in {key:?}; only `\\@...`, `\\#text`, and `\\\\...` are valid escaped forms"
+            ),
+            Self::DuplicateLogicalKey { key } => {
+                write!(f, "duplicate logical nested key {key:?}")
+            }
+            Self::DepthExceeded { depth, limit } => {
+                write!(
+                    f,
+                    "nested value depth {depth} exceeds the maximum of {limit}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for NestedKeyError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NestedDepthError {
+    pub depth: usize,
+    pub limit: usize,
+}
+
+impl std::fmt::Display for NestedDepthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "nested value depth {} exceeds the maximum of {}",
+            self.depth, self.limit
+        )
+    }
+}
+
+impl std::error::Error for NestedDepthError {}
+
+impl<'a> NestedKey<'a> {
+    /// Decode one canonical key spelling without interpreting format roles.
+    pub fn decode(key: &'a str) -> Result<Self, NestedKeyError> {
+        let Some(rest) = key.strip_prefix('\\') else {
+            return Ok(Self {
+                text: Cow::Borrowed(key),
+                escaped: false,
+            });
+        };
+        if rest.starts_with('@') || rest == "#text" || rest.starts_with('\\') {
+            Ok(Self {
+                text: Cow::Borrowed(rest),
+                escaped: true,
+            })
+        } else {
+            Err(NestedKeyError::NonCanonicalEscape {
+                key: key.to_string(),
+            })
+        }
+    }
+
+    /// Return the unique canonical spelling for a literal logical key.
+    pub fn encode_literal(key: &'a str) -> Cow<'a, str> {
+        if key.starts_with('@') || key == "#text" || key.starts_with('\\') {
+            Cow::Owned(format!("\\{key}"))
+        } else {
+            Cow::Borrowed(key)
+        }
+    }
+}
+
+/// Validate the shared nested depth cap iteratively. Scalars have depth zero;
+/// each array or map container adds one level.
+pub fn validate_nested_depth(value: &Value) -> Result<(), NestedDepthError> {
+    fn visit(value: &Value, depth: usize) -> Result<(), NestedDepthError> {
+        match value {
+            Value::Array(values) => {
+                let next = depth + 1;
+                if next > MAX_NESTED_VALUE_DEPTH {
+                    return Err(NestedDepthError {
+                        depth: next,
+                        limit: MAX_NESTED_VALUE_DEPTH,
+                    });
+                }
+                for value in values {
+                    visit(value, next)?;
+                }
+            }
+            Value::Map(values) => {
+                let next = depth + 1;
+                if next > MAX_NESTED_VALUE_DEPTH {
+                    return Err(NestedDepthError {
+                        depth: next,
+                        limit: MAX_NESTED_VALUE_DEPTH,
+                    });
+                }
+                for value in values.values() {
+                    visit(value, next)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    visit(value, 0)
+}
+
+/// Validate canonical key spellings throughout a neutral value tree.
+pub fn validate_nested_keys(value: &Value) -> Result<(), NestedKeyError> {
+    fn visit(value: &Value, depth: usize) -> Result<(), NestedKeyError> {
+        match value {
+            Value::Array(values) => {
+                let next = depth + 1;
+                if next > MAX_NESTED_VALUE_DEPTH {
+                    return Err(NestedKeyError::DepthExceeded {
+                        depth: next,
+                        limit: MAX_NESTED_VALUE_DEPTH,
+                    });
+                }
+                for value in values {
+                    visit(value, next)?;
+                }
+            }
+            Value::Map(values) => {
+                let next = depth + 1;
+                if next > MAX_NESTED_VALUE_DEPTH {
+                    return Err(NestedKeyError::DepthExceeded {
+                        depth: next,
+                        limit: MAX_NESTED_VALUE_DEPTH,
+                    });
+                }
+                for (position, (key, value)) in values.iter().enumerate() {
+                    let decoded = NestedKey::decode(key)?;
+                    for prior in values.keys().take(position) {
+                        if NestedKey::decode(prior)?.text == decoded.text {
+                            return Err(NestedKeyError::DuplicateLogicalKey {
+                                key: decoded.text.into_owned(),
+                            });
+                        }
+                    }
+                    visit(value, next)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    visit(value, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_key_escapes_round_trip() {
+        for logical in ["name", "@id", "#text", "\\leading"] {
+            let encoded = NestedKey::encode_literal(logical);
+            let decoded = NestedKey::decode(&encoded).unwrap();
+            assert_eq!(decoded.text, logical);
+            assert_eq!(decoded.escaped, encoded != logical);
+        }
+    }
+
+    #[test]
+    fn noncanonical_escape_is_rejected() {
+        assert!(NestedKey::decode("\\ordinary").is_err());
+        assert!(NestedKey::decode("\\#other").is_err());
+    }
+
+    #[test]
+    fn duplicate_logical_keys_are_rejected_after_escape_decoding() {
+        let mut values = indexmap::IndexMap::new();
+        values.insert("@id".into(), Value::Integer(1));
+        values.insert("\\@id".into(), Value::Integer(2));
+        let value = Value::Map(Box::new(values));
+        assert_eq!(
+            validate_nested_keys(&value),
+            Err(NestedKeyError::DuplicateLogicalKey { key: "@id".into() })
+        );
+    }
+
+    #[test]
+    fn depth_cap_accepts_cap_and_rejects_cap_plus_one() {
+        fn nested(depth: usize) -> Value {
+            let mut value = Value::Null;
+            for _ in 0..depth {
+                value = Value::Array(vec![value]);
+            }
+            value
+        }
+        assert!(validate_nested_depth(&nested(MAX_NESTED_VALUE_DEPTH)).is_ok());
+        assert!(validate_nested_depth(&nested(MAX_NESTED_VALUE_DEPTH + 1)).is_err());
+    }
+}

--- a/crates/clinker/src/refactor.rs
+++ b/crates/clinker/src/refactor.rs
@@ -724,6 +724,31 @@ fn collect_qualifier_ranges_expr(
         Expr::Unary { operand, .. } => {
             collect_qualifier_ranges_expr(operand, old, offset, src_len, out)
         }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_qualifier_ranges_expr(element, old, offset, src_len, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_qualifier_ranges_expr(key, old, offset, src_len, out);
+                }
+                collect_qualifier_ranges_expr(&entry.value, old, offset, src_len, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_qualifier_ranges_expr(source, old, offset, src_len, out);
+            collect_qualifier_ranges_expr(item, old, offset, src_len, out);
+            if let Some(predicate) = predicate {
+                collect_qualifier_ranges_expr(predicate, old, offset, src_len, out);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             collect_qualifier_ranges_expr(receiver, old, offset, src_len, out);
             for a in args {

--- a/crates/cxl-cli/src/main.rs
+++ b/crates/cxl-cli/src/main.rs
@@ -640,11 +640,54 @@ fn format_expr(expr: &cxl::ast::Expr) -> String {
         cxl::ast::Expr::Literal { value, .. } => match value {
             cxl::ast::LiteralValue::Int(n) => n.to_string(),
             cxl::ast::LiteralValue::Float(f) => f.to_string(),
-            cxl::ast::LiteralValue::String(s) => format!("\"{}\"", s),
+            cxl::ast::LiteralValue::String(s) => format!("{s:?}"),
             cxl::ast::LiteralValue::Date(d) => format!("#{}", d.format("%Y-%m-%d")),
             cxl::ast::LiteralValue::Bool(b) => b.to_string(),
             cxl::ast::LiteralValue::Null => "null".into(),
         },
+        cxl::ast::Expr::ArrayLiteral { elements, .. } => format!(
+            "[{}]",
+            elements
+                .iter()
+                .map(format_expr)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        cxl::ast::Expr::MapLiteral { entries, .. } => format!(
+            "{{{}}}",
+            entries
+                .iter()
+                .map(|entry| {
+                    let key = match &entry.key {
+                        cxl::ast::MapKey::Static(key) => format!("{key:?}"),
+                        cxl::ast::MapKey::Computed(key) => {
+                            format!("[{}]", format_expr(key))
+                        }
+                    };
+                    format!("{key}: {}", format_expr(&entry.value))
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        cxl::ast::Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            let mut formatted = format!(
+                "[{} for {} in {}",
+                format_expr(item),
+                binding,
+                format_expr(source)
+            );
+            if let Some(predicate) = predicate {
+                formatted.push_str(&format!(" if {}", format_expr(predicate)));
+            }
+            formatted.push(']');
+            formatted
+        }
         cxl::ast::Expr::FieldRef { name, .. } => name.to_string(),
         cxl::ast::Expr::QualifiedFieldRef { parts, .. } => {
             parts.iter().map(|p| &**p).collect::<Vec<_>>().join(".")
@@ -940,5 +983,21 @@ mod tests {
         // format_statement should normalize whitespace
         let formatted = format_statement(&parsed.ast.statements[0]);
         assert!(formatted.contains("emit x = 1 + 2"));
+    }
+
+    #[test]
+    fn test_cxl_fmt_nested_constructors_are_canonical_and_reparse() {
+        let source = r##"emit payload = {
+  "@kind": "event",
+  items: [item * 2 for item in values if item > 0],
+}"##;
+        let parsed = cxl::parser::Parser::parse(source);
+        assert!(parsed.errors.is_empty());
+        let formatted = format_statement(&parsed.ast.statements[0]);
+        assert_eq!(
+            formatted,
+            r#"emit payload = {"@kind": "event", "items": [item * 2 for item in values if item > 0]}"#
+        );
+        assert!(cxl::parser::Parser::parse(&formatted).errors.is_empty());
     }
 }

--- a/crates/cxl/src/analyzer/mod.rs
+++ b/crates/cxl/src/analyzer/mod.rs
@@ -306,6 +306,20 @@ mod tests {
     }
 
     #[test]
+    fn nested_constructors_keep_all_value_dependencies_visible() {
+        let typed = compile(
+            "emit payload = {dept: dept, values: [item + amount for item in [score] if region == \"west\"]}",
+        );
+        let analysis = analyze_transform("test", &typed);
+        for field in ["dept", "amount", "score", "region"] {
+            assert!(
+                analysis.accessed_fields.contains(field),
+                "nested value dependency {field:?} must remain visible"
+            );
+        }
+    }
+
+    #[test]
     fn test_analyzer_aggregate_window() {
         let typed = compile("emit total = $window.sum(amount)");
         let analysis = analyze_transform("test", &typed);

--- a/crates/cxl/src/analyzer/visitor.rs
+++ b/crates/cxl/src/analyzer/visitor.rs
@@ -86,6 +86,31 @@ pub fn walk_expr<V: Visitor + ?Sized>(visitor: &mut V, expr: &Expr) {
             visitor.visit_expr(rhs);
         }
         Expr::Unary { operand, .. } => visitor.visit_expr(operand),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                visitor.visit_expr(element);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let crate::ast::MapKey::Computed(key) = &entry.key {
+                    visitor.visit_expr(key);
+                }
+                visitor.visit_expr(&entry.value);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            visitor.visit_expr(item);
+            visitor.visit_expr(source);
+            if let Some(predicate) = predicate {
+                visitor.visit_expr(predicate);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             visitor.visit_expr(receiver);
             for arg in args {

--- a/crates/cxl/src/ast.rs
+++ b/crates/cxl/src/ast.rs
@@ -190,6 +190,27 @@ pub enum Expr {
         value: LiteralValue,
         span: Span,
     },
+    /// Ordered array construction: `[expr, ...]`.
+    ArrayLiteral {
+        node_id: NodeId,
+        elements: Vec<Expr>,
+        span: Span,
+    },
+    /// Insertion-ordered map construction: `{ key: expr, [expr]: expr }`.
+    MapLiteral {
+        node_id: NodeId,
+        entries: Vec<MapEntry>,
+        span: Span,
+    },
+    /// Single-clause array comprehension: `[item for binding in source if predicate]`.
+    ArrayComprehension {
+        node_id: NodeId,
+        item: Box<Expr>,
+        binding: Box<str>,
+        source: Box<Expr>,
+        predicate: Option<Box<Expr>>,
+        span: Span,
+    },
     FieldRef {
         node_id: NodeId,
         name: Box<str>,
@@ -378,6 +399,21 @@ pub enum Expr {
     },
 }
 
+/// One entry in a map literal, retained in author order.
+#[derive(Debug, Clone)]
+pub struct MapEntry {
+    pub key: MapKey,
+    pub value: Expr,
+    pub span: Span,
+}
+
+/// A map key is either author text or a computed string expression.
+#[derive(Debug, Clone)]
+pub enum MapKey {
+    Static(Box<str>),
+    Computed(Box<Expr>),
+}
+
 impl Expr {
     /// Get the span of this expression.
     pub fn span(&self) -> Span {
@@ -385,6 +421,9 @@ impl Expr {
             Expr::Binary { span, .. }
             | Expr::Unary { span, .. }
             | Expr::Literal { span, .. }
+            | Expr::ArrayLiteral { span, .. }
+            | Expr::MapLiteral { span, .. }
+            | Expr::ArrayComprehension { span, .. }
             | Expr::FieldRef { span, .. }
             | Expr::QualifiedFieldRef { span, .. }
             | Expr::MethodCall { span, .. }
@@ -415,6 +454,9 @@ impl Expr {
             Expr::Binary { node_id, .. }
             | Expr::Unary { node_id, .. }
             | Expr::Literal { node_id, .. }
+            | Expr::ArrayLiteral { node_id, .. }
+            | Expr::MapLiteral { node_id, .. }
+            | Expr::ArrayComprehension { node_id, .. }
             | Expr::FieldRef { node_id, .. }
             | Expr::QualifiedFieldRef { node_id, .. }
             | Expr::MethodCall { node_id, .. }
@@ -475,6 +517,31 @@ impl Expr {
                 rhs.support_into(fields);
             }
             Expr::Unary { operand, .. } => operand.support_into(fields),
+            Expr::ArrayLiteral { elements, .. } => {
+                for element in elements {
+                    element.support_into(fields);
+                }
+            }
+            Expr::MapLiteral { entries, .. } => {
+                for entry in entries {
+                    if let MapKey::Computed(key) = &entry.key {
+                        key.support_into(fields);
+                    }
+                    entry.value.support_into(fields);
+                }
+            }
+            Expr::ArrayComprehension {
+                item,
+                source,
+                predicate,
+                ..
+            } => {
+                source.support_into(fields);
+                item.support_into(fields);
+                if let Some(predicate) = predicate {
+                    predicate.support_into(fields);
+                }
+            }
             Expr::IfThenElse {
                 condition,
                 then_branch,
@@ -647,6 +714,31 @@ fn fold_config_expr(expr: &mut Expr, resolve: &impl Fn(&str) -> Option<LiteralVa
             fold_config_expr(rhs, resolve);
         }
         Expr::Unary { operand, .. } => fold_config_expr(operand, resolve),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                fold_config_expr(element, resolve);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    fold_config_expr(key, resolve);
+                }
+                fold_config_expr(&mut entry.value, resolve);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            fold_config_expr(item, resolve);
+            fold_config_expr(source, resolve);
+            if let Some(predicate) = predicate {
+                fold_config_expr(predicate, resolve);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             fold_config_expr(receiver, resolve);
             for a in args.iter_mut() {
@@ -742,6 +834,39 @@ pub fn offset_node_ids(expr: &mut Expr, base: u32) {
         } => {
             shift(node_id, base);
             offset_node_ids(operand, base);
+        }
+        Expr::ArrayLiteral {
+            node_id, elements, ..
+        } => {
+            shift(node_id, base);
+            for element in elements {
+                offset_node_ids(element, base);
+            }
+        }
+        Expr::MapLiteral {
+            node_id, entries, ..
+        } => {
+            shift(node_id, base);
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    offset_node_ids(key, base);
+                }
+                offset_node_ids(&mut entry.value, base);
+            }
+        }
+        Expr::ArrayComprehension {
+            node_id,
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            shift(node_id, base);
+            offset_node_ids(item, base);
+            offset_node_ids(source, base);
+            if let Some(predicate) = predicate {
+                offset_node_ids(predicate, base);
+            }
         }
         Expr::MethodCall {
             node_id,
@@ -857,6 +982,36 @@ pub fn rebase_expr_spans(expr: &mut Expr, delta: u32) {
         Expr::Unary { span, operand, .. } => {
             shift(span, delta);
             rebase_expr_spans(operand, delta);
+        }
+        Expr::ArrayLiteral { span, elements, .. } => {
+            shift(span, delta);
+            for element in elements {
+                rebase_expr_spans(element, delta);
+            }
+        }
+        Expr::MapLiteral { span, entries, .. } => {
+            shift(span, delta);
+            for entry in entries {
+                shift(&mut entry.span, delta);
+                if let MapKey::Computed(key) = &mut entry.key {
+                    rebase_expr_spans(key, delta);
+                }
+                rebase_expr_spans(&mut entry.value, delta);
+            }
+        }
+        Expr::ArrayComprehension {
+            span,
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            shift(span, delta);
+            rebase_expr_spans(item, delta);
+            rebase_expr_spans(source, delta);
+            if let Some(predicate) = predicate {
+                rebase_expr_spans(predicate, delta);
+            }
         }
         Expr::MethodCall {
             span,

--- a/crates/cxl/src/eval/compiled.rs
+++ b/crates/cxl/src/eval/compiled.rs
@@ -57,7 +57,7 @@ use clinker_record::{GroupByKey, RecordStorage, Value, value_to_group_key};
 use regex::Regex;
 use rust_decimal::Decimal;
 
-use crate::ast::{BinOp, EmitTarget, Expr, LiteralValue, Statement, TraceLevel, UnaryOp};
+use crate::ast::{BinOp, EmitTarget, Expr, LiteralValue, MapKey, Statement, TraceLevel, UnaryOp};
 use crate::lexer::Span;
 use crate::resolve::ResolvedBinding;
 use crate::resolve::traits::{FieldResolver, WindowContext};
@@ -84,6 +84,57 @@ struct Frame<'a, 'w, S: RecordStorage + 'w> {
     resolver: &'a dyn FieldResolver,
     window: Option<&'a dyn WindowContext<'w, S>>,
     env: HashMap<String, Value>,
+    construction: ConstructionBudget,
+}
+
+/// Per-record budget for author-constructed arrays and maps. The budget is
+/// charged before container growth and is shared by every nested constructor
+/// evaluated for the record.
+struct ConstructionBudget {
+    retained_bytes: usize,
+    depth: usize,
+}
+
+const MAX_CONSTRUCTED_BYTES: usize = 10 * 1024 * 1024;
+
+impl ConstructionBudget {
+    fn enter(&mut self, span: Span) -> Result<(), EvalError> {
+        if self.depth >= clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+            return Err(EvalError::new(
+                EvalErrorKind::ConstructionDepthExceeded {
+                    limit: clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH,
+                },
+                span,
+            ));
+        }
+        self.depth += 1;
+        Ok(())
+    }
+
+    fn leave(&mut self) {
+        self.depth = self.depth.saturating_sub(1);
+    }
+
+    fn charge(&mut self, bytes: usize, span: Span) -> Result<(), EvalError> {
+        let next = self.retained_bytes.checked_add(bytes).ok_or_else(|| {
+            EvalError::new(
+                EvalErrorKind::ConstructionLimitExceeded {
+                    limit: MAX_CONSTRUCTED_BYTES,
+                },
+                span,
+            )
+        })?;
+        if next > MAX_CONSTRUCTED_BYTES {
+            return Err(EvalError::new(
+                EvalErrorKind::ConstructionLimitExceeded {
+                    limit: MAX_CONSTRUCTED_BYTES,
+                },
+                span,
+            ));
+        }
+        self.retained_bytes = next;
+        Ok(())
+    }
 }
 
 /// Mutable cross-record evaluation state threaded into `eval_record`.
@@ -238,6 +289,10 @@ impl CompiledScalar {
             resolver,
             window: None,
             env: HashMap::new(),
+            construction: ConstructionBudget {
+                retained_bytes: 0,
+                depth: 0,
+            },
         };
         (self.expr)(&mut frame)
     }
@@ -346,6 +401,10 @@ impl<S: RecordStorage + 'static> CompiledProgram<S> {
             resolver,
             window,
             env: HashMap::new(),
+            construction: ConstructionBudget {
+                retained_bytes: 0,
+                depth: 0,
+            },
         };
         // The cumulative fan-out budget is per input record; reset it
         // before any `emit each` block runs so one record's expansion
@@ -866,6 +925,173 @@ fn compile_expr<S: RecordStorage + 'static>(typed: &TypedProgram, expr: &Expr) -
             // is one `Value` clone with no variant re-match.
             let baked = literal_to_value(value);
             Box::new(move |_frame| Ok(baked.clone()))
+        }
+        Expr::ArrayLiteral { elements, span, .. } => {
+            let elements = elements
+                .iter()
+                .map(|element| compile_expr::<S>(typed, element))
+                .collect::<Vec<_>>();
+            let span = *span;
+            Box::new(move |frame| {
+                frame.construction.enter(span)?;
+                let result = (|| {
+                    frame
+                        .construction
+                        .charge(elements.len() * std::mem::size_of::<Value>(), span)?;
+                    let mut values = Vec::with_capacity(elements.len());
+                    for element in &elements {
+                        let value = element(frame)?;
+                        frame.construction.charge(value.heap_size(), span)?;
+                        values.push(value);
+                    }
+                    Ok(Value::Array(values))
+                })();
+                frame.construction.leave();
+                result
+            })
+        }
+        Expr::MapLiteral { entries, span, .. } => {
+            enum CompiledKey<S: RecordStorage + 'static> {
+                Static(Box<str>),
+                Computed(CompiledExpr<S>),
+            }
+            let entries = entries
+                .iter()
+                .map(|entry| {
+                    let key = match &entry.key {
+                        MapKey::Static(key) => CompiledKey::Static(key.clone()),
+                        MapKey::Computed(key) => {
+                            CompiledKey::Computed(compile_expr::<S>(typed, key))
+                        }
+                    };
+                    (key, compile_expr::<S>(typed, &entry.value), entry.span)
+                })
+                .collect::<Vec<_>>();
+            let span = *span;
+            Box::new(move |frame| {
+                frame.construction.enter(span)?;
+                let result = (|| {
+                    let entry_bytes = std::mem::size_of::<Box<str>>()
+                        + std::mem::size_of::<Value>()
+                        + std::mem::size_of::<u64>()
+                        + std::mem::size_of::<usize>();
+                    frame
+                        .construction
+                        .charge(entries.len() * entry_bytes, span)?;
+                    let mut values: indexmap::IndexMap<Box<str>, Value> =
+                        indexmap::IndexMap::with_capacity(entries.len());
+                    for (key, value, entry_span) in &entries {
+                        let key_text: Box<str> = match key {
+                            CompiledKey::Static(key) => key.clone(),
+                            CompiledKey::Computed(key) => match key(frame)? {
+                                Value::String(key) => key.as_str().into(),
+                                other => {
+                                    return Err(EvalError::type_mismatch(
+                                        "non-null String map key",
+                                        other.type_name(),
+                                        *entry_span,
+                                    ));
+                                }
+                            },
+                        };
+                        frame.construction.charge(key_text.len(), *entry_span)?;
+                        let decoded = clinker_record::nested_key::NestedKey::decode(&key_text)
+                            .map_err(|error| {
+                                EvalError::new(
+                                    EvalErrorKind::InvalidNestedKey {
+                                        key: key_text.to_string(),
+                                        message: error.to_string(),
+                                    },
+                                    *entry_span,
+                                )
+                            })?;
+                        let logical_key = decoded.text.as_ref();
+                        if values.keys().any(|prior| {
+                            clinker_record::nested_key::NestedKey::decode(prior)
+                                .expect("previous keys were validated before insertion")
+                                .text
+                                == logical_key
+                        }) {
+                            return Err(EvalError::new(
+                                EvalErrorKind::DuplicateMapKey {
+                                    key: logical_key.to_string(),
+                                },
+                                *entry_span,
+                            ));
+                        }
+                        let value = value(frame)?;
+                        frame.construction.charge(value.heap_size(), *entry_span)?;
+                        values.insert(key_text, value);
+                    }
+                    Ok(Value::Map(Box::new(values)))
+                })();
+                frame.construction.leave();
+                result
+            })
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            span,
+            ..
+        } => {
+            let item = compile_expr::<S>(typed, item);
+            let source = compile_expr::<S>(typed, source);
+            let predicate = predicate
+                .as_ref()
+                .map(|predicate| compile_expr::<S>(typed, predicate));
+            let binding = binding.to_string();
+            let span = *span;
+            Box::new(move |frame| {
+                frame.construction.enter(span)?;
+                let result = (|| {
+                    let source_value = source(frame)?;
+                    let Value::Array(source_values) = source_value else {
+                        return Err(EvalError::type_mismatch(
+                            "Array comprehension source",
+                            source_value.type_name(),
+                            span,
+                        ));
+                    };
+                    frame
+                        .construction
+                        .charge(source_values.len() * std::mem::size_of::<Value>(), span)?;
+                    let previous = frame.env.remove(&binding);
+                    let values_result = (|| {
+                        let mut values = Vec::with_capacity(source_values.len());
+                        for source_value in source_values {
+                            frame.env.insert(binding.clone(), source_value);
+                            if let Some(predicate) = &predicate {
+                                match predicate(frame)? {
+                                    Value::Bool(true) => {}
+                                    Value::Bool(false) => continue,
+                                    other => {
+                                        return Err(EvalError::type_mismatch(
+                                            "Bool comprehension predicate",
+                                            other.type_name(),
+                                            span,
+                                        ));
+                                    }
+                                }
+                            }
+                            let value = item(frame)?;
+                            frame.construction.charge(value.heap_size(), span)?;
+                            values.push(value);
+                        }
+                        Ok(Value::Array(values))
+                    })();
+                    if let Some(previous) = previous {
+                        frame.env.insert(binding.clone(), previous);
+                    } else {
+                        frame.env.remove(&binding);
+                    }
+                    values_result
+                })();
+                frame.construction.leave();
+                result
+            })
         }
         Expr::FieldRef { name, .. } => {
             let name = name.to_string();
@@ -1501,9 +1727,17 @@ fn window_predicate_fold<'a, 'w, S: RecordStorage + 'w>(
             resolver: &row,
             window,
             env,
+            construction: std::mem::replace(
+                &mut frame.construction,
+                ConstructionBudget {
+                    retained_bytes: 0,
+                    depth: 0,
+                },
+            ),
         };
         let raw = predicate(&mut sub);
         env = std::mem::take(&mut sub.env);
+        frame.construction = sub.construction;
         let raw = match raw {
             Ok(v) => v,
             Err(e) => {

--- a/crates/cxl/src/eval/compiled/tests.rs
+++ b/crates/cxl/src/eval/compiled/tests.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use clinker_record::{RecordStorage, Value};
 use proptest::prelude::*;
 
-use super::program_has_distinct;
+use super::{ConstructionBudget, MAX_CONSTRUCTED_BYTES, program_has_distinct};
 use crate::eval::context::{EvalContext, StableEvalContext};
 use crate::eval::error::EvalError;
 use crate::eval::{EvalResult, ProgramEvaluator, SkipReason};
@@ -58,6 +58,41 @@ impl RecordStorage for NullStorage {
 
 fn empty_row() -> Row {
     Row::closed(indexmap::IndexMap::new(), crate::lexer::Span::new(0, 0))
+}
+
+#[test]
+fn construction_budget_checks_limits_before_committing_growth() {
+    let span = crate::lexer::Span::new(0, 1);
+    let mut budget = ConstructionBudget {
+        retained_bytes: 0,
+        depth: 0,
+    };
+    budget.charge(MAX_CONSTRUCTED_BYTES, span).unwrap();
+    let error = budget.charge(1, span).unwrap_err();
+    assert!(matches!(
+        error.kind,
+        crate::eval::error::EvalErrorKind::ConstructionLimitExceeded { limit }
+            if limit == MAX_CONSTRUCTED_BYTES
+    ));
+    assert_eq!(budget.retained_bytes, MAX_CONSTRUCTED_BYTES);
+
+    let mut depth = ConstructionBudget {
+        retained_bytes: 0,
+        depth: 0,
+    };
+    for _ in 0..clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+        depth.enter(span).unwrap();
+    }
+    let error = depth.enter(span).unwrap_err();
+    assert!(matches!(
+        error.kind,
+        crate::eval::error::EvalErrorKind::ConstructionDepthExceeded { limit }
+            if limit == clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH
+    ));
+    assert_eq!(
+        depth.depth,
+        clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH
+    );
 }
 
 /// Parse → resolve → typecheck a CXL program against the given input

--- a/crates/cxl/src/eval/error.rs
+++ b/crates/cxl/src/eval/error.rs
@@ -70,6 +70,19 @@ pub enum EvalErrorKind {
         size: usize,
         limit: usize,
     },
+    DuplicateMapKey {
+        key: String,
+    },
+    InvalidNestedKey {
+        key: String,
+        message: String,
+    },
+    ConstructionLimitExceeded {
+        limit: usize,
+    },
+    ConstructionDepthExceeded {
+        limit: usize,
+    },
     /// `emit each` produced more records from a single input than the
     /// transform's `max_expansion` ceiling allows. The originating
     /// record is routed to DLQ; the fan-out is aborted at the
@@ -114,6 +127,20 @@ impl std::fmt::Display for EvalErrorKind {
                 f,
                 "string output exceeds maximum size ({} bytes, limit {})",
                 size, limit
+            ),
+            Self::DuplicateMapKey { key } => {
+                write!(f, "duplicate map key '{key}'")
+            }
+            Self::InvalidNestedKey { key, message } => {
+                write!(f, "invalid nested map key {key:?}: {message}")
+            }
+            Self::ConstructionLimitExceeded { limit } => write!(
+                f,
+                "nested value construction exceeds the per-record memory limit ({limit} bytes)"
+            ),
+            Self::ConstructionDepthExceeded { limit } => write!(
+                f,
+                "nested value construction exceeds the maximum depth ({limit})"
             ),
             Self::ExpansionLimitExceeded { limit } => write!(
                 f,
@@ -222,6 +249,10 @@ pub fn extract_triggering_value(kind: &EvalErrorKind) -> Option<Value> {
         | EvalErrorKind::InvariantViolation { .. }
         | EvalErrorKind::IntegerOverflow { .. }
         | EvalErrorKind::StringTooLarge { .. }
+        | EvalErrorKind::DuplicateMapKey { .. }
+        | EvalErrorKind::InvalidNestedKey { .. }
+        | EvalErrorKind::ConstructionLimitExceeded { .. }
+        | EvalErrorKind::ConstructionDepthExceeded { .. }
         | EvalErrorKind::ExpansionLimitExceeded { .. } => None,
     }
 }
@@ -238,6 +269,14 @@ impl miette::Diagnostic for EvalError {
             EvalErrorKind::InvariantViolation { .. } => "cxl::eval::internal_invariant",
             EvalErrorKind::IntegerOverflow { .. } => "cxl::eval::integer_overflow",
             EvalErrorKind::StringTooLarge { .. } => "cxl::eval::string_too_large",
+            EvalErrorKind::DuplicateMapKey { .. } => "cxl::eval::duplicate_map_key",
+            EvalErrorKind::InvalidNestedKey { .. } => "cxl::eval::invalid_nested_key",
+            EvalErrorKind::ConstructionLimitExceeded { .. } => {
+                "cxl::eval::construction_limit_exceeded"
+            }
+            EvalErrorKind::ConstructionDepthExceeded { .. } => {
+                "cxl::eval::construction_depth_exceeded"
+            }
             EvalErrorKind::ExpansionLimitExceeded { .. } => "cxl::eval::expansion_limit_exceeded",
         };
         Some(Box::new(s))

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -96,6 +96,143 @@ fn eval_single(src: &str, fields: &[&str], record: HashMap<String, Value>) -> Va
     output.into_values().next().unwrap_or(Value::Null)
 }
 
+fn eval_error(src: &str, fields: &[&str], record: HashMap<String, Value>) -> EvalError {
+    let parsed = Parser::parse(src);
+    assert!(
+        parsed.errors.is_empty(),
+        "Parse errors: {:?}",
+        parsed.errors
+    );
+    let resolved = resolve_program(parsed.ast, fields, parsed.node_count).unwrap();
+    let typed = type_check(resolved, &empty_row()).unwrap();
+    let stable = StableEvalContext::test_default();
+    let ctx = EvalContext::test_default_borrowed(&stable);
+    let resolver = HashMapResolver::new(record);
+    run_fields::<NullStorage>(typed, &ctx, &resolver, None).expect_err("expected eval error")
+}
+
+#[test]
+fn nested_literals_evaluate_in_author_order() {
+    let value = eval_single(
+        "emit payload = {first: [1, 2], [key]: {active: true}, last: null}",
+        &["key"],
+        HashMap::from([("key".into(), Value::String("computed".into()))]),
+    );
+    let Value::Map(map) = value else {
+        panic!("expected map");
+    };
+    assert_eq!(
+        map.keys().map(|key| key.as_ref()).collect::<Vec<_>>(),
+        vec!["first", "computed", "last"]
+    );
+    assert_eq!(
+        map["first"],
+        Value::Array(vec![Value::Integer(1), Value::Integer(2)])
+    );
+    assert!(matches!(map["computed"], Value::Map(_)));
+    assert_eq!(map["last"], Value::Null);
+}
+
+#[test]
+fn array_comprehension_filters_and_preserves_order() {
+    let value = eval_single(
+        "emit doubled = [item * 2 for item in values if item > 0]",
+        &["values"],
+        HashMap::from([(
+            "values".into(),
+            Value::Array(vec![
+                Value::Integer(3),
+                Value::Integer(-1),
+                Value::Integer(2),
+            ]),
+        )]),
+    );
+    assert_eq!(
+        value,
+        Value::Array(vec![Value::Integer(6), Value::Integer(4)])
+    );
+}
+
+#[test]
+fn duplicate_map_key_fails_at_first_duplicate() {
+    let error = eval_error(
+        "emit payload = {name: 1, [key]: 2}",
+        &["key"],
+        HashMap::from([("key".into(), Value::String("name".into()))]),
+    );
+    assert!(matches!(
+        error.kind,
+        EvalErrorKind::DuplicateMapKey { ref key } if key == "name"
+    ));
+}
+
+#[test]
+fn null_computed_key_and_null_comprehension_source_fail() {
+    let key_error = eval_error(
+        "emit payload = {[key]: 1}",
+        &["key"],
+        HashMap::from([("key".into(), Value::Null)]),
+    );
+    assert!(matches!(
+        key_error.kind,
+        EvalErrorKind::TypeMismatch {
+            expected: "non-null String map key",
+            got: "null"
+        }
+    ));
+
+    let source_error = eval_error(
+        "emit values = [item for item in source]",
+        &["source"],
+        HashMap::from([("source".into(), Value::Null)]),
+    );
+    assert!(matches!(
+        source_error.kind,
+        EvalErrorKind::TypeMismatch {
+            expected: "Array comprehension source",
+            got: "null"
+        }
+    ));
+}
+
+#[test]
+fn computed_map_keys_use_the_same_canonical_escape_grammar() {
+    let error = eval_error(
+        "emit payload = {[key]: 1}",
+        &["key"],
+        HashMap::from([("key".into(), Value::String("\\ordinary".into()))]),
+    );
+    assert!(matches!(
+        error.kind,
+        EvalErrorKind::InvalidNestedKey { ref key, .. } if key == "\\ordinary"
+    ));
+}
+
+#[test]
+fn constructed_nested_values_accept_the_depth_cap_and_reject_cap_plus_one() {
+    let source_at_depth = |depth: usize| {
+        format!(
+            "emit payload = {}null{}",
+            "[".repeat(depth),
+            "]".repeat(depth)
+        )
+    };
+
+    let at_cap = source_at_depth(clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH);
+    assert!(matches!(
+        eval_single(&at_cap, &[], HashMap::new()),
+        Value::Array(_)
+    ));
+
+    let over_cap = source_at_depth(clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH + 1);
+    let error = eval_error(&over_cap, &[], HashMap::new());
+    assert!(matches!(
+        error.kind,
+        EvalErrorKind::ConstructionDepthExceeded { limit }
+            if limit == clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH
+    ));
+}
+
 fn dec(mantissa: i64, scale: u32) -> Value {
     Value::Decimal(rust_decimal::Decimal::new(mantissa, scale))
 }

--- a/crates/cxl/src/lexer.rs
+++ b/crates/cxl/src/lexer.rs
@@ -20,7 +20,7 @@ impl Span {
 /// CXL token produced by the lexer.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
-    // --- Keywords (21) ---
+    // --- Keywords (23) ---
     Let,
     Emit,
     If,
@@ -42,6 +42,8 @@ pub enum Token {
     Filter,
     Distinct,
     By,
+    For,
+    In,
 
     // --- Operators (14) ---
     Plus,
@@ -433,6 +435,8 @@ impl<'src> Lexer<'src> {
             "filter" => Token::Filter,
             "distinct" => Token::Distinct,
             "by" => Token::By,
+            "for" => Token::For,
+            "in" => Token::In,
             _ => Token::Ident(text.into()),
         };
 
@@ -467,7 +471,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_lex_keywords_all_21() {
+    fn test_lex_keywords_all_23() {
         let keywords = [
             ("let", Token::Let),
             ("emit", Token::Emit),
@@ -490,8 +494,10 @@ mod tests {
             ("filter", Token::Filter),
             ("distinct", Token::Distinct),
             ("by", Token::By),
+            ("for", Token::For),
+            ("in", Token::In),
         ];
-        assert_eq!(keywords.len(), 21);
+        assert_eq!(keywords.len(), 23);
         for (src, expected) in keywords {
             let tokens = Lexer::tokenize(src);
             assert_eq!(tokens[0].0, expected, "keyword '{}' failed", src);

--- a/crates/cxl/src/module_eval.rs
+++ b/crates/cxl/src/module_eval.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-use crate::ast::{Expr, FnDecl, MatchArm, Module, ModuleConst, NodeId};
+use crate::ast::{Expr, FnDecl, MapEntry, MapKey, MatchArm, Module, ModuleConst, NodeId};
 use crate::lexer::Span;
 
 const RUNTIME_MODULE_NODE: NodeId = NodeId(u32::MAX);
@@ -366,6 +366,37 @@ fn collect_declaration_dependencies(
             visit(rhs, lexical, dependencies)
         }
         Expr::Unary { operand, .. } => visit(operand, lexical, dependencies),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                visit(element, lexical, dependencies)?;
+            }
+            Ok(())
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &entry.key {
+                    visit(key, lexical, dependencies)?;
+                }
+                visit(&entry.value, lexical, dependencies)?;
+            }
+            Ok(())
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            visit(source, lexical, dependencies)?;
+            let mut nested = lexical.clone();
+            nested.insert(binding.to_string());
+            visit(item, &nested, dependencies)?;
+            if let Some(predicate) = predicate {
+                visit(predicate, &nested, dependencies)?;
+            }
+            Ok(())
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -773,6 +804,76 @@ impl RuntimeModuleRegistry {
                 operand: Box::new(expand(operand, stack)?),
                 span: call_span,
             },
+            Expr::ArrayLiteral { elements, .. } => Expr::ArrayLiteral {
+                node_id: RUNTIME_MODULE_NODE,
+                elements: elements
+                    .iter()
+                    .map(|element| expand(element, stack))
+                    .collect::<Result<Vec<_>, _>>()?,
+                span: call_span,
+            },
+            Expr::MapLiteral { entries, .. } => Expr::MapLiteral {
+                node_id: RUNTIME_MODULE_NODE,
+                entries: entries
+                    .iter()
+                    .map(|entry| {
+                        Ok(MapEntry {
+                            key: match &entry.key {
+                                MapKey::Static(key) => MapKey::Static(key.clone()),
+                                MapKey::Computed(key) => {
+                                    MapKey::Computed(Box::new(expand(key, stack)?))
+                                }
+                            },
+                            value: expand(&entry.value, stack)?,
+                            span: call_span,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, String>>()?,
+                span: call_span,
+            },
+            Expr::ArrayComprehension {
+                item,
+                binding,
+                source,
+                predicate,
+                ..
+            } => {
+                let source = Box::new(expand(source, stack)?);
+                let mut nested_substitutions = substitutions.clone();
+                nested_substitutions.remove(binding.as_ref());
+                let mut nested_protected = protected.clone();
+                nested_protected.insert(binding.to_string());
+                let item = Box::new(self.expand_expr(
+                    module_id,
+                    item,
+                    &nested_substitutions,
+                    &nested_protected,
+                    stack,
+                    call_span,
+                )?);
+                let predicate = predicate
+                    .as_ref()
+                    .map(|predicate| {
+                        self.expand_expr(
+                            module_id,
+                            predicate,
+                            &nested_substitutions,
+                            &nested_protected,
+                            stack,
+                            call_span,
+                        )
+                        .map(Box::new)
+                    })
+                    .transpose()?;
+                Expr::ArrayComprehension {
+                    node_id: RUNTIME_MODULE_NODE,
+                    item,
+                    binding: binding.clone(),
+                    source,
+                    predicate,
+                    span: call_span,
+                }
+            }
             Expr::Coalesce { lhs, rhs, .. } => Expr::Coalesce {
                 node_id: RUNTIME_MODULE_NODE,
                 lhs: Box::new(expand(lhs, stack)?),
@@ -1027,6 +1128,31 @@ fn walk_expr(expr: &Expr, refs: &mut Vec<String>) {
         Expr::Unary { operand, .. } => {
             walk_expr(operand, refs);
         }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                walk_expr(element, refs);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &entry.key {
+                    walk_expr(key, refs);
+                }
+                walk_expr(&entry.value, refs);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            walk_expr(source, refs);
+            walk_expr(item, refs);
+            if let Some(predicate) = predicate {
+                walk_expr(predicate, refs);
+            }
+        }
         Expr::Coalesce { lhs, rhs, .. } => {
             walk_expr(lhs, refs);
             walk_expr(rhs, refs);
@@ -1198,6 +1324,31 @@ fn collect_function_refs(expr: &Expr, names: &HashMap<&str, usize>, refs: &mut V
             collect_function_refs(rhs, names, refs);
         }
         Expr::Unary { operand, .. } => collect_function_refs(operand, names, refs),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_function_refs(element, names, refs);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &entry.key {
+                    collect_function_refs(key, names, refs);
+                }
+                collect_function_refs(&entry.value, names, refs);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_function_refs(source, names, refs);
+            collect_function_refs(item, names, refs);
+            if let Some(predicate) = predicate {
+                collect_function_refs(predicate, names, refs);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,

--- a/crates/cxl/src/parser.rs
+++ b/crates/cxl/src/parser.rs
@@ -499,11 +499,9 @@ impl Parser {
                 ));
             }
         };
-        // The `in` separator is an identifier (CXL has no `in` keyword);
-        // accept the literal text "in" to keep the grammar surface from
-        // adding another reserved word.
+        // `in` is shared by emit_each and collection comprehensions.
         match self.peek().clone() {
-            Token::Ident(name) if name.as_ref() == "in" => {
+            Token::In => {
                 self.advance();
             }
             other => {
@@ -805,6 +803,8 @@ impl Parser {
                     | Token::FatArrow
                     | Token::Then
                     | Token::Else
+                    | Token::For
+                    | Token::If
             ) {
                 break;
             }
@@ -1002,6 +1002,9 @@ impl Parser {
                 self.expect_token(&Token::RParen, "')'")?;
                 Ok(expr)
             }
+
+            Token::LBracket => self.parse_array_expr(),
+            Token::LBrace => self.parse_map_expr(),
 
             // if/then/else
             Token::If => self.parse_if_expr(),
@@ -1252,6 +1255,153 @@ impl Parser {
                 "Check for missing operands or mismatched delimiters",
             )),
         }
+    }
+
+    fn parse_array_expr(&mut self) -> Result<Expr, ParseError> {
+        let node_id = self.alloc_id();
+        let start = self.current_span();
+        self.advance();
+        self.skip_newlines();
+
+        if *self.peek() == Token::RBracket {
+            self.advance();
+            let end = self.prev_span();
+            return Ok(Expr::ArrayLiteral {
+                node_id,
+                elements: Vec::new(),
+                span: Span::new(start.start as usize, end.end as usize),
+            });
+        }
+
+        let first = self.parse_expr(0)?;
+        self.skip_newlines();
+        if *self.peek() == Token::For {
+            self.advance();
+            self.skip_newlines();
+            let binding = self.expect_ident("array-comprehension binding")?;
+            self.expect_token(&Token::In, "'in'")?;
+            self.skip_newlines();
+            let source = self.parse_expr(0)?;
+            self.skip_newlines();
+            let predicate = if *self.peek() == Token::If {
+                self.advance();
+                self.skip_newlines();
+                let predicate = self.parse_expr(0)?;
+                self.skip_newlines();
+                Some(Box::new(predicate))
+            } else {
+                None
+            };
+            self.expect_token(&Token::RBracket, "']'")?;
+            let end = self.prev_span();
+            return Ok(Expr::ArrayComprehension {
+                node_id,
+                item: Box::new(first),
+                binding: binding.into(),
+                source: Box::new(source),
+                predicate,
+                span: Span::new(start.start as usize, end.end as usize),
+            });
+        }
+
+        let mut elements = vec![first];
+        while *self.peek() == Token::Comma {
+            self.advance();
+            self.skip_newlines();
+            if *self.peek() == Token::RBracket {
+                break;
+            }
+            elements.push(self.parse_expr(0)?);
+            self.skip_newlines();
+        }
+        self.expect_token(&Token::RBracket, "']'")?;
+        let end = self.prev_span();
+        Ok(Expr::ArrayLiteral {
+            node_id,
+            elements,
+            span: Span::new(start.start as usize, end.end as usize),
+        })
+    }
+
+    fn parse_map_expr(&mut self) -> Result<Expr, ParseError> {
+        let node_id = self.alloc_id();
+        let start = self.current_span();
+        self.advance();
+        self.skip_newlines();
+        let mut entries = Vec::new();
+        let mut static_keys = Vec::<String>::new();
+
+        while *self.peek() != Token::RBrace {
+            let entry_start = self.current_span();
+            let key = match self.peek().clone() {
+                Token::Ident(key) | Token::StringLit(key) => {
+                    self.advance();
+                    let decoded = clinker_record::nested_key::NestedKey::decode(&key).map_err(
+                        |error| {
+                            self.error(
+                                &error.to_string(),
+                                "nested map keys use one canonical backslash escape grammar",
+                                "use `\\@name`, `\\#text`, or `\\\\name` only when escaping a reserved-looking literal key",
+                            )
+                        },
+                    )?;
+                    if static_keys
+                        .iter()
+                        .any(|existing| existing == decoded.text.as_ref())
+                    {
+                        return Err(self.error(
+                            &format!("duplicate map key {:?}", decoded.text),
+                            "static map keys must be unique after canonical escape decoding",
+                            "remove or rename the duplicate key",
+                        ));
+                    }
+                    static_keys.push(decoded.text.into_owned());
+                    MapKey::Static(key)
+                }
+                Token::LBracket => {
+                    self.advance();
+                    self.skip_newlines();
+                    let key = self.parse_expr(0)?;
+                    self.skip_newlines();
+                    self.expect_token(&Token::RBracket, "']'")?;
+                    MapKey::Computed(Box::new(key))
+                }
+                _ => {
+                    return Err(self.error(
+                        "map keys must be identifiers, strings, or computed string expressions",
+                        "CXL maps use `{ name: value }`, `{ \"name\": value }`, or `{ [expr]: value }`",
+                        "quote the key or wrap a string-valued expression in brackets",
+                    ));
+                }
+            };
+            self.skip_newlines();
+            self.expect_token(&Token::Colon, "':'")?;
+            self.skip_newlines();
+            let value = self.parse_expr(0)?;
+            let value_span = value.span();
+            entries.push(MapEntry {
+                key,
+                value,
+                span: Span::new(entry_start.start as usize, value_span.end as usize),
+            });
+            self.skip_newlines();
+            if *self.peek() != Token::Comma {
+                break;
+            }
+            self.advance();
+            self.skip_newlines();
+            if *self.peek() == Token::RBrace {
+                break;
+            }
+        }
+
+        self.expect_token(&Token::RBrace, "'}'")?;
+        let end = self.prev_span();
+        Ok(Expr::MapLiteral {
+            node_id,
+            entries,
+            span: Span::new(start.start as usize, end.end as usize),
+        })
     }
 
     fn parse_if_expr(&mut self) -> Result<Expr, ParseError> {
@@ -1688,6 +1838,109 @@ mod tests {
             }
             _ => panic!("expected Emit"),
         }
+    }
+
+    #[test]
+    fn parses_nested_array_and_map_literals() {
+        let r = parse_ok("let payload = [{name: \"Ada\", scores: [10, 20]}, null]");
+        let Expr::ArrayLiteral { elements, .. } = let_expr(&r) else {
+            panic!("expected array literal");
+        };
+        assert_eq!(elements.len(), 2);
+        let Expr::MapLiteral { entries, .. } = &elements[0] else {
+            panic!("expected nested map literal");
+        };
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(&entries[0].key, MapKey::Static(key) if &**key == "name"));
+        assert!(
+            matches!(&entries[1].value, Expr::ArrayLiteral { elements, .. } if elements.len() == 2)
+        );
+    }
+
+    #[test]
+    fn parses_multiline_nested_constructors_for_yaml_block_scalars() {
+        let r = parse_ok(
+            r##"let payload = {
+  "@kind": "event",
+  items: [
+    {"#text": "first"},
+    {"#text": "second"},
+  ],
+}"##,
+        );
+        let Expr::MapLiteral { entries, .. } = let_expr(&r) else {
+            panic!("expected map literal");
+        };
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(
+            &entries[1].value,
+            Expr::ArrayLiteral { elements, .. } if elements.len() == 2
+        ));
+    }
+
+    #[test]
+    fn parses_computed_map_keys_in_author_order() {
+        let r = parse_ok("let payload = {first: 1, [prefix + suffix]: 2, \"last\": 3}");
+        let Expr::MapLiteral { entries, .. } = let_expr(&r) else {
+            panic!("expected map literal");
+        };
+        assert_eq!(entries.len(), 3);
+        assert!(matches!(&entries[1].key, MapKey::Computed(_)));
+    }
+
+    #[test]
+    fn parses_single_clause_array_comprehension() {
+        let r = parse_ok("let doubled = [item * 2 for item in values if item > 0]");
+        let Expr::ArrayComprehension {
+            binding, predicate, ..
+        } = let_expr(&r)
+        else {
+            panic!("expected array comprehension");
+        };
+        assert_eq!(&**binding, "item");
+        assert!(predicate.is_some());
+    }
+
+    #[test]
+    fn rejects_noncanonical_map_key_syntax() {
+        let result = Parser::parse("let payload = {1: \"nope\"}");
+        assert!(result.errors.iter().any(|error| {
+            error
+                .message
+                .contains("map keys must be identifiers, strings, or computed string expressions")
+        }));
+    }
+
+    #[test]
+    fn canonical_map_key_escapes_are_preserved_for_format_roles() {
+        let r = parse_ok(r#"let payload = {"\\@literal": 1, "\\#text": 2}"#);
+        let Expr::MapLiteral { entries, .. } = let_expr(&r) else {
+            panic!("expected map literal");
+        };
+        assert!(matches!(&entries[0].key, MapKey::Static(key) if &**key == "\\@literal"));
+        assert!(matches!(&entries[1].key, MapKey::Static(key) if &**key == "\\#text"));
+    }
+
+    #[test]
+    fn duplicate_static_keys_are_rejected_after_escape_decoding() {
+        let result = Parser::parse(r#"let payload = {"@id": 1, "\\@id": 2}"#);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.message.contains("duplicate map key \"@id\""))
+        );
+    }
+
+    #[test]
+    fn noncanonical_map_key_escape_is_rejected() {
+        let result = Parser::parse(r#"let payload = {"\\ordinary": 1}"#);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.message.contains("non-canonical nested key escape"))
+        );
     }
 
     #[test]

--- a/crates/cxl/src/plan/extract_aggregates.rs
+++ b/crates/cxl/src/plan/extract_aggregates.rs
@@ -17,7 +17,7 @@ use std::fmt::Write as _;
 use clinker_record::accumulator::AggregateType;
 
 use super::{AggregateBinding, BindingArg, CompiledAggregate, CompiledEmit};
-use crate::ast::{BinOp, Expr, LiteralValue, NodeId, Statement};
+use crate::ast::{BinOp, Expr, LiteralValue, MapKey, NodeId, Statement};
 use crate::lexer::Span;
 use crate::typecheck::{TypeDiagnostic, TypedProgram};
 
@@ -166,6 +166,31 @@ fn extract_aggs_from_expr(
         }
         Expr::Unary { operand, .. } => {
             extract_aggs_from_expr(operand, bindings, dedup, input_schema)?;
+        }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                extract_aggs_from_expr(element, bindings, dedup, input_schema)?;
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    extract_aggs_from_expr(key, bindings, dedup, input_schema)?;
+                }
+                extract_aggs_from_expr(&mut entry.value, bindings, dedup, input_schema)?;
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            extract_aggs_from_expr(source, bindings, dedup, input_schema)?;
+            extract_aggs_from_expr(item, bindings, dedup, input_schema)?;
+            if let Some(predicate) = predicate {
+                extract_aggs_from_expr(predicate, bindings, dedup, input_schema)?;
+            }
         }
         Expr::MethodCall { receiver, args, .. } => {
             extract_aggs_from_expr(receiver, bindings, dedup, input_schema)?;
@@ -322,6 +347,31 @@ fn rewrite_group_key_refs(
         Expr::Unary { operand, .. } => {
             rewrite_group_key_refs(operand, group_by_set, group_by_fields);
         }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                rewrite_group_key_refs(element, group_by_set, group_by_fields);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    rewrite_group_key_refs(key, group_by_set, group_by_fields);
+                }
+                rewrite_group_key_refs(&mut entry.value, group_by_set, group_by_fields);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            rewrite_group_key_refs(source, group_by_set, group_by_fields);
+            rewrite_group_key_refs(item, group_by_set, group_by_fields);
+            if let Some(predicate) = predicate {
+                rewrite_group_key_refs(predicate, group_by_set, group_by_fields);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             rewrite_group_key_refs(receiver, group_by_set, group_by_fields);
             for a in args {
@@ -414,6 +464,31 @@ fn substitute_let_bindings(expr: &mut Expr, let_bindings: &HashMap<Box<str>, Exp
             substitute_let_bindings(rhs, let_bindings);
         }
         Expr::Unary { operand, .. } => substitute_let_bindings(operand, let_bindings),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                substitute_let_bindings(element, let_bindings);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    substitute_let_bindings(key, let_bindings);
+                }
+                substitute_let_bindings(&mut entry.value, let_bindings);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            substitute_let_bindings(source, let_bindings);
+            substitute_let_bindings(item, let_bindings);
+            if let Some(predicate) = predicate {
+                substitute_let_bindings(predicate, let_bindings);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             substitute_let_bindings(receiver, let_bindings);
             for a in args {
@@ -491,6 +566,21 @@ fn contains_agg_call(expr: &Expr) -> bool {
             contains_agg_call(lhs) || contains_agg_call(rhs)
         }
         Expr::Unary { operand, .. } => contains_agg_call(operand),
+        Expr::ArrayLiteral { elements, .. } => elements.iter().any(contains_agg_call),
+        Expr::MapLiteral { entries, .. } => entries.iter().any(|entry| {
+            matches!(&entry.key, MapKey::Computed(key) if contains_agg_call(key))
+                || contains_agg_call(&entry.value)
+        }),
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            contains_agg_call(source)
+                || contains_agg_call(item)
+                || predicate.as_deref().map(contains_agg_call).unwrap_or(false)
+        }
         Expr::MethodCall { receiver, args, .. } => {
             contains_agg_call(receiver) || args.iter().any(contains_agg_call)
         }
@@ -575,6 +665,54 @@ fn write_struct_form(buf: &mut String, expr: &Expr) {
         },
         Expr::FieldRef { name, .. } => {
             let _ = write!(buf, "f:{name}");
+        }
+        Expr::ArrayLiteral { elements, .. } => {
+            buf.push('[');
+            for (index, element) in elements.iter().enumerate() {
+                if index > 0 {
+                    buf.push(',');
+                }
+                write_struct_form(buf, element);
+            }
+            buf.push(']');
+        }
+        Expr::MapLiteral { entries, .. } => {
+            buf.push('{');
+            for (index, entry) in entries.iter().enumerate() {
+                if index > 0 {
+                    buf.push(',');
+                }
+                match &entry.key {
+                    MapKey::Static(key) => {
+                        let _ = write!(buf, "{:?}", key);
+                    }
+                    MapKey::Computed(key) => {
+                        buf.push('[');
+                        write_struct_form(buf, key);
+                        buf.push(']');
+                    }
+                }
+                buf.push(':');
+                write_struct_form(buf, &entry.value);
+            }
+            buf.push('}');
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            buf.push_str("[comp ");
+            write_struct_form(buf, item);
+            let _ = write!(buf, " for {binding} in ");
+            write_struct_form(buf, source);
+            if let Some(predicate) = predicate {
+                buf.push_str(" if ");
+                write_struct_form(buf, predicate);
+            }
+            buf.push(']');
         }
         Expr::QualifiedFieldRef { parts, .. } => {
             buf.push_str("qf:");

--- a/crates/cxl/src/resolve/pass.rs
+++ b/crates/cxl/src/resolve/pass.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::levenshtein::best_match;
 use super::scoped_vars::ScopedVarsRegistry;
-use crate::ast::{Expr, MatchArm, NodeId, Program, Statement};
+use crate::ast::{Expr, MapKey, MatchArm, NodeId, Program, Statement};
 use crate::lexer::Span;
 
 /// What a resolved identifier binds to.
@@ -543,6 +543,47 @@ impl<'a> Resolver<'a> {
             }
             Expr::Literal { .. } => {
                 // Literals don't need resolution
+            }
+            Expr::ArrayLiteral { elements, .. } => {
+                for element in elements {
+                    self.resolve_expr(element);
+                }
+            }
+            Expr::MapLiteral { entries, .. } => {
+                for entry in entries {
+                    if let MapKey::Computed(key) = &entry.key {
+                        self.resolve_expr(key);
+                    }
+                    self.resolve_expr(&entry.value);
+                }
+            }
+            Expr::ArrayComprehension {
+                item,
+                binding,
+                source,
+                predicate,
+                span,
+                ..
+            } => {
+                self.resolve_expr(source);
+                if self.let_vars.iter().any(|name| name == binding.as_ref())
+                    || self.fields.contains(&binding.as_ref())
+                {
+                    self.diagnostics.push(ResolveDiagnostic {
+                        span: *span,
+                        message: format!(
+                            "array-comprehension binding '{binding}' shadows an existing name"
+                        ),
+                        help: Some("choose a fresh binding name for the comprehension".into()),
+                    });
+                }
+                let saved_len = self.let_vars.len();
+                self.let_vars.push(binding.to_string());
+                self.resolve_expr(item);
+                if let Some(predicate) = predicate {
+                    self.resolve_expr(predicate);
+                }
+                self.let_vars.truncate(saved_len);
             }
             Expr::Binary { lhs, rhs, .. } => {
                 self.resolve_expr(lhs);
@@ -1127,6 +1168,36 @@ mod tests {
             .iter()
             .any(|b| matches!(b, Some(ResolvedBinding::LetVar(0))));
         assert!(has_let, "Expected LetVar(0) — let should shadow field");
+    }
+
+    #[test]
+    fn array_comprehension_binding_resolves_only_inside_body() {
+        let resolved = resolve_ok(
+            "emit values = [element * 2 for element in items if element > 0]",
+            &["items"],
+        );
+        let let_bindings = resolved
+            .bindings
+            .iter()
+            .filter(|binding| matches!(binding, Some(ResolvedBinding::LetVar(_))))
+            .count();
+        assert_eq!(
+            let_bindings, 2,
+            "item and predicate should resolve to the binder"
+        );
+    }
+
+    #[test]
+    fn array_comprehension_rejects_shadowing() {
+        let diagnostics = resolve_err(
+            "let element = 1\nemit values = [element for element in items]",
+            &["items"],
+        );
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("array-comprehension binding 'element' shadows an existing name")
+        }));
     }
 
     #[test]

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -540,6 +540,72 @@ impl<'a> TypeChecker<'a> {
                 ty
             }
 
+            Expr::ArrayLiteral {
+                node_id, elements, ..
+            } => {
+                for element in elements {
+                    self.check_expr(element, in_predicate);
+                }
+                self.set_type(*node_id, Type::Array);
+                Type::Array
+            }
+
+            Expr::MapLiteral {
+                node_id, entries, ..
+            } => {
+                for entry in entries {
+                    if let crate::ast::MapKey::Computed(key) = &entry.key {
+                        let key_ty = self.check_expr(key, in_predicate);
+                        if !matches!(key_ty.unwrap_nullable(), Type::String | Type::Any) {
+                            self.error(
+                                key.span(),
+                                format!("computed map key must be String, got {key_ty}"),
+                                Some("convert the key explicitly with `.to_string()`".into()),
+                            );
+                        }
+                    }
+                    self.check_expr(&entry.value, in_predicate);
+                }
+                self.set_type(*node_id, Type::Map);
+                Type::Map
+            }
+
+            Expr::ArrayComprehension {
+                node_id,
+                item,
+                binding,
+                source,
+                predicate,
+                ..
+            } => {
+                let source_ty = self.check_expr(source, in_predicate);
+                if !matches!(source_ty.unwrap_nullable(), Type::Array | Type::Any) {
+                    self.error(
+                        source.span(),
+                        format!("array comprehension requires an Array source, got {source_ty}"),
+                        Some("handle null explicitly or provide an Array-valued expression".into()),
+                    );
+                }
+                self.lexical_types
+                    .push(HashMap::from([(binding.clone(), Type::Any)]));
+                self.check_expr(item, in_predicate);
+                if let Some(predicate) = predicate {
+                    let predicate_ty = self.check_expr(predicate, in_predicate);
+                    if !matches!(predicate_ty, Type::Bool | Type::Any) {
+                        self.error(
+                            predicate.span(),
+                            format!(
+                                "array-comprehension predicate must be Bool, got {predicate_ty}"
+                            ),
+                            Some("use an explicit boolean comparison".into()),
+                        );
+                    }
+                }
+                self.lexical_types.pop();
+                self.set_type(*node_id, Type::Array);
+                Type::Array
+            }
+
             Expr::FieldRef {
                 node_id,
                 name,
@@ -1513,6 +1579,31 @@ impl<'a> TypeChecker<'a> {
                 self.walk_agg_ctx(rhs, let_exprs);
             }
             Expr::Unary { operand, .. } => self.walk_agg_ctx(operand, let_exprs),
+            Expr::ArrayLiteral { elements, .. } => {
+                for element in elements {
+                    self.walk_agg_ctx(element, let_exprs);
+                }
+            }
+            Expr::MapLiteral { entries, .. } => {
+                for entry in entries {
+                    if let crate::ast::MapKey::Computed(key) = &entry.key {
+                        self.walk_agg_ctx(key, let_exprs);
+                    }
+                    self.walk_agg_ctx(&entry.value, let_exprs);
+                }
+            }
+            Expr::ArrayComprehension {
+                item,
+                source,
+                predicate,
+                ..
+            } => {
+                self.walk_agg_ctx(source, let_exprs);
+                self.walk_agg_ctx(item, let_exprs);
+                if let Some(predicate) = predicate {
+                    self.walk_agg_ctx(predicate, let_exprs);
+                }
+            }
             Expr::Coalesce { lhs, rhs, .. } => {
                 self.walk_agg_ctx(lhs, let_exprs);
                 self.walk_agg_ctx(rhs, let_exprs);
@@ -2038,6 +2129,9 @@ fn reindex_expr(expr: &mut Expr, next_id: &mut u32) {
         Expr::Binary { node_id, .. }
         | Expr::Unary { node_id, .. }
         | Expr::Literal { node_id, .. }
+        | Expr::ArrayLiteral { node_id, .. }
+        | Expr::MapLiteral { node_id, .. }
+        | Expr::ArrayComprehension { node_id, .. }
         | Expr::FieldRef { node_id, .. }
         | Expr::QualifiedFieldRef { node_id, .. }
         | Expr::MethodCall { node_id, .. }
@@ -2071,6 +2165,31 @@ fn reindex_expr(expr: &mut Expr, next_id: &mut u32) {
             reindex_expr(rhs, next_id);
         }
         Expr::Unary { operand, .. } => reindex_expr(operand, next_id),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                reindex_expr(element, next_id);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let crate::ast::MapKey::Computed(key) = &mut entry.key {
+                    reindex_expr(key, next_id);
+                }
+                reindex_expr(&mut entry.value, next_id);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            reindex_expr(item, next_id);
+            reindex_expr(source, next_id);
+            if let Some(predicate) = predicate {
+                reindex_expr(predicate, next_id);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             reindex_expr(receiver, next_id);
             for arg in args {
@@ -2168,6 +2287,50 @@ mod tests {
         assert!(parsed.errors.is_empty());
         let resolved = resolve_program(parsed.ast, fields, parsed.node_count).unwrap();
         type_check(resolved, schema).expect_err("Expected type errors but got Ok")
+    }
+
+    #[test]
+    fn nested_constructor_types_are_checked() {
+        let typed = typecheck_ok(
+            "emit payload = {items: [1, 2], selected: [item for item in values if item > 0]}",
+            &["values"],
+            &empty_row(),
+        );
+        let Statement::Emit { expr, .. } = &typed.program.statements[0] else {
+            panic!("expected emit");
+        };
+        assert_eq!(typed.types[expr.node_id().0 as usize], Some(Type::Map));
+    }
+
+    #[test]
+    fn computed_map_key_requires_string() {
+        let diagnostics = typecheck_err("emit payload = {[1]: true}", &[], &empty_row());
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("computed map key must be String")
+        }));
+    }
+
+    #[test]
+    fn comprehension_rejects_null_source_and_non_bool_predicate() {
+        let null_source = typecheck_err("emit values = [item for item in null]", &[], &empty_row());
+        assert!(null_source.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("array comprehension requires an Array source")
+        }));
+
+        let non_bool = typecheck_err(
+            "emit values = [item for item in [1, 2] if 42]",
+            &[],
+            &empty_row(),
+        );
+        assert!(non_bool.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("array-comprehension predicate must be Bool")
+        }));
     }
 
     fn typecheck_with_module(

--- a/docs/engine/src/cxl-internals.md
+++ b/docs/engine/src/cxl-internals.md
@@ -47,6 +47,16 @@ records. Statements execute top to bottom; later statements can reference
 fields produced by earlier `emit` or `let` statements, and a false `filter`
 excludes the record. Evaluation performs no type inference.
 
+Array literals, map literals, and array comprehensions are ordinary expression
+nodes throughout this pipeline, including inside aggregate residuals. Every AST
+walker must recurse into item/value expressions, computed map keys,
+comprehension sources, and predicates; otherwise schema binding, dependency
+analysis, semantic identity, or lineage can silently miss an input. Runtime
+construction preserves author order, rejects duplicate logical keys after
+canonical escape decoding, and shares a per-record 10 MiB allocation budget and
+64-container depth cap across nested constructors. The aggregate residual
+evaluator enforces the same rules.
+
 The phase split is what makes CXL's compile-time guarantee meaningful: a `cxl check transform.cxl` runs Parse → Resolve → Typecheck and reports any error with a span before a single record is read, e.g.
 
 ```text

--- a/docs/user/src/cxl/types.md
+++ b/docs/user/src/cxl/types.md
@@ -1,6 +1,6 @@
 # Types & Literals
 
-CXL has 9 value types. Every field value, literal, and expression result is one of these types.
+CXL has 10 value types. Every field value, literal, and expression result is one of these types.
 
 ## Value types
 
@@ -106,6 +106,51 @@ $ cxl eval -e 'emit nothing = null'
   "nothing": null
 }
 ```
+
+### Arrays and comprehensions
+
+Array literals accept full expressions and preserve their written order:
+
+```cxl
+emit values = [order_id, amount * 2, null]
+```
+
+Use one `for` clause and an optional trailing `if` to construct an array from
+another array:
+
+```cxl
+emit positive_doubles = [item * 2 for item in values if item > 0]
+```
+
+The source must be an array; `null` and scalar sources are errors. The binding
+is local to the item expression and predicate, cannot destructure, and cannot
+shadow an input field or surrounding `let` binding.
+
+### Maps
+
+Map literals preserve key insertion order. Bare identifiers and quoted strings
+are static keys; brackets hold a computed expression whose result must be a
+non-null string:
+
+```cxl
+emit payload = {
+  customer: customer_name,
+  items: [{sku: item.sku, quantity: item.quantity} for item in line_items],
+  [dynamic_key]: dynamic_value,
+}
+```
+
+Duplicate keys are errors, including two differently escaped spellings that
+decode to the same logical key. Nested maps and arrays are limited to 64
+container levels, and CXL construction is limited to 10 MiB per input record;
+both limits fail the record instead of growing without bound.
+
+Nested keys use one canonical escape grammar. After CXL string decoding, one
+leading backslash makes a reserved-looking key literal: `\@name`, `\#text`,
+or `\\name`. In CXL source each backslash in a quoted string is itself escaped,
+so write `"\\@name"`, `"\\#text"`, or `"\\\\name"`. Other leading-backslash
+forms are rejected. Output formats decide how the neutral nested value is
+encoded; their format documentation defines that boundary.
 
 ## Schema types
 


### PR DESCRIPTION
## Summary

- add ordered array and map literals plus filtered array comprehensions
- enforce canonical nested keys, duplicate detection, a 64-level depth limit, and a 10 MiB per-record construction budget
- carry the new expression forms through resolution, typechecking, planning, aggregate evaluation, refactoring, formatting, and lineage
- document the author-facing CXL syntax and limits

## Why

Nested values already exist in the neutral record model, but pipeline authors could not construct them in CXL. This closes that language gap without introducing an unbounded collection path.

The expression variants form one compile boundary because CXL and its downstream semantic consumers use closed matches. Writer-specific JSON and XML encoding is kept in a separate follow-up pull request.

## Testing

- cargo test -p cxl --lib --locked --offline
- cargo check --workspace --all-targets --locked --offline
- cargo fmt --all --check
- affected-crate Clippy with warnings denied