### PR TITLE
Write nested values as native JSON and XML

### DIFF
--- a/crates/clinker-exec/tests/nested_cxl_write_e2e.rs
+++ b/crates/clinker-exec/tests/nested_cxl_write_e2e.rs
@@ -1,0 +1,98 @@
+//! Production-path proof for CXL native nested construction: pipeline YAML is
+//! parsed and compiled, a real transform evaluates maps/arrays/comprehensions,
+//! and both recursive writers receive the resulting neutral value.
+
+mod common;
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+
+const PIPELINE: &str = r##"
+pipeline:
+  name: nested_cxl_write
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: ./in.csv
+      options:
+        has_header: true
+      schema:
+        - { name: first, type: string }
+        - { name: second, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        emit payload = {
+          "@kind": "event",
+          "#text": "before",
+          item: [{"@id": item, "#text": item.to_string()} for item in [first.to_int(), second.to_int()] if item > 0],
+          tail: "after"
+        }
+  - type: output
+    name: json_out
+    input: construct
+    config:
+      name: json_out
+      type: json
+      path: ./out.json
+      include_unmapped: false
+      options:
+        format: ndjson
+  - type: output
+    name: xml_out
+    input: construct
+    config:
+      name: xml_out
+      type: xml
+      path: ./out.xml
+      include_unmapped: false
+"##;
+
+#[test]
+fn cxl_nested_values_reach_json_and_xml_writers_exactly() {
+    let config = clinker_plan::config::parse_config(PIPELINE).expect("pipeline parses");
+    let readers: SourceReaders = HashMap::from([(
+        "rows".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.csv",
+            Box::new(std::io::Cursor::new(b"first,second\n2,-1\n".to_vec())),
+        ),
+    )]);
+    let json = SharedBuffer::new();
+    let xml = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        (
+            "json_out".to_string(),
+            Box::new(json.clone()) as Box<dyn std::io::Write + Send>,
+        ),
+        (
+            "xml_out".to_string(),
+            Box::new(xml.clone()) as Box<dyn std::io::Write + Send>,
+        ),
+    ]);
+    let params = PipelineRunParams {
+        execution_id: "nested-cxl-e2e".into(),
+        batch_id: "batch-1".into(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    common::run_config(&config, readers, writers, &params).expect("pipeline runs");
+
+    assert_eq!(
+        json.as_string(),
+        "{\"payload\":{\"@kind\":\"event\",\"#text\":\"before\",\"item\":[{\"@id\":2,\"#text\":\"2\"}],\"tail\":\"after\"}}"
+    );
+    assert_eq!(
+        xml.as_string(),
+        "<Root><Record><payload kind=\"event\">before<item id=\"2\">2</item><tail>after</tail></payload></Record></Root>"
+    );
+}

--- a/crates/clinker-format/AGENTS.md
+++ b/crates/clinker-format/AGENTS.md
@@ -76,7 +76,9 @@ Existing dev/bench dependencies are expected: `criterion` and
 - JSON/XML envelope pre-scans retain only declared `$doc.*` paths and enforce `max_index_bytes`.
 - Reader/writer wrappers must delegate hooks such as `current_source_file`, `prepare_document`, `take_envelope_events`, `advance_to_next_file`, `begin_document`, `end_document`, and `bytes_written`.
 - `FormatError::StructuralCount` is the only format error class marked for document-DLQ reclassification; other corruption remains fatal.
-- Non-JSON writers reject `Value::Map` payloads instead of inventing scalar encodings.
+- JSON and XML write `Value::Map` payloads recursively with their documented
+  native key rules; scalar-only writers reject maps instead of inventing an
+  encoding.
 - EDI/HL7 positional ceilings re-exported from readers must stay aligned with planner validation.
 - `SplittingWriter` is a rotation orchestrator; format-specific headers, preambles, and footers belong in writer factories and concrete writers.
 

--- a/crates/clinker-format/src/json/writer.rs
+++ b/crates/clinker-format/src/json/writer.rs
@@ -166,6 +166,15 @@ impl<W: Write> JsonWriter<W> {
     fn serialize_record(&mut self, record: &Record) -> Result<(), FormatError> {
         use serde::Serialize as _;
         self.ensure_plan(record)?;
+        for (index, value) in record.values().iter().enumerate() {
+            if !self.config.include_engine_stamped && record.schema().is_engine_stamped(index) {
+                continue;
+            }
+            clinker_record::nested_key::validate_nested_depth(value)
+                .map_err(|error| FormatError::Json(error.to_string()))?;
+            clinker_record::nested_key::validate_nested_keys(value)
+                .map_err(|error| FormatError::Json(error.to_string()))?;
+        }
         // Disjoint field borrows: serializing reads the plan (`plan_cache`)
         // while writing into `scratch`.
         let Self {
@@ -480,10 +489,21 @@ pub(crate) fn clinker_to_json(val: &Value) -> Result<serde_json::Value, FormatEr
         Value::DateTime(dt) => Jv::String(dt.to_string()),
         Value::Array(arr) => Jv::Array(arr.iter().map(clinker_to_json).collect::<Result<_, _>>()?),
         Value::Map(m) => {
-            let obj = m
-                .iter()
-                .map(|(k, v)| Ok((k.to_string(), clinker_to_json(v)?)))
-                .collect::<Result<_, FormatError>>()?;
+            let mut obj = serde_json::Map::with_capacity(m.len());
+            for (raw_key, value) in m.iter() {
+                let key = clinker_record::nested_key::NestedKey::decode(raw_key)
+                    .map_err(|error| FormatError::Json(error.to_string()))?;
+                let logical_key = key.text.into_owned();
+                if obj
+                    .insert(logical_key.clone(), clinker_to_json(value)?)
+                    .is_some()
+                {
+                    return Err(FormatError::Json(format!(
+                        "duplicate logical nested key {:?}",
+                        logical_key
+                    )));
+                }
+            }
             Jv::Object(obj)
         }
     })
@@ -702,7 +722,9 @@ impl serde::Serialize for ValueSer<'_> {
             Value::Map(m) => {
                 let mut map = serializer.serialize_map(Some(m.len()))?;
                 for (k, v) in m.iter() {
-                    map.serialize_entry(k.as_ref(), &ValueSer(v))?;
+                    let key = clinker_record::nested_key::NestedKey::decode(k)
+                        .map_err(S::Error::custom)?;
+                    map.serialize_entry(key.text.as_ref(), &ValueSer(v))?;
                 }
                 map.end()
             }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -25,6 +25,7 @@ use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 
 use clinker_record::field_path::{self, FieldPathError};
+use clinker_record::nested_key::{NestedKey, validate_nested_depth, validate_nested_keys};
 use clinker_record::{DocumentContext, Record, Schema, Value};
 
 use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
@@ -140,8 +141,8 @@ impl<W: Write> XmlWriter<W> {
 
     /// Fill the reusable `fill` buffer with this record's rendered field values
     /// and per-field presence, in the same iterator order the plan indexes.
-    /// Runs before any bytes are emitted, so a `Value::Map` field (rejected by
-    /// [`write_value_text`]) fails the record without leaving partial output.
+    /// Runs before any bytes are emitted, so malformed recursive values fail
+    /// the record without leaving partial output.
     fn fill_values(&mut self, record: &Record) -> Result<(), FormatError> {
         let Self {
             plan_cache,
@@ -152,14 +153,29 @@ impl<W: Write> XmlWriter<W> {
         let cache = plan_cache.as_ref().expect("plan built before fill_values");
         let flags = &cache.field_is_attr;
         let preserve = config.preserve_nulls;
+        let attribute_prefix = &config.attribute_prefix;
         fill.reset(flags.len());
         if config.include_engine_stamped {
             for (i, (name, val)) in record.iter_all_fields().enumerate() {
-                fill_slot(&mut fill.slots[i], flags[i], preserve, name, val)?;
+                fill_slot(
+                    &mut fill.slots[i],
+                    flags[i],
+                    preserve,
+                    attribute_prefix,
+                    name,
+                    val,
+                )?;
             }
         } else {
             for (i, (name, val)) in record.iter_user_fields().enumerate() {
-                fill_slot(&mut fill.slots[i], flags[i], preserve, name, val)?;
+                fill_slot(
+                    &mut fill.slots[i],
+                    flags[i],
+                    preserve,
+                    attribute_prefix,
+                    name,
+                    val,
+                )?;
             }
         }
         Ok(())
@@ -187,13 +203,38 @@ impl<W: Write> XmlWriter<W> {
         if let Some((field, ref v)) = count_value {
             pairs.push((field, v));
         }
-        let tree = build_field_tree(&pairs, config.preserve_nulls, &config.attribute_prefix)?;
+        let names = pairs.iter().map(|(name, _)| *name).collect::<Vec<_>>();
+        let (plan, field_is_attr) = build_tree_plan(&names, config)?;
+        let mut fill = FillBuf::new();
+        fill.reset(pairs.len());
+        for (index, (name, value)) in pairs.iter().enumerate() {
+            fill_slot(
+                &mut fill.slots[index],
+                field_is_attr[index],
+                config.preserve_nulls,
+                &config.attribute_prefix,
+                name,
+                value,
+            )?;
+        }
+        let values = pairs.iter().map(|(_, value)| *value).collect::<Vec<_>>();
         let mut start = BytesStart::new(wrapper);
-        push_attributes(&mut start, &tree.attrs);
+        for attr in &plan.root.attrs {
+            if fill.emits(attr.field) {
+                push_one_attribute(&mut start, &attr.name, fill.text(attr.field));
+            }
+        }
         writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
-        write_field_tree(writer, &tree.children)?;
+        emit_body(
+            writer,
+            &plan.root,
+            &fill,
+            &values,
+            config.preserve_nulls,
+            &config.attribute_prefix,
+        )?;
         let end = BytesEnd::new(wrapper);
         writer
             .write_event(Event::End(end))
@@ -220,70 +261,23 @@ impl<W: Write> XmlWriter<W> {
     }
 }
 
-/// Recursively write a field tree as nested XML elements. Takes the emitter
-/// directly rather than `&mut self`, so a caller can render an envelope section
-/// while holding a disjoint borrow of the framer.
-fn write_field_tree<W: Write>(
-    writer: &mut XmlEmitter<W>,
-    nodes: &[FieldNode],
-) -> Result<(), FormatError> {
-    for node in nodes {
-        match node {
-            FieldNode::Leaf { name, text } => {
-                if text.is_empty() {
-                    // Self-closing empty element (for preserve_nulls: true)
-                    let elem = BytesStart::new(name.as_str());
-                    writer
-                        .write_event(Event::Empty(elem))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                } else {
-                    let start = BytesStart::new(name.as_str());
-                    writer
-                        .write_event(Event::Start(start))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    let text_event = BytesText::new(text);
-                    writer
-                        .write_event(Event::Text(text_event))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    let end = BytesEnd::new(name.as_str());
-                    writer
-                        .write_event(Event::End(end))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                }
-            }
-            FieldNode::Branch { name, body } => {
-                let mut start = BytesStart::new(name.as_str());
-                push_attributes(&mut start, &body.attrs);
-                if body.children.is_empty() {
-                    // Attribute-only branch: nothing nests inside, so the
-                    // element self-closes carrying its attributes.
-                    writer
-                        .write_event(Event::Empty(start))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                } else {
-                    writer
-                        .write_event(Event::Start(start))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    write_field_tree(writer, &body.children)?;
-                    let end = BytesEnd::new(name.as_str());
-                    writer
-                        .write_event(Event::End(end))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<W: Write + Send> FormatWriter for XmlWriter<W> {
     fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
         // Both the plan build and the value fill run before the record start
         // tag is emitted: attribute-classified fields must be known when the
-        // tag opens, and a rejected field (map payload, malformed attribute
+        // tag opens, and a rejected field (malformed nested value or attribute
         // name) must not leave a dangling half-written record behind.
         self.ensure_plan(record)?;
         self.fill_values(record)?;
+
+        // The plan indexes emitted schema fields positionally. Borrow the
+        // corresponding values for the recursive collection emitter; this
+        // vector is bounded by schema width and does not clone record data.
+        let emitted_values: Vec<&Value> = if self.config.include_engine_stamped {
+            record.iter_all_fields().map(|(_, value)| value).collect()
+        } else {
+            record.iter_user_fields().map(|(_, value)| value).collect()
+        };
 
         self.write_header()?;
 
@@ -307,7 +301,14 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
         }
         writer.write_event(Event::Start(start)).map_err(xml_err)?;
 
-        emit_body(writer, &plan.root, fill)?;
+        emit_body(
+            writer,
+            &plan.root,
+            fill,
+            &emitted_values,
+            config.preserve_nulls,
+            &config.attribute_prefix,
+        )?;
 
         writer
             .write_event(Event::End(BytesEnd::new(&*config.record_element)))
@@ -381,83 +382,14 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
     }
 }
 
-// ── Field tree for dotted name → nested element expansion ────────────
-
 /// Wrap a field-name grammar failure as this writer's error.
 fn field_path_error(source: FieldPathError) -> FormatError {
     FormatError::field_path("XML", source)
 }
 
-/// One element's content: the attributes attached to its start tag plus its
-/// child nodes. The whole body is materialized before the element's start
-/// tag is emitted, because attributes have to be known at that point.
-#[derive(Default)]
-struct ElementBody {
-    attrs: Vec<(String, String)>,
-    children: Vec<FieldNode>,
-}
-
-enum FieldNode {
-    Leaf { name: String, text: String },
-    Branch { name: String, body: ElementBody },
-}
-
-/// Build an element body from dotted field names. Fields with shared
-/// prefixes are grouped under a single parent branch
-/// (`Address.City` + `Address.State` → one `Address` branch with two leaf
-/// children), and a field whose final segment carries the attribute prefix
-/// becomes an attribute of its enclosing element instead of a child
-/// (`@id` → attribute on the returned body, `Address.@type` → attribute on
-/// the `Address` branch).
-///
-/// Null attribute fields are dropped even under `preserve_nulls` — a null
-/// element round-trips as a self-closing tag, but an attribute has no
-/// present-but-empty form that reads back as null.
-///
-/// Returns `FormatError::UnserializableMapValue` if any field carries
-/// a `Value::Map` payload — XML elements have no canonical scalar
-/// serialization for a map, and `value_to_text` raises from the Map
-/// arm directly. Returns `FormatError::Xml` for a malformed attribute
-/// path (a prefixed segment with children nested under it, or a bare
-/// prefix with no attribute name).
-fn build_field_tree(
-    fields: &[(&str, &Value)],
-    preserve_nulls: bool,
-    attribute_prefix: &str,
-) -> Result<ElementBody, FormatError> {
-    field_path::check_expandable(fields.iter().map(|&(name, _)| name)).map_err(field_path_error)?;
-    let mut root = ElementBody::default();
-
-    for &(name, val) in fields {
-        let path = field_path::decode(name).map_err(field_path_error)?;
-        if val.is_null() && (!preserve_nulls || is_attribute_path(&path, attribute_prefix)) {
-            continue;
-        }
-        let text = value_to_text(name, val)?;
-        insert_field(&mut root, name, &path, &text, attribute_prefix)?;
-    }
-
-    Ok(root)
-}
-
-/// Push name/value attributes onto an element's start tag, escaping each
-/// value.
-///
-/// quick-xml's `(&str, &str)` attribute conversion escapes only the five
-/// predefined entities, leaving literal tab / CR / LF untouched — a
-/// conformant parser then collapses those to spaces (XML attribute-value
-/// normalization), silently altering values that carry literal whitespace.
-/// They are written as character references instead, which both clinker's
-/// reader and any conformant parser resolve back to the exact bytes.
-fn push_attributes(start: &mut BytesStart, attrs: &[(String, String)]) {
-    for (key, value) in attrs {
-        push_one_attribute(start, key, value);
-    }
-}
-
 /// Push a single name/value attribute onto an element's start tag, escaping the
-/// value (see [`push_attributes`] for why literal whitespace is emitted as
-/// character references).
+/// value. Literal whitespace is emitted as character references so a
+/// conformant parser does not normalize it to spaces.
 fn push_one_attribute(start: &mut BytesStart, key: &str, value: &str) {
     start.push_attribute(Attribute {
         key: QName(key.as_bytes()),
@@ -489,15 +421,6 @@ fn escape_attribute_value(raw: &str) -> String {
         }
     }
     escaped
-}
-
-/// True when the path's final segment is attribute-classified — i.e. a
-/// non-empty prefix marks it as an attribute of its enclosing element.
-fn is_attribute_path(path: &[Cow<'_, str>], attribute_prefix: &str) -> bool {
-    !attribute_prefix.is_empty()
-        && path
-            .last()
-            .is_some_and(|segment| segment.starts_with(attribute_prefix))
 }
 
 /// True when `c` may begin an XML 1.0 `Name` (the `NameStartChar`
@@ -570,86 +493,12 @@ fn check_xml_name(name: &str, context: &str) -> Result<(), FormatError> {
     }
 }
 
-/// Insert a decoded field path into the tree, creating branches as needed.
-/// An attribute-prefixed segment must be the path's final segment (an
-/// attribute is a leaf — nothing can nest under it); `field` is the full
-/// original field name, carried for error messages.
-fn insert_field(
-    body: &mut ElementBody,
-    field: &str,
-    path: &[Cow<'_, str>],
-    text: &str,
-    attribute_prefix: &str,
-) -> Result<(), FormatError> {
-    let (segment, rest) = path
-        .split_first()
-        .expect("a decoded field path has at least one segment");
-    if !rest.is_empty() {
-        if !attribute_prefix.is_empty() && segment.starts_with(attribute_prefix) {
-            return Err(FormatError::Xml(format!(
-                "field '{field}': attribute-prefixed segment '{segment}' \
-                 cannot have fields nested under it — an XML attribute is a leaf"
-            )));
-        }
-        check_xml_name(segment, &format!("field '{field}': element"))?;
-        // Find or create a branch for `segment`
-        let branch = body.children.iter_mut().find(
-            |n| matches!(n, FieldNode::Branch { name, .. } if name.as_str() == segment.as_ref()),
-        );
-        if let Some(FieldNode::Branch {
-            body: branch_body, ..
-        }) = branch
-        {
-            insert_field(branch_body, field, rest, text, attribute_prefix)
-        } else {
-            let mut branch_body = ElementBody::default();
-            insert_field(&mut branch_body, field, rest, text, attribute_prefix)?;
-            body.children.push(FieldNode::Branch {
-                name: segment.to_string(),
-                body: branch_body,
-            });
-            Ok(())
-        }
-    } else if !attribute_prefix.is_empty() && segment.starts_with(attribute_prefix) {
-        let attr_name = &segment[attribute_prefix.len()..];
-        if attr_name.is_empty() {
-            return Err(FormatError::Xml(format!(
-                "field '{field}': attribute prefix '{attribute_prefix}' \
-                 carries no attribute name"
-            )));
-        }
-        if !is_valid_xml_name(attr_name) {
-            return Err(FormatError::Xml(format!(
-                "field '{field}': attribute name '{attr_name}' is not a \
-                 well-formed XML name"
-            )));
-        }
-        body.attrs.push((attr_name.to_string(), text.to_string()));
-        Ok(())
-    } else {
-        check_xml_name(segment, &format!("field '{field}': element"))?;
-        body.children.push(FieldNode::Leaf {
-            name: segment.to_string(),
-            text: text.to_string(),
-        });
-        Ok(())
-    }
-}
-
 /// Convert a clinker Value to XML text content.
 ///
-/// This renders a single scalar into one element body. A top-level
-/// `Value::Array` at a record element field is a `multiple:` field, emitted as
-/// repeated child elements before reaching here (see [`fill_slot`] and
-/// [`emit_repeated_leaf`]) — so an array reaching this scalar renderer is a
-/// NESTED collection (an array or map inside a `multiple:` field), which has no
-/// element-body serialization. A `Value::Map` likewise has none. Both return
-/// `FormatError::UnserializableMapValue` / `FormatError::UnserializableArrayValue`
-/// carrying the offending column rather than being silently flattened, which
-/// would hide a routing bug (e.g. a `$widened` sidecar reaching the writer
-/// without `include_unmapped: true` expansion). The envelope-section path also
-/// renders through here, so a section field carrying a collection is rejected
-/// the same way.
+/// This renders one scalar for an element body, attribute, or `#text` entry.
+/// Recursive callers dispatch arrays and maps before reaching this helper; the
+/// collection error arms are defensive invariant checks rather than a fallback
+/// serialization.
 fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
     let mut buf = String::new();
     write_value_text(&mut buf, col, val)?;
@@ -657,9 +506,7 @@ fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
 }
 
 /// Render a clinker Value as XML text content into `buf` (appending). Shares
-/// its logic with [`value_to_text`] so the record fast path and the envelope
-/// section path stay byte-identical. `Value::Map` and `Value::Array` are
-/// rejected exactly as `value_to_text` documents.
+/// its logic with [`value_to_text`] so every scalar path stays byte-identical.
 fn write_value_text(buf: &mut String, col: &str, val: &Value) -> Result<(), FormatError> {
     use std::fmt::Write as _;
     match val {
@@ -766,14 +613,25 @@ struct PlanCache {
 
 /// Build the tree plan for a record's schema. Walks the fields in iterator
 /// order (position = field index) and classifies each into the element tree,
-/// validating attribute names up front. Mirrors [`build_field_tree`]'s shape
-/// exactly so output stays byte-identical.
+/// validating attribute names up front.
 fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCache, FormatError> {
     let names: Vec<&str> = if config.include_engine_stamped {
         record.iter_all_fields().map(|(name, _)| name).collect()
     } else {
         record.iter_user_fields().map(|(name, _)| name).collect()
     };
+    let (plan, field_is_attr) = build_tree_plan(&names, config)?;
+    Ok(PlanCache {
+        schema: Arc::clone(record.schema()),
+        plan,
+        field_is_attr,
+    })
+}
+
+fn build_tree_plan(
+    names: &[&str],
+    config: &XmlWriterConfig,
+) -> Result<(TreePlan, Vec<bool>), FormatError> {
     field_path::check_expandable(names.iter().copied()).map_err(field_path_error)?;
     let mut root = PlanBody::default();
     let mut field_is_attr = vec![false; names.len()];
@@ -789,11 +647,7 @@ fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCac
             &mut field_is_attr,
         )?;
     }
-    Ok(PlanCache {
-        schema: Arc::clone(record.schema()),
-        plan: TreePlan { root },
-        field_is_attr,
-    })
+    Ok((TreePlan { root }, field_is_attr))
 }
 
 /// Insert a decoded field path into the plan, creating branches as needed —
@@ -931,16 +785,13 @@ struct FillBuf {
 
 #[derive(Default)]
 struct FillSlot {
-    /// Scalar rendering. Empty when the field is null-dropped or holds an array.
+    /// Scalar rendering. Empty when the field is null-dropped or holds a
+    /// recursively structured value.
     text: String,
-    /// Per-element renderings when the field's value is a `Value::Array`. The
-    /// live entries are `parts[..part_count]`; the `Vec` and each inner `String`
-    /// retain their capacity across records, like `text` does.
-    parts: Vec<String>,
-    part_count: usize,
-    /// True when this slot holds an array — the repeated-element emit path reads
-    /// `parts` rather than `text`.
-    is_array: bool,
+    /// True for a native array or map. The emitter then borrows the original
+    /// record value after the validation pass instead of materializing a
+    /// second owned tree.
+    is_structured: bool,
     emits: bool,
 }
 
@@ -967,12 +818,8 @@ impl FillBuf {
         &self.slots[field].text
     }
 
-    /// The per-element renderings for an array field, or `None` for a scalar.
-    /// A returned slice is always non-empty: an empty array sets `emits = false`,
-    /// so callers gate on `emits` before reaching here.
-    fn parts(&self, field: usize) -> Option<&[String]> {
-        let slot = &self.slots[field];
-        slot.is_array.then_some(&slot.parts[..slot.part_count])
+    fn is_structured(&self, field: usize) -> bool {
+        self.slots[field].is_structured
     }
 }
 
@@ -983,38 +830,23 @@ impl FillBuf {
 /// preserved null element renders to the empty string, emitted as a self-closing
 /// tag).
 ///
-/// A `Value::Array` at an ELEMENT field is a `multiple:` field: each element is
-/// rendered into `parts` for the repeated-element emit path, and an empty array
-/// drops the field (`emits = false`) so it emits nothing. An array at an
-/// ATTRIBUTE field is rejected — an XML attribute holds a single value and
-/// cannot repeat.
+/// Arrays and maps at element fields are fully validated here before the record
+/// start tag is written, then emitted recursively from the borrowed value.
+/// Attributes remain scalar-only.
 fn fill_slot(
     slot: &mut FillSlot,
     is_attr: bool,
     preserve_nulls: bool,
+    attribute_prefix: &str,
     name: &str,
     val: &Value,
 ) -> Result<(), FormatError> {
-    slot.is_array = false;
-    slot.part_count = 0;
+    slot.is_structured = false;
     match val {
         Value::Array(items) if !is_attr => {
-            // BACKSTOP GAP: this treats ANY top-level array at an element field
-            // as a `multiple:` field and emits repeated elements, because the
-            // writer is not given the declared-`multiple:` column set — its
-            // config carries only the `join_values` override subset, not every
-            // declared-multiple field. A misrouted runtime array on a column
-            // that is NOT declared `multiple:` (e.g. a stray `match: collect`
-            // result) is therefore emitted as repeats rather than failing loud
-            // with `UnserializableArrayValue`. A NESTED array (array-inside-a-
-            // field) is still caught by `write_value_text` in `fill_parts`;
-            // only the top-level non-multiple case slips through. Restoring the
-            // loud backstop needs the plan to thread the declared-multiple set
-            // into `XmlWriterConfig` — the same missing plumbing the CSV writer
-            // has at https://github.com/rustpunk/clinker/issues/853.
-            slot.is_array = true;
+            validate_xml_nested_value(val, name, attribute_prefix)?;
+            slot.is_structured = true;
             slot.text.clear();
-            fill_parts(slot, name, items)?;
             slot.emits = !items.is_empty();
         }
         Value::Array(_) => {
@@ -1022,6 +854,19 @@ fn fill_slot(
                 "field '{name}': an XML attribute cannot hold multiple values — a \
                  `multiple:` field maps to repeated elements, not an attribute"
             )));
+        }
+        Value::Map(_) if is_attr => {
+            return Err(FormatError::UnserializableMapValue {
+                format: "XML",
+                column: name.to_string(),
+            });
+        }
+        Value::Map(_) => {
+            validate_xml_nested_value(val, name, attribute_prefix)?;
+            slot.is_structured = true;
+            slot.text.clear();
+            // A map has a named container even when it has no children.
+            slot.emits = true;
         }
         _ => {
             let skip = if is_attr {
@@ -1039,31 +884,86 @@ fn fill_slot(
     Ok(())
 }
 
-/// Render each element of a `multiple:` field's array into the slot's `parts`,
-/// reusing the existing `String` capacity. A nested collection element (an array
-/// or map inside the field) has no element body and is rejected by
-/// [`write_value_text`], the same misroute detection the scalar path applies.
-fn fill_parts(slot: &mut FillSlot, name: &str, items: &[Value]) -> Result<(), FormatError> {
-    if slot.parts.len() < items.len() {
-        slot.parts.resize_with(items.len(), String::new);
+/// Validate every recursive XML decision before any bytes for the record are
+/// written. Neutral maps preserve insertion order; unescaped reserved keys
+/// become attributes or text, while escaped keys remain ordinary element
+/// names. Arrays repeat their containing element name and therefore cannot be
+/// nested directly inside another array without an intervening map key.
+fn validate_xml_nested_value(
+    value: &Value,
+    field: &str,
+    attribute_prefix: &str,
+) -> Result<(), FormatError> {
+    validate_nested_depth(value)
+        .map_err(|error| FormatError::Xml(format!("field '{field}': {error}")))?;
+    validate_nested_keys(value)
+        .map_err(|error| FormatError::Xml(format!("field '{field}': {error}")))?;
+
+    fn visit(value: &Value, field: &str, attribute_prefix: &str) -> Result<(), FormatError> {
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    if matches!(item, Value::Array(_)) {
+                        return Err(FormatError::UnserializableArrayValue {
+                            format: "XML",
+                            column: field.to_string(),
+                        });
+                    }
+                    visit(item, field, attribute_prefix)?;
+                }
+            }
+            Value::Map(entries) => {
+                for (raw_key, child) in entries.iter() {
+                    let key = NestedKey::decode(raw_key).expect("keys validated above");
+                    let is_attribute = !key.escaped
+                        && !attribute_prefix.is_empty()
+                        && key.text.starts_with(attribute_prefix);
+                    let is_text = !key.escaped && key.text == "#text";
+                    if is_attribute {
+                        let name = &key.text[attribute_prefix.len()..];
+                        if name.is_empty() {
+                            return Err(FormatError::Xml(format!(
+                                "field '{field}': attribute prefix '{attribute_prefix}' carries no attribute name"
+                            )));
+                        }
+                        check_xml_name(name, &format!("field '{field}': nested attribute"))?;
+                        if matches!(child, Value::Array(_) | Value::Map(_)) {
+                            return Err(FormatError::Xml(format!(
+                                "field '{field}': nested XML attribute '{}' must hold a scalar value",
+                                key.text
+                            )));
+                        }
+                    } else if is_text {
+                        if matches!(child, Value::Array(_) | Value::Map(_)) {
+                            return Err(FormatError::Xml(format!(
+                                "field '{field}': nested XML #text must hold a scalar value"
+                            )));
+                        }
+                    } else {
+                        check_xml_name(&key.text, &format!("field '{field}': nested element"))?;
+                        visit(child, field, attribute_prefix)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
     }
-    for (i, item) in items.iter().enumerate() {
-        slot.parts[i].clear();
-        write_value_text(&mut slot.parts[i], name, item)?;
-    }
-    slot.part_count = items.len();
-    Ok(())
+
+    visit(value, field, attribute_prefix)
 }
 
 /// Emit a body's child nodes (its start-tag attributes are handled by the
 /// caller). A branch is emitted only when it has at least one emitting
 /// attribute or child, and self-closes when it has no emitting children —
-/// matching the pruning `build_field_tree` performs by never inserting a
-/// dropped field.
+/// matching the null-pruning rules used while filling each leaf.
 fn emit_body<W: Write>(
     writer: &mut XmlEmitter<W>,
     body: &PlanBody,
     fill: &FillBuf,
+    values: &[&Value],
+    preserve_nulls: bool,
+    attribute_prefix: &str,
 ) -> Result<(), FormatError> {
     for child in &body.children {
         match child {
@@ -1075,8 +975,15 @@ fn emit_body<W: Write>(
                 if !fill.emits(*field) {
                     continue;
                 }
-                if let Some(parts) = fill.parts(*field) {
-                    emit_repeated_leaf(writer, name, repeat, parts)?;
+                if fill.is_structured(*field) {
+                    emit_structured_leaf(
+                        writer,
+                        name,
+                        repeat,
+                        values[*field],
+                        preserve_nulls,
+                        attribute_prefix,
+                    )?;
                     continue;
                 }
                 let text = fill.text(*field);
@@ -1122,7 +1029,7 @@ fn emit_body<W: Write>(
                 }
                 if has_children {
                     writer.write_event(Event::Start(start)).map_err(xml_err)?;
-                    emit_body(writer, body, fill)?;
+                    emit_body(writer, body, fill, values, preserve_nulls, attribute_prefix)?;
                     writer
                         .write_event(Event::End(BytesEnd::new(name.as_str())))
                         .map_err(xml_err)?;
@@ -1133,6 +1040,160 @@ fn emit_body<W: Write>(
         }
     }
     Ok(())
+}
+
+/// Emit one schema leaf whose value is a native map or array. Array items reuse
+/// the leaf (or configured `repeat_as`) name; a map is one structured item.
+fn emit_structured_leaf<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    leaf_name: &str,
+    repeat: &Option<XmlRepeat>,
+    value: &Value,
+    preserve_nulls: bool,
+    attribute_prefix: &str,
+) -> Result<(), FormatError> {
+    let item_name = repeat.as_ref().map_or(leaf_name, |r| r.item_name.as_str());
+    let wrap_in = repeat.as_ref().and_then(|r| r.wrap_in.as_deref());
+    if let Some(container) = wrap_in {
+        writer
+            .write_event(Event::Start(BytesStart::new(container)))
+            .map_err(xml_err)?;
+    }
+
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                emit_named_value(writer, item_name, item, preserve_nulls, attribute_prefix)?;
+            }
+        }
+        Value::Map(_) => {
+            emit_named_value(writer, item_name, value, preserve_nulls, attribute_prefix)?
+        }
+        _ => unreachable!("structured slots contain only maps and arrays"),
+    }
+
+    if let Some(container) = wrap_in {
+        writer
+            .write_event(Event::End(BytesEnd::new(container)))
+            .map_err(xml_err)?;
+    }
+    Ok(())
+}
+
+/// Emit a named native value recursively. Validation has already established
+/// legal names, scalar-only attributes/text, canonical keys, and bounded depth.
+fn emit_named_value<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    name: &str,
+    value: &Value,
+    preserve_nulls: bool,
+    attribute_prefix: &str,
+) -> Result<(), FormatError> {
+    match value {
+        Value::Null if !preserve_nulls => Ok(()),
+        Value::Null => writer
+            .write_event(Event::Empty(BytesStart::new(name)))
+            .map_err(xml_err),
+        Value::Array(items) => {
+            for item in items {
+                emit_named_value(writer, name, item, preserve_nulls, attribute_prefix)?;
+            }
+            Ok(())
+        }
+        Value::Map(entries) => {
+            let mut start = BytesStart::new(name);
+            for (raw_key, child) in entries.iter() {
+                let key = NestedKey::decode(raw_key).expect("keys validated before emission");
+                let is_attribute = !key.escaped
+                    && !attribute_prefix.is_empty()
+                    && key.text.starts_with(attribute_prefix);
+                if is_attribute && !child.is_null() {
+                    let attr_name = &key.text[attribute_prefix.len()..];
+                    let text = value_to_text(raw_key, child)?;
+                    push_one_attribute(&mut start, attr_name, &text);
+                }
+            }
+
+            if !map_has_content(entries, preserve_nulls, attribute_prefix) {
+                return writer.write_event(Event::Empty(start)).map_err(xml_err);
+            }
+            writer.write_event(Event::Start(start)).map_err(xml_err)?;
+            for (raw_key, child) in entries.iter() {
+                let key = NestedKey::decode(raw_key).expect("keys validated before emission");
+                let is_attribute = !key.escaped
+                    && !attribute_prefix.is_empty()
+                    && key.text.starts_with(attribute_prefix);
+                if is_attribute {
+                    continue;
+                }
+                if !key.escaped && key.text == "#text" {
+                    if !child.is_null() {
+                        let text = value_to_text(raw_key, child)?;
+                        if !text.is_empty() {
+                            writer
+                                .write_event(Event::Text(BytesText::new(&text)))
+                                .map_err(xml_err)?;
+                        }
+                    }
+                    continue;
+                }
+                emit_named_value(writer, &key.text, child, preserve_nulls, attribute_prefix)?;
+            }
+            writer
+                .write_event(Event::End(BytesEnd::new(name)))
+                .map_err(xml_err)
+        }
+        _ => {
+            let text = value_to_text(name, value)?;
+            if text.is_empty() {
+                writer
+                    .write_event(Event::Empty(BytesStart::new(name)))
+                    .map_err(xml_err)
+            } else {
+                writer
+                    .write_event(Event::Start(BytesStart::new(name)))
+                    .map_err(xml_err)?;
+                writer
+                    .write_event(Event::Text(BytesText::new(&text)))
+                    .map_err(xml_err)?;
+                writer
+                    .write_event(Event::End(BytesEnd::new(name)))
+                    .map_err(xml_err)
+            }
+        }
+    }
+}
+
+fn map_has_content(
+    entries: &indexmap::IndexMap<Box<str>, Value>,
+    preserve_nulls: bool,
+    attribute_prefix: &str,
+) -> bool {
+    entries.iter().any(|(raw_key, child)| {
+        let key = NestedKey::decode(raw_key).expect("keys validated before emission");
+        let is_attribute =
+            !key.escaped && !attribute_prefix.is_empty() && key.text.starts_with(attribute_prefix);
+        if is_attribute {
+            return false;
+        }
+        if !key.escaped && key.text == "#text" {
+            return match child {
+                Value::Null => false,
+                Value::String(text) => !text.is_empty(),
+                _ => true,
+            };
+        }
+        value_emits(child, preserve_nulls)
+    })
+}
+
+fn value_emits(value: &Value, preserve_nulls: bool) -> bool {
+    match value {
+        Value::Null => preserve_nulls,
+        Value::Array(items) => items.iter().any(|item| value_emits(item, preserve_nulls)),
+        Value::Map(_) => true,
+        _ => true,
+    }
 }
 
 /// Emit a `multiple:` field's values as repeated child elements. `parts` holds
@@ -1443,30 +1504,78 @@ mod tests {
         assert_eq!(r2.get("name"), Some(&Value::String("Bob".into())));
     }
 
-    /// XML writer rejects `Value::Map` payloads with
-    /// `FormatError::UnserializableMapValue`. The pre-walk in
-    /// `write_fields` catches the misroute before the value-to-text
-    /// function silently JSON-encodes the map inside an element.
+    /// Native maps use reserved `@...` and `#text` keys while ordinary keys
+    /// become child elements. Arrays repeat their containing child name and
+    /// preserve author insertion order.
     #[test]
-    fn test_xml_writer_rejects_map_value() {
+    fn test_xml_writer_emits_recursive_map_and_array_values() {
         use indexmap::IndexMap;
         let schema = Arc::new(Schema::new(vec!["id".into(), "payload".into()]));
-        let mut sidecar: IndexMap<Box<str>, Value> = IndexMap::new();
-        sidecar.insert("a".into(), Value::Integer(1));
+
+        let mut first: IndexMap<Box<str>, Value> = IndexMap::new();
+        first.insert("@id".into(), Value::Integer(1));
+        first.insert("#text".into(), Value::String("alpha".into()));
+        let mut second: IndexMap<Box<str>, Value> = IndexMap::new();
+        second.insert("@id".into(), Value::Integer(2));
+        second.insert("#text".into(), Value::String("beta".into()));
+
+        let mut payload: IndexMap<Box<str>, Value> = IndexMap::new();
+        payload.insert("@kind".into(), Value::String("event".into()));
+        payload.insert("#text".into(), Value::String("before".into()));
+        payload.insert(
+            "item".into(),
+            Value::Array(vec![
+                Value::Map(Box::new(first)),
+                Value::Map(Box::new(second)),
+            ]),
+        );
+        payload.insert("tail".into(), Value::String("after".into()));
         let record = Record::new(
             Arc::clone(&schema),
-            vec![Value::Integer(7), Value::Map(Box::new(sidecar))],
+            vec![Value::Integer(7), Value::Map(Box::new(payload))],
         );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(
+            output,
+            "<Root><Record><id>7</id><payload kind=\"event\">before<item id=\"1\">alpha</item><item id=\"2\">beta</item><tail>after</tail></payload></Record></Root>"
+        );
+    }
+
+    #[test]
+    fn test_xml_writer_rejects_duplicate_decoded_map_keys_before_output() {
+        use indexmap::IndexMap;
+        let schema = Arc::new(Schema::new(vec!["payload".into()]));
+        let mut payload: IndexMap<Box<str>, Value> = IndexMap::new();
+        payload.insert("@id".into(), Value::Integer(1));
+        payload.insert("\\@id".into(), Value::Integer(2));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Map(Box::new(payload))]);
         let mut buf = Vec::new();
         let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
         let err = writer.write_record(&record).unwrap_err();
-        match err {
-            FormatError::UnserializableMapValue { format, column } => {
-                assert_eq!(format, "XML");
-                assert_eq!(column, "payload");
-            }
-            other => panic!("expected UnserializableMapValue, got {other:?}"),
-        }
+        assert!(
+            matches!(&err, FormatError::Xml(message) if message.contains("duplicate logical nested key \"@id\"")),
+            "unexpected error: {err:?}"
+        );
+        drop(writer);
+        assert!(buf.is_empty(), "rejected record must emit no partial XML");
+    }
+
+    #[test]
+    fn test_xml_writer_rejects_collection_valued_nested_attribute_before_output() {
+        use indexmap::IndexMap;
+        let schema = Arc::new(Schema::new(vec!["payload".into()]));
+        let mut payload: IndexMap<Box<str>, Value> = IndexMap::new();
+        payload.insert("@ids".into(), Value::Array(vec![Value::Integer(1)]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Map(Box::new(payload))]);
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Xml(message) if message.contains("attribute '@ids' must hold a scalar")),
+            "unexpected error: {err:?}"
+        );
+        drop(writer);
+        assert!(buf.is_empty(), "rejected record must emit no partial XML");
     }
 
     /// Build a `[id, tags]` record whose `tags` field carries `values`.
@@ -2411,6 +2520,37 @@ mod tests {
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains(r#"<header version="1.1"><batch_id>A</batch_id></header>"#),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn xml_envelope_section_writes_native_nested_value() {
+        use indexmap::IndexMap;
+
+        let schema = Arc::new(Schema::new(vec!["amount".into()]));
+        let config = XmlWriterConfig {
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: None,
+                footer_record_count_field: None,
+            }),
+            ..Default::default()
+        };
+        let mut metadata: IndexMap<Box<str>, Value> = IndexMap::new();
+        metadata.insert("@kind".into(), Value::String("batch".into()));
+        metadata.insert("name".into(), Value::String("A".into()));
+        let doc = doc_with_sections(&[("Head", &[("metadata", Value::Map(Box::new(metadata)))])]);
+        let mut buf = Vec::new();
+        {
+            let mut w = XmlWriter::new(&mut buf, Arc::clone(&schema), config);
+            w.begin_document(&doc).unwrap();
+            w.end_document(&doc).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains(r#"<header><metadata kind="batch"><name>A</name></metadata></header>"#),
             "got: {out}"
         );
     }

--- a/crates/clinker-format/tests/nested_write_symmetry.rs
+++ b/crates/clinker-format/tests/nested_write_symmetry.rs
@@ -12,6 +12,7 @@ use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
 use clinker_format::{FormatError, FormatWriter};
 use clinker_record::schema::FieldMetadata;
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
+use indexmap::IndexMap;
 
 fn schema_of(columns: &[&str]) -> Arc<Schema> {
     columns.iter().copied().collect::<SchemaBuilder>().build()
@@ -211,4 +212,101 @@ fn both_writers_refuse_a_malformed_escape() {
         let err = err.expect("a malformed escape is refused by both writers");
         assert!(matches!(err, FormatError::FieldPath { .. }), "{err:?}");
     }
+}
+
+#[test]
+fn native_nested_values_keep_order_and_format_specific_xml_roles() {
+    let schema = schema_of(&["payload"]);
+    let mut first = IndexMap::new();
+    first.insert("@id".into(), Value::Integer(1));
+    first.insert("#text".into(), Value::String("alpha".into()));
+    let mut second = IndexMap::new();
+    second.insert("@id".into(), Value::Integer(2));
+    second.insert("#text".into(), Value::String("beta".into()));
+    let mut payload = IndexMap::new();
+    payload.insert("@kind".into(), Value::String("event".into()));
+    payload.insert("#text".into(), Value::String("before".into()));
+    payload.insert(
+        "item".into(),
+        Value::Array(vec![
+            Value::Map(Box::new(first)),
+            Value::Map(Box::new(second)),
+        ]),
+    );
+    payload.insert("tail".into(), Value::String("after".into()));
+    let value = Value::Map(Box::new(payload));
+
+    assert_eq!(
+        write_json(&schema, vec![value.clone()], false),
+        r##"{"payload":{"@kind":"event","#text":"before","item":[{"@id":1,"#text":"alpha"},{"@id":2,"#text":"beta"}],"tail":"after"}}"##
+    );
+    assert_eq!(
+        write_xml(&schema, vec![value], false),
+        "<Root><Record><payload kind=\"event\">before<item id=\"1\">alpha</item><item id=\"2\">beta</item><tail>after</tail></payload></Record></Root>"
+    );
+}
+
+#[test]
+fn escaped_nested_keys_decode_for_json_and_are_validated_before_output() {
+    let schema = schema_of(&["payload"]);
+    let mut payload = IndexMap::new();
+    payload.insert("\\@literal".into(), Value::Integer(1));
+    assert_eq!(
+        write_json(&schema, vec![Value::Map(Box::new(payload))], false),
+        r#"{"payload":{"@literal":1}}"#
+    );
+
+    let mut duplicate = IndexMap::new();
+    duplicate.insert("@id".into(), Value::Integer(1));
+    duplicate.insert("\\@id".into(), Value::Integer(2));
+    let record = Record::new(Arc::clone(&schema), vec![Value::Map(Box::new(duplicate))]);
+    let mut json_buf = Vec::new();
+    let mut json = JsonWriter::new(
+        &mut json_buf,
+        Arc::clone(&schema),
+        JsonWriterConfig::default(),
+    );
+    assert!(json.write_record(&record).is_err());
+    drop(json);
+    assert!(json_buf.is_empty());
+
+    let mut xml_buf = Vec::new();
+    let mut xml = XmlWriter::new(
+        &mut xml_buf,
+        Arc::clone(&schema),
+        XmlWriterConfig::default(),
+    );
+    assert!(xml.write_record(&record).is_err());
+    drop(xml);
+    assert!(xml_buf.is_empty());
+}
+
+#[test]
+fn both_recursive_writers_reject_depth_cap_plus_one_before_output() {
+    let schema = schema_of(&["payload"]);
+    let mut value = Value::Null;
+    for _ in 0..=clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+        value = Value::Array(vec![value]);
+    }
+    let record = Record::new(Arc::clone(&schema), vec![value]);
+
+    let mut json_buf = Vec::new();
+    let mut json = JsonWriter::new(
+        &mut json_buf,
+        Arc::clone(&schema),
+        JsonWriterConfig::default(),
+    );
+    assert!(json.write_record(&record).is_err());
+    drop(json);
+    assert!(json_buf.is_empty());
+
+    let mut xml_buf = Vec::new();
+    let mut xml = XmlWriter::new(
+        &mut xml_buf,
+        Arc::clone(&schema),
+        XmlWriterConfig::default(),
+    );
+    assert!(xml.write_record(&record).is_err());
+    drop(xml);
+    assert!(xml_buf.is_empty());
 }

--- a/docs/engine/src/auto-widen-internals.md
+++ b/docs/engine/src/auto-widen-internals.md
@@ -46,11 +46,17 @@ When `include_unmapped: true` (the default), fields the source absorbed into `$w
 
 `include_unmapped` composes independently with `include_correlation_keys`; the two flags are orthogonal — `include_correlation_keys` does not surface `$widened`. Because expansion is a projection-layer operation, a CSV source under `auto_widen` feeding a JSON output under `include_unmapped: true` produces JSON objects whose top-level keys include both declared columns and absorbed input columns, with no sidecar key remaining.
 
-## Writer rejection of `Value::Map` payloads
+## Writer handling of `Value::Map` payloads
 
-CSV, XML, and fixed-width writers refuse any record carrying a `Value::Map` payload at any column slot, raising `FormatError::UnserializableMapValue { format, column }`. The rejection lives in **each writer's value-to-string helper** — a single point of truth, with no defensive prechecks scattered ahead of it. JSON serializes `Value::Map` natively as a nested object and never raises.
+CSV and fixed-width writers refuse a user-visible `Value::Map` column, raising
+`FormatError::UnserializableMapValue { format, column }`. JSON writes a map as
+a native object; XML recursively maps it to elements, attributes, and text.
 
-The common trigger is the `$widened` sidecar reaching one of those three writers because the Output node set `include_unmapped: false` (which suppresses the projection-layer expansion that would otherwise have flattened the map to top-level scalars). Two remediations exist, and the error message names both: leave `include_unmapped` at its default `true` so projection expands the map before write, or coerce the map to a scalar in CXL before the emit.
+The `$widened` map is different from a user-visible nested value: Output
+projection expands it to top-level fields under `include_unmapped: true`, or
+strips it under `include_unmapped: false`. It is never passed through as the
+author's JSON/XML nested structure. That projection rule keeps schema-drift
+handling separate from the recursive writer vocabulary.
 
 ### DLQ filtering
 

--- a/docs/engine/src/output-internals.md
+++ b/docs/engine/src/output-internals.md
@@ -1,6 +1,6 @@
 # Streaming Output Writes
 
-Output nodes are the terminal sinks of a pipeline. When the planner certifies a single linear producer feeding one Output, the executor can take a **streaming handoff** that wires the producer arm to a dedicated writer thread through a bounded crossbeam channel and fires `Writer::write_record` per record, concurrent with producer emission. Other producer shapes materialize their output before the writer fires. This page covers the topology that selects the streaming handoff, its relationship to Source-to-Merge fusion, the back-pressure chain, the counter semantics that must match the buffered arm, and the writer contract that rejects `Value::Map` payloads.
+Output nodes are the terminal sinks of a pipeline. When the planner certifies a single linear producer feeding one Output, the executor can take a **streaming handoff** that wires the producer arm to a dedicated writer thread through a bounded crossbeam channel and fires `Writer::write_record` per record, concurrent with producer emission. Other producer shapes materialize their output before the writer fires. This page covers the topology that selects the streaming handoff, its relationship to Source-to-Merge fusion, the back-pressure chain, the counter semantics that must match the buffered arm, and the per-format nested-value contract.
 
 *User-facing view: the User Guide's "Output Nodes" page.*
 
@@ -296,14 +296,23 @@ Counter behavior under the streaming path matches the buffered Output arm **exac
 
 Stage metrics (`SchemaScan`, `Write`, `Projection`) accumulate into the same fields the buffered path uses. The dispatcher folds the streaming task's per-task accounting back into the run-wide totals at end of DAG, so a streaming run and a buffered run over the same input produce identical counter output.
 
-## Writer rejection of `Value::Map` payloads
+## Writer handling of `Value::Map` payloads
 
-CSV, XML, fixed-width, EDIFACT, X12, and HL7 writers **refuse** records carrying a `Value::Map` payload at any column slot, raising:
+CSV, fixed-width, EDIFACT, X12, and HL7 writers **refuse** records carrying a `Value::Map` payload at any column slot, raising:
 
 ```
 FormatError::UnserializableMapValue { format, column }
 ```
 
-JSON is the exception — it serializes `Value::Map` natively as a nested object.
+JSON serializes `Value::Map` natively as a nested object. XML also accepts a
+map at an element field and recursively maps ordinary keys to child elements,
+unescaped `@...` keys to attributes, `#text` to text, and arrays to repeated
+children. Both recursive writers validate the shared key grammar, decoded-key
+collisions, and the 64-container depth cap before any record bytes reach the
+sink.
 
-The typical cause is a `$widened` sidecar reaching a non-JSON writer because the Output node set `include_unmapped: false`, which strips the sidecar's expansion and leaves the raw `Value::Map` slot to hit the writer. The contract is the same on the streaming and buffered paths: the writer rejects the map-valued record rather than emitting a malformed row. See [Schema Drift & the `$widened` Sidecar](auto-widen-internals.md) for the sidecar lifecycle, the `include_unmapped` interaction, and the remediation routes for this rejection.
+The engine-stamped `$widened` sidecar is handled at projection: it is expanded
+or stripped rather than exposed as author XML. The contract is the same on the
+streaming and buffered paths. See
+[Schema Drift & the `$widened` Sidecar](auto-widen-internals.md) for that
+lifecycle.

--- a/docs/user/src/cxl/aggregates.md
+++ b/docs/user/src/cxl/aggregates.md
@@ -98,10 +98,10 @@ cxl: |
   emit all_order_ids = collect(order_id)
 ```
 
-Because `collect` emits an array, route the result to a JSON output
-(which serializes arrays natively) or coerce it to a scalar in a
-downstream `Transform` (for example `emit ids = all_order_ids.join(";")`).
-The CSV, XML, and fixed-width writers reject an array-valued field.
+Because `collect` emits an array, JSON writes it as a native array, XML as
+repeated child elements, and CSV as a delimited cell. Coerce it to a scalar for
+a format such as fixed-width (for example
+`emit ids = all_order_ids.join(";")`).
 
 ### weighted_avg(value, weight) -> Float or Decimal
 

--- a/docs/user/src/cxl/types.md
+++ b/docs/user/src/cxl/types.md
@@ -150,7 +150,13 @@ leading backslash makes a reserved-looking key literal: `\@name`, `\#text`,
 or `\\name`. In CXL source each backslash in a quoted string is itself escaped,
 so write `"\\@name"`, `"\\#text"`, or `"\\\\name"`. Other leading-backslash
 forms are rejected. Output formats decide how the neutral nested value is
-encoded; their format documentation defines that boundary.
+encoded. JSON removes the structural escape when writing the key; XML assigns
+roles to the unescaped forms as described in
+[Writing XML](../formats/xml.md#native-map-and-array-values).
+
+The runnable `examples/pipelines/nested_values.yaml` pipeline sends one
+constructed value to both JSON and XML so the two native encodings can be
+compared directly.
 
 ## Schema types
 

--- a/docs/user/src/cxl/windows.md
+++ b/docs/user/src/cxl/windows.md
@@ -221,11 +221,10 @@ Collects distinct values of the field in the window into an array.
 emit unique_regions = $window.distinct(region)
 ```
 
-`$window.collect` and `$window.distinct` emit arrays. The CSV, XML,
-and fixed-width writers reject an array-valued field, so route such a
-result to a JSON output, or coerce the emitted array to a scalar in a
-downstream `Transform` (for example `emit regions = unique_regions.join(";")`)
-before a tabular sink.
+`$window.collect` and `$window.distinct` emit arrays. JSON writes them as native
+arrays, XML as repeated child elements, and CSV as a delimited cell. Before a
+scalar-only sink such as fixed-width, coerce the value in a downstream
+`Transform` (for example `emit regions = unique_regions.join(";")`).
 
 ## Complete example
 

--- a/docs/user/src/formats/auto-widen.md
+++ b/docs/user/src/formats/auto-widen.md
@@ -76,7 +76,12 @@ Different records can carry different auto-widened columns — for example a `Me
 
 ### Writer errors on unexpanded columns
 
-The CSV, XML, and fixed-width writers can only write flat scalar columns. If a `$widened` sidecar map reaches one of these writers without being expanded — which happens when you set `include_unmapped: false` but a nested value is still present — the write fails with an `UnserializableMapValue` error naming the format and column. (JSON has no such limit; it writes nested values natively.)
+CSV and fixed-width writers can only write flat scalar columns. If an
+unexpanded map reaches one of those writers, the write fails with an
+`UnserializableMapValue` error naming the format and column. JSON and XML can
+write a user-visible nested value natively, although the engine-stamped
+`$widened` sidecar is still expanded or stripped by the Output projection and
+is never an author-facing XML structure.
 
 The fix is to either leave `include_unmapped` at its default of `true`, so the columns are expanded to top-level before writing, or to convert the value to a scalar in CXL before emitting it. The error message lists both routes.
 

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -221,6 +221,29 @@ in full on [Field Paths](../cxl/field-paths.md):
   as that map or array. Expansion adds structure above the value, never inside
   it.
 
+### Native map and array values
+
+CXL can construct maps, arrays, and array comprehensions directly; a JSON
+output writes those values recursively as native objects and arrays. Map key
+insertion order and array item order are preserved:
+
+```cxl
+emit payload = {
+  customer: customer_name,
+  items: [{sku: item.sku, quantity: item.quantity} for item in line_items],
+}
+```
+
+The output contains `"payload"` as an object with an `"items"` array. There is
+no implicit stringification or fallback encoding. Canonically escaped neutral
+keys are decoded before JSON writes them: the CXL key spelling `"\\@literal"`
+writes the JSON key `"@literal"`.
+
+Before writing any bytes for a record, the writer validates all nested keys,
+rejects duplicate logical keys, and enforces the shared 64-container depth
+limit. A failed nested value therefore cannot leave a partial JSON record in
+the output.
+
 ### Keeping a literal `.` in a key
 
 To emit a key that genuinely contains a `.`, escape the separator in the column

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -154,6 +154,51 @@ Attribute handling details:
 - An element with only attribute fields and no children self-closes:
   `Address.@type` alone emits `<Address type="home"/>`.
 
+### Native map and array values
+
+An element-valued CXL map is written recursively. Ordinary keys become child
+elements, an unescaped key beginning with `attribute_prefix` becomes an
+attribute on the current element, and the unescaped key `#text` becomes text in
+the current element. Map insertion order controls text/child order; attributes
+are collected onto the start tag. Arrays held under an ordinary key repeat that
+key as the element name.
+
+```cxl
+emit payload = {
+  "@kind": "event",
+  "#text": "before",
+  item: [
+    {"@id": 1, "#text": "alpha"},
+    {"@id": 2, "#text": "beta"},
+  ],
+  tail: "after",
+}
+```
+
+writes:
+
+```xml
+<payload kind="event">before<item id="1">alpha</item><item id="2">beta</item><tail>after</tail></payload>
+```
+
+The rules are deliberately strict:
+
+- Attribute and `#text` values must be scalar or null; maps and arrays there
+  are rejected.
+- A direct array inside another array is rejected because XML has no child name
+  to repeat. Put the inner array under a map key to supply that name.
+- Every decoded ordinary key and attribute name must be a well-formed XML name.
+  A canonical escape (`"\\@literal"`, `"\\#text"`, or `"\\\\name"` in CXL
+  source) disables the structural role, but it does not make an otherwise
+  illegal XML name legal.
+- Duplicate logical keys, malformed escapes, and values deeper than 64
+  containers reject the whole record before its first byte is emitted. XML
+  never silently falls back to JSON text.
+
+With `preserve_nulls: false`, null child elements and null array items are
+omitted; with it enabled they emit as self-closing elements. Null attributes
+are always omitted.
+
 ### Writing multi-value fields (repeated elements)
 
 A `multiple:` field is written as **repeated child elements**, one per value, in

--- a/docs/user/src/nodes/aggregate.md
+++ b/docs/user/src/nodes/aggregate.md
@@ -385,9 +385,8 @@ cargo run -p clinker -- run examples/pipelines/multi_source_session.yaml
     path: "./output/account_summary.json"
 ```
 
-The output is JSON because `collect(category)` emits an array. The
-CSV, XML, and fixed-width writers reject an array-valued field (a
-stray collection reaching a tabular sink is treated as a routing
-bug); route such a pipeline to JSON, which serializes arrays
-natively, or coerce the array to a scalar first with a downstream
-`Transform` (for example `emit categories = categories.join(";")`).
+The output is JSON because `collect(category)` emits an array. JSON serializes
+it as a native array; XML can instead write it as repeated child elements, and
+CSV can join it into a delimited cell. For a scalar-only output such as
+fixed-width, coerce it first with a downstream `Transform` (for example
+`emit categories = categories.join(";")`).

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -216,9 +216,15 @@ When a source declares a `correlation_key:`, the engine tracks correlation-group
 
 `include_correlation_keys` does **not** surface auto-widened columns -- `include_unmapped` is the separate flag for that. The two are independent: each, both, or neither can be set.
 
-### Nested columns and non-JSON writers
+### Nested columns and writer capabilities
 
-The CSV, XML, fixed-width, EDIFACT, X12, and HL7 writers can only write flat scalar columns; a nested value reaching one of them fails with an `UnserializableMapValue` error. JSON writes nested values natively. The usual cause is an auto-widened column reaching a non-JSON writer with `include_unmapped: false` — see [Auto-Widen & Schema Drift](../formats/auto-widen.md#writer-errors-on-unexpanded-columns) for the fix.
+JSON and XML write map and array values recursively. JSON uses native objects
+and arrays; XML maps ordinary keys to child elements, reserves unescaped
+`@...`/`#text` keys for attributes/text, and repeats a child name for arrays.
+CSV, fixed-width, EDIFACT, X12, and HL7 remain scalar formats and reject a map
+that reaches a column slot. See [JSON](../formats/json.md#native-map-and-array-values),
+[XML](../formats/xml.md#native-map-and-array-values), and
+[Auto-Widen & Schema Drift](../formats/auto-widen.md#writer-errors-on-unexpanded-columns).
 
 ### Field mapping
 

--- a/examples/pipelines/data/nested_values.csv
+++ b/examples/pipelines/data/nested_values.csv
@@ -1,0 +1,3 @@
+event_id,first,second
+evt-1,2,-1
+evt-2,3,5

--- a/examples/pipelines/nested_values.yaml
+++ b/examples/pipelines/nested_values.yaml
@@ -1,0 +1,48 @@
+pipeline:
+  name: nested_values
+
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: ./data/nested_values.csv
+      options:
+        has_header: true
+      schema:
+        - { name: event_id, type: string }
+        - { name: first, type: int }
+        - { name: second, type: int }
+
+  - type: transform
+    name: construct_payload
+    input: rows
+    config:
+      cxl: |
+        emit event_id = event_id
+        emit payload = {
+          "@kind": "sample",
+          "#text": "values:",
+          value: [item for item in [first, second] if item > 0],
+        }
+
+  - type: output
+    name: json_result
+    input: construct_payload
+    config:
+      name: json_result
+      type: json
+      path: ./output/nested_values.json
+      include_unmapped: false
+      options:
+        format: ndjson
+
+  - type: output
+    name: xml_result
+    input: construct_payload
+    config:
+      name: xml_result
+      type: xml
+      path: ./output/nested_values.xml
+      include_unmapped: false


### PR DESCRIPTION
## Summary

- serialize nested maps and arrays recursively in JSON and XML
- give XML maps explicit child, attribute, and text roles while preserving author order
- reject malformed keys, duplicate logical keys, invalid nesting, and non-scalar attributes before emitting record bytes
- add a production-path YAML to CSV to CXL to JSON and XML test with exact byte assertions
- add a runnable example and update format, output, aggregate, window, and engine documentation

## Why

The neutral value model and CXL can now represent structured values, but format writers need explicit native behavior rather than implicit stringification. This change makes the recursive boundary deterministic and preserves the existing bounded-memory contract.

This pull request is stacked on #1085 so its review shows only writer, integration-test, example, and documentation changes. After #1085 merges, this branch can be rebased onto main without changing the intended delta.

## Testing

- cargo test -p clinker-format --locked --offline
- cargo test -p clinker-exec --test nested_cxl_write_e2e --locked --offline
- cargo test -p clinker --locked --offline
- cargo check --workspace --all-targets --locked --offline
- cargo test --benches -p clinker-benchmarks --locked --offline
- affected-crate Clippy with warnings denied
- cargo fmt --all --check
- mdbook build docs/user
- mdbook build docs/engine
- git diff --check