### PR TITLE
Enforce approved dependency capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "clinker-record",
  "clinker-scenarios",
  "cxl",
+ "fs4",
  "indexmap",
  "insta",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ clinker-lineage = { path = "crates/clinker-lineage" }
 
 toml = "0.8"
 serde = { version = "1", features = ["derive", "rc"] }
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1", features = ["arbitrary_precision", "preserve_order"] }
 serde-saphyr = { version = "=0.0.23", features = ["miette"] }
 chrono = { version = "0.4", features = ["serde"] }
 miette = { version = "7", features = ["fancy"] }

--- a/crates/clinker-format/src/json/streaming.rs
+++ b/crates/clinker-format/src/json/streaming.rs
@@ -24,6 +24,12 @@ use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess,
 
 use crate::error::FormatError;
 
+// `serde_json` presents a number to a generic `deserialize_any` visitor as a
+// one-entry map when `arbitrary_precision` is enabled. This is the same token
+// its own `Value` visitor recognizes; handling it here keeps the counting
+// visitor semantically identical while preserving the number's source lexeme.
+const ARBITRARY_PRECISION_NUMBER_TOKEN: &str = "$serde_json::private::Number";
+
 /// One declared section's RFC 6901 pointer, decoded to path segments, plus
 /// its author-chosen name.
 ///
@@ -403,6 +409,26 @@ impl<'de, 'a, 's> Visitor<'de> for CountingValueVisitor<'a, 's> {
 
     fn visit_map<M: MapAccess<'de>>(mut self, mut map: M) -> Result<serde_json::Value, M::Error> {
         let mut out = serde_json::Map::new();
+        let Some(first_key) = map.next_key::<String>()? else {
+            return Ok(serde_json::Value::Object(out));
+        };
+
+        if first_key == ARBITRARY_PRECISION_NUMBER_TOKEN {
+            let lexeme = map.next_value::<String>()?;
+            self.charge(lexeme.len())?;
+            let number = lexeme
+                .parse::<serde_json::Number>()
+                .map_err(serde::de::Error::custom)?;
+            return Ok(serde_json::Value::Number(number));
+        }
+
+        self.charge(first_key.len())?;
+        let first_value = map.next_value_seed(CountingValueSeed {
+            section: self.section,
+            state: self.state,
+        })?;
+        out.insert(first_key, first_value);
+
         while let Some(key) = map.next_key::<String>()? {
             // Charge the key bytes (the retained map owns the key string).
             self.charge(key.len())?;
@@ -413,5 +439,39 @@ impl<'de, 'a, 's> Visitor<'de> for CountingValueVisitor<'a, 's> {
             out.insert(key, value);
         }
         Ok(serde_json::Value::Object(out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SectionTarget, extract_sections};
+    use std::io::{BufReader, Cursor};
+
+    #[test]
+    fn retained_sections_preserve_arbitrary_precision_number_nodes() {
+        const HUGE: &str = "1234567890123456789012345678901234567890";
+        let source = format!(r#"{{"Meta":{{"ratio":0.5,"huge":{HUGE}}}}}"#);
+        let mut reader = BufReader::new(Cursor::new(source.as_bytes()));
+        let targets = [SectionTarget::new("Meta".into(), "/Meta")];
+
+        let sections = extract_sections(&mut reader, &targets, None).expect("extract Meta");
+        let meta = sections
+            .get("Meta")
+            .and_then(serde_json::Value::as_object)
+            .expect("Meta object");
+
+        assert_eq!(meta["ratio"].as_f64(), Some(0.5));
+        assert_eq!(meta["huge"].to_string(), HUGE);
+    }
+
+    #[test]
+    fn arbitrary_precision_number_lexemes_count_against_the_section_cap() {
+        let source = br#"{"Meta":1234567890123456789012345678901234567890}"#;
+        let mut reader = BufReader::new(Cursor::new(source));
+        let targets = [SectionTarget::new("Meta".into(), "/Meta")];
+
+        let error = extract_sections(&mut reader, &targets, Some(8)).unwrap_err();
+
+        assert!(error.to_string().contains("document-index cap exceeded"));
     }
 }

--- a/crates/clinker-plan/src/yaml.rs
+++ b/crates/clinker-plan/src/yaml.rs
@@ -97,10 +97,125 @@ where
     serde_saphyr::from_str_with_options(yaml, budget_options()).map_err(YamlError)
 }
 
-/// Serialize a value back to YAML. Thin pass-through; no budget needed
-/// on the serialize side.
+/// Serialize a value back to YAML.
+///
+/// `serde_json` represents numbers through a private one-field struct when
+/// its `arbitrary_precision` feature is enabled. General-purpose serializers
+/// that do not recognize that private contract emit the struct itself instead
+/// of a numeric scalar. Detect that representation and route the value through
+/// an exact-lexeme bridge before returning YAML. The fallback holds one JSON
+/// value tree and two rendered buffers for the duration of this call.
 pub fn to_string<T: Serialize>(value: &T) -> Result<String, String> {
-    serde_saphyr::to_string(value).map_err(|e| e.to_string())
+    const JSON_NUMBER_TOKEN: &str = "$serde_json::private::Number";
+
+    let rendered = serde_saphyr::to_string(value).map_err(|e| e.to_string())?;
+    if !rendered.contains(JSON_NUMBER_TOKEN) {
+        return Ok(rendered);
+    }
+
+    let json = serde_json::to_value(value)
+        .map_err(|error| format!("JSON-number YAML bridge failed: {error}"))?;
+    json_value_to_string(&json)
+}
+
+/// Serialize a JSON value to YAML while preserving every numeric lexeme.
+///
+/// The bridge replaces numbers with collision-free plain-scalar markers,
+/// delegates structure and quoting to `serde-saphyr`, then substitutes the
+/// authoritative lexemes supplied by `serde_json::Number`. It does not parse,
+/// normalize, or round numbers through a machine numeric type.
+fn json_value_to_string(value: &serde_json::Value) -> Result<String, String> {
+    let mut marker_prefix = "__clinker_json_number_".to_owned();
+    while json_contains_text(value, &marker_prefix) {
+        marker_prefix.push('_');
+    }
+
+    let mut numbers = Vec::new();
+    let bridged = bridge_json_numbers(value, &marker_prefix, &mut numbers);
+    let rendered = serde_saphyr::to_string(&bridged).map_err(|e| e.to_string())?;
+    restore_json_numbers(&rendered, &marker_prefix, &numbers)
+}
+
+fn json_contains_text(value: &serde_json::Value, needle: &str) -> bool {
+    match value {
+        serde_json::Value::String(value) => value.contains(needle),
+        serde_json::Value::Array(values) => {
+            values.iter().any(|value| json_contains_text(value, needle))
+        }
+        serde_json::Value::Object(values) => values
+            .iter()
+            .any(|(key, value)| key.contains(needle) || json_contains_text(value, needle)),
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {
+            false
+        }
+    }
+}
+
+fn bridge_json_numbers(
+    value: &serde_json::Value,
+    marker_prefix: &str,
+    numbers: &mut Vec<String>,
+) -> serde_json::Value {
+    match value {
+        serde_json::Value::Number(number) => {
+            let index = numbers.len();
+            numbers.push(number.to_string());
+            serde_json::Value::String(format!("{marker_prefix}{index}__"))
+        }
+        serde_json::Value::Array(values) => serde_json::Value::Array(
+            values
+                .iter()
+                .map(|value| bridge_json_numbers(value, marker_prefix, numbers))
+                .collect(),
+        ),
+        serde_json::Value::Object(values) => {
+            let mut bridged = serde_json::Map::new();
+            for (key, value) in values {
+                bridged.insert(
+                    key.clone(),
+                    bridge_json_numbers(value, marker_prefix, numbers),
+                );
+            }
+            serde_json::Value::Object(bridged)
+        }
+        other => other.clone(),
+    }
+}
+
+fn restore_json_numbers(
+    rendered: &str,
+    marker_prefix: &str,
+    numbers: &[String],
+) -> Result<String, String> {
+    let mut restored = String::with_capacity(rendered.len());
+    let mut remaining = rendered;
+    let mut seen = vec![false; numbers.len()];
+
+    while let Some(marker_start) = remaining.find(marker_prefix) {
+        restored.push_str(&remaining[..marker_start]);
+        let marker = &remaining[marker_start + marker_prefix.len()..];
+        let marker_end = marker
+            .find("__")
+            .ok_or_else(|| "JSON-number YAML bridge emitted a malformed marker".to_owned())?;
+        let index = marker[..marker_end]
+            .parse::<usize>()
+            .map_err(|_| "JSON-number YAML bridge emitted a malformed index".to_owned())?;
+        let number = numbers
+            .get(index)
+            .ok_or_else(|| "JSON-number YAML bridge emitted an unknown index".to_owned())?;
+        if seen[index] {
+            return Err("JSON-number YAML bridge emitted a duplicate marker".to_owned());
+        }
+        seen[index] = true;
+        restored.push_str(number);
+        remaining = &marker[marker_end + 2..];
+    }
+    restored.push_str(remaining);
+
+    if seen.iter().any(|seen| !seen) {
+        return Err("JSON-number YAML bridge omitted a marker".to_owned());
+    }
+    Ok(restored)
 }
 
 /// Build a synthetic oversize error. `serde_saphyr::Error` does not
@@ -225,6 +340,37 @@ mod tests {
         let parsed: Trivial = from_str(yaml).expect("trivial parse");
         assert_eq!(parsed.name, "hello");
         assert_eq!(parsed.count, 7);
+    }
+
+    #[test]
+    fn arbitrary_precision_json_numbers_remain_yaml_scalars() {
+        let value: serde_json::Value = serde_json::from_str(
+            r#"{"priority":20,"ratio":12345678901234567890.12345678901234567890}"#,
+        )
+        .expect("parse exact JSON numbers");
+
+        let rendered = to_string(&value).expect("serialize exact numbers");
+
+        assert!(rendered.contains("priority: 20"), "{rendered}");
+        assert!(
+            rendered.contains("ratio: 12345678901234567890.12345678901234567890"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("$serde_json::private::Number"));
+        assert!(!rendered.contains("__clinker_json_number_"));
+    }
+
+    #[test]
+    fn arbitrary_precision_bridge_avoids_authored_marker_text() {
+        let source = "label: __clinker_json_number_0__\nvalue: 42\n";
+        let value: serde_json::Value = from_str(source).expect("parse marker-shaped text");
+
+        let rendered = to_string(&value).expect("serialize marker-shaped text");
+
+        assert!(rendered.contains("label: __clinker_json_number_0__"));
+        assert!(rendered.contains("value: 42"));
+        let reparsed: serde_json::Value = from_str(&rendered).expect("reparse marker-shaped text");
+        assert_eq!(reparsed, value);
     }
 
     // ---- Spike 1: Spanned<TaggedEnum> via outer wrap -----------------

--- a/crates/clinker/Cargo.toml
+++ b/crates/clinker/Cargo.toml
@@ -47,6 +47,8 @@ tracing-subscriber = { workspace = true }
 uuid = { version = "1", features = ["v7"] }
 miette = { workspace = true }
 tempfile = { workspace = true }
+# CLI-owned advisory locking for compare-and-swap configuration writes.
+fs4 = { workspace = true }
 
 [dev-dependencies]
 clinker-exec = { workspace = true, features = ["test-utils"] }

--- a/tools/dependency-policy/src/manifest.rs
+++ b/tools/dependency-policy/src/manifest.rs
@@ -67,7 +67,11 @@ const NETWORK_METADATA_DEPENDENCIES: [ExpectedMetadataDependency; 13] = [
     ExpectedMetadataDependency::normal("http", &[], true),
     ExpectedMetadataDependency::normal("indexmap", &["serde"], true),
     ExpectedMetadataDependency::optional("rustls-graviola", &[], true),
-    ExpectedMetadataDependency::normal("serde_json", &["preserve_order"], true),
+    ExpectedMetadataDependency::normal(
+        "serde_json",
+        &["arbitrary_precision", "preserve_order"],
+        true,
+    ),
     ExpectedMetadataDependency::normal("tracing", &[], true),
     // Not `rustls`: that feature is `rustls-no-provider` plus ring plus the
     // webpki roots, and ring is the C-toolchain build dependency this
@@ -88,7 +92,11 @@ const LINEAGE_METADATA_DEPENDENCIES: [ExpectedMetadataDependency; 7] = [
     ExpectedMetadataDependency::normal("cxl", &[], true),
     ExpectedMetadataDependency::normal("petgraph", &[], true),
     ExpectedMetadataDependency::normal("serde", &["derive", "rc"], true),
-    ExpectedMetadataDependency::normal("serde_json", &["preserve_order"], true),
+    ExpectedMetadataDependency::normal(
+        "serde_json",
+        &["arbitrary_precision", "preserve_order"],
+        true,
+    ),
 ];
 /// The resolved graph this policy has been shown, as a count and a digest over
 /// every locked package's name, version, source and checksum.

--- a/tools/dependency-policy/src/manifest_tests.rs
+++ b/tools/dependency-policy/src/manifest_tests.rs
@@ -45,7 +45,12 @@ fn expected_metadata(root: &std::path::Path) -> JsonValue {
                 normal_edge(root, "http", &[], true),
                 normal_edge(root, "indexmap", &["serde"], true),
                 optional_edge(root, "rustls-graviola", &[], true),
-                normal_edge(root, "serde_json", &["preserve_order"], true),
+                normal_edge(
+                    root,
+                    "serde_json",
+                    &["arbitrary_precision", "preserve_order"],
+                    true,
+                ),
                 normal_edge(root, "tracing", &[], true),
                 optional_edge(root, "ureq", &["rustls-no-provider", "rustls-webpki-roots"], false),
                 development_edge(root, "clinker-bench-support", &[]),
@@ -61,7 +66,12 @@ fn expected_metadata(root: &std::path::Path) -> JsonValue {
                 normal_edge(root, "cxl", &[], true),
                 normal_edge(root, "petgraph", &[], true),
                 normal_edge(root, "serde", &["derive", "rc"], true),
-                normal_edge(root, "serde_json", &["preserve_order"], true)
+                normal_edge(
+                    root,
+                    "serde_json",
+                    &["arbitrary_precision", "preserve_order"],
+                    true,
+                )
              ]}
         ]
     })
@@ -355,9 +365,18 @@ fn cargo_metadata_rejects_edge_kind_feature_optional_default_and_target_changes(
 
     let tree = TempTree::new("inherited-consumer-feature-expansion");
     let mut metadata = expected_metadata(tree.root());
-    metadata["packages"][1]["dependencies"][8]["features"] = json!(["preserve_order", "raw_value"]);
+    metadata["packages"][1]["dependencies"][8]["features"] =
+        json!(["arbitrary_precision", "preserve_order", "raw_value"]);
     let error = check_metadata(tree.root(), &metadata, Scope::ClinkerNet)
         .expect_err("inherited workspace feature expansion must be rejected")
+        .to_string();
+    assert!(error.contains("clinker-net -> serde_json"), "{error}");
+
+    let tree = TempTree::new("missing-inherited-arbitrary-precision");
+    let mut metadata = expected_metadata(tree.root());
+    metadata["packages"][1]["dependencies"][8]["features"] = json!(["preserve_order"]);
+    let error = check_metadata(tree.root(), &metadata, Scope::ClinkerNet)
+        .expect_err("missing approved workspace feature must be rejected")
         .to_string();
     assert!(error.contains("clinker-net -> serde_json"), "{error}");
 }

--- a/tools/release-policy/src/decision.rs
+++ b/tools/release-policy/src/decision.rs
@@ -212,7 +212,13 @@ fn verify_serde_json_contract(
     require_string_set(
         serde_node,
         "features",
-        &["default", "indexmap", "preserve_order", "std"],
+        &[
+            "arbitrary_precision",
+            "default",
+            "indexmap",
+            "preserve_order",
+            "std",
+        ],
         "resolved serde_json features",
     )?;
 
@@ -239,7 +245,7 @@ fn verify_serde_json_contract(
                 "serde_json",
                 "^1",
                 true,
-                &["preserve_order"],
+                &["arbitrary_precision", "preserve_order"],
                 None,
                 "workspace serde_json declaration",
             )?;
@@ -258,6 +264,7 @@ fn verify_fs4_consumer_contract(
     packages: &[serde_json::Value],
 ) -> Result<(), GateError> {
     let expected = BTreeMap::from([
+        ("clinker", "crates/clinker/Cargo.toml"),
         ("clinker-channel", "crates/clinker-channel/Cargo.toml"),
         ("clinker-exec", "crates/clinker-exec/Cargo.toml"),
     ]);
@@ -311,7 +318,7 @@ fn verify_fs4_consumer_contract(
     let expected_consumers: BTreeSet<_> = expected.keys().copied().collect();
     if consumers != expected_consumers {
         return Err(policy(
-            "direct fs4 consumers must be exactly clinker-channel and clinker-exec",
+            "direct fs4 consumers must be exactly clinker, clinker-channel, and clinker-exec",
         ));
     }
     Ok(())

--- a/tools/release-policy/tests/decision_contract.rs
+++ b/tools/release-policy/tests/decision_contract.rs
@@ -374,6 +374,30 @@ fn dependency_capability_real_workspace_passes() {
         b"Approved dependency capabilities verified\n"
     );
     assert!(output.stderr.is_empty());
+
+    let mut metadata = dependency_metadata();
+    let serde_json = metadata_dependency_mut(
+        metadata_package_mut(&mut metadata, "clinker-format", None),
+        "serde_json",
+    );
+    assert_eq!(
+        serde_json["features"],
+        json!(["arbitrary_precision", "preserve_order"])
+    );
+
+    let fs4 = metadata_dependency_mut(metadata_package_mut(&mut metadata, "clinker", None), "fs4");
+    assert_eq!(fs4["features"], json!(["sync"]));
+    assert_eq!(fs4["uses_default_features"], json!(false));
+
+    let fixture = repository_root().join("tools/no-c-gate-fixture");
+    assert!(fixture.join("build.rs").is_file());
+    assert!(
+        metadata["packages"]
+            .as_array()
+            .expect("metadata packages")
+            .iter()
+            .all(|package| package["name"] != "clinker-no-c-gate-fixture")
+    );
 }
 
 #[test]
@@ -385,22 +409,38 @@ fn dependency_capability_feature_and_consumer_drift_rejects() {
     )
     .expect("real metadata contract");
 
-    let mut premature_precision = baseline.clone();
+    let mut missing_precision = baseline.clone();
     metadata_dependency_mut(
-        metadata_package_mut(&mut premature_precision, "clinker-format", None),
+        metadata_package_mut(&mut missing_precision, "clinker-format", None),
         "serde_json",
-    )["features"] = json!(["arbitrary_precision", "preserve_order"]);
-    dependency_metadata_rejected(&premature_precision);
+    )["features"] = json!(["preserve_order"]);
+    dependency_metadata_rejected(&missing_precision);
 
     let mut raw_value = baseline.clone();
     metadata_dependency_mut(
         metadata_package_mut(&mut raw_value, "clinker-format", None),
         "serde_json",
-    )["features"] = json!(["preserve_order", "raw_value"]);
+    )["features"] = json!(["arbitrary_precision", "preserve_order", "raw_value"]);
     dependency_metadata_rejected(&raw_value);
 
+    let mut missing_resolved_precision = baseline.clone();
+    metadata_node_mut(&mut missing_resolved_precision, "#serde_json@1.0.149")["features"] =
+        json!(["default", "indexmap", "preserve_order", "std"]);
+    dependency_metadata_rejected(&missing_resolved_precision);
+
+    let mut extra_resolved_feature = baseline.clone();
+    metadata_node_mut(&mut extra_resolved_feature, "#serde_json@1.0.149")["features"] = json!([
+        "arbitrary_precision",
+        "default",
+        "indexmap",
+        "preserve_order",
+        "raw_value",
+        "std"
+    ]);
+    dependency_metadata_rejected(&extra_resolved_feature);
+
     let mut missing_consumer = baseline.clone();
-    metadata_package_mut(&mut missing_consumer, "clinker-channel", None)["dependencies"]
+    metadata_package_mut(&mut missing_consumer, "clinker", None)["dependencies"]
         .as_array_mut()
         .unwrap()
         .retain(|dependency| dependency["name"] != "fs4");
@@ -412,7 +452,7 @@ fn dependency_capability_feature_and_consumer_drift_rejects() {
         "fs4",
     )
     .clone();
-    metadata_package_mut(&mut unapproved_consumer, "clinker", None)["dependencies"]
+    metadata_package_mut(&mut unapproved_consumer, "clinker-plan", None)["dependencies"]
         .as_array_mut()
         .unwrap()
         .push(Value::Object(fs4));
@@ -420,10 +460,17 @@ fn dependency_capability_feature_and_consumer_drift_rejects() {
 
     let mut wrong_kind = baseline.clone();
     metadata_dependency_mut(
-        metadata_package_mut(&mut wrong_kind, "clinker-exec", None),
+        metadata_package_mut(&mut wrong_kind, "clinker", None),
         "fs4",
     )["kind"] = json!("dev");
     dependency_metadata_rejected(&wrong_kind);
+
+    let mut wrong_fs4_feature = baseline.clone();
+    metadata_dependency_mut(
+        metadata_package_mut(&mut wrong_fs4_feature, "clinker", None),
+        "fs4",
+    )["features"] = json!([]);
+    dependency_metadata_rejected(&wrong_fs4_feature);
 
     let mut version_drift = baseline.clone();
     metadata_package_mut(&mut version_drift, "serde_json", Some("1.0.149"))["version"] =


### PR DESCRIPTION
## Summary

- preserve arbitrary-precision JSON numbers across workspace consumers while retaining deterministic object order
- give the CLI the existing advisory-lock capability required for compare-and-swap configuration writes
- make both dependency policy checks reject missing or extra features, consumers, native/build edges, and transitive drift
- keep arbitrary-precision numbers as plain YAML scalars when validated documents are rewritten
- preserve exact JSON number nodes in bounded envelope pre-scans while charging their retained lexemes to the section cap

No new crates are introduced.

## Validation

- focused dependency-capability contract tests and live workspace metadata verification
- dependency-policy manifest tests, including missing and unexpected feature cases
- `cargo check -p clinker-format -p clinker --locked --offline`
- `cargo test -p clinker-plan --lib --locked --offline` — 951 passed
- `cargo test -p clinker --bin clinker --locked --offline` — 104 passed
- `cargo test -p clinker-format --lib --locked --offline` — 793 passed
- focused rename execution regression test
- exact-number YAML rewrite and authored-marker collision regressions
- exact-number envelope retention and memory-cap regressions
- `cargo clippy -p clinker-plan -p clinker --all-targets --locked --offline -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Contract impact

This changes dependency authority and the YAML serialization bridge. It does not alter row routing, introduce execution work, or retain input-growing runtime state. The serialization fallback is bounded to one document rewrite and holds one JSON value tree plus two rendered buffers; no lineage, telemetry, or runtime memory-consumer changes are triggered.
