### PR TITLE
Rename terminal config type to SinkConfig

### DIFF
--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -28,7 +28,7 @@ use cxl::eval::{EvalContext, ProgramEvaluator, SkipReason, StableEvalContext};
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
-use clinker_plan::config::{ErrorStrategy, OutputConfig, PipelineConfig};
+use clinker_plan::config::{ErrorStrategy, PipelineConfig, SinkConfig};
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::EntityRef;
 
@@ -1114,8 +1114,8 @@ pub(crate) struct ExecutorContext<'a> {
     /// runtime-retained slice of the former compile artifacts; resolved
     /// by `CompositionBodyId` via `composition_bodies.get(&id)`.
     pub(crate) composition_bodies: &'a CompositionBodies,
-    pub(crate) output_configs: &'a [OutputConfig],
-    pub(crate) primary_output: &'a OutputConfig,
+    pub(crate) output_configs: &'a [SinkConfig],
+    pub(crate) primary_output: &'a SinkConfig,
     pub(crate) stable: &'a StableEvalContext,
     /// Run-scoped non-blocking telemetry handle. Cloned only when enabled;
     /// `None` keeps dispatch on the zero-work signal path.
@@ -1739,7 +1739,7 @@ pub(crate) struct RetainedAggregatorState {
 pub(crate) fn mapping_probe<'p>(
     probes: &'p mut BTreeMap<String, crate::projection::MappingProbe>,
     output_name: &str,
-    out_cfg: &clinker_plan::config::OutputConfig,
+    out_cfg: &clinker_plan::config::SinkConfig,
 ) -> &'p mut crate::projection::MappingProbe {
     if !probes.contains_key(output_name) {
         probes.insert(
@@ -1757,7 +1757,7 @@ impl<'a> ExecutorContext<'a> {
     pub(crate) fn merge_mapping_probe(
         &mut self,
         output_name: &str,
-        out_cfg: &clinker_plan::config::OutputConfig,
+        out_cfg: &clinker_plan::config::SinkConfig,
         probe: &crate::projection::MappingProbe,
     ) {
         if out_cfg.mapping.is_some() {

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -69,7 +69,7 @@ use crate::executor::output_dispatch::OrderedWriterBoundary;
 use crate::executor::stream_event::{SourceRowId, StreamEvent};
 use crate::executor::structured_output_guard::StructuredOutputDocumentGuard;
 use crate::executor::{DlqEntry, build_format_writer};
-use clinker_plan::config::OutputConfig;
+use clinker_plan::config::SinkConfig;
 use clinker_plan::error::PipelineError;
 
 /// Identity of one document the policy operates on: its source file (the
@@ -346,7 +346,7 @@ struct DocBucket {
 /// decisions, then flushed at the driver's end.
 pub(crate) struct DocumentDlqDriver<'cfg> {
     output_name: String,
-    out_cfg: &'cfg OutputConfig,
+    out_cfg: &'cfg SinkConfig,
     cxl_emit_names: Option<Vec<String>>,
     /// Per-file spillable buckets, dropped at each file's outermost close.
     buckets: HashMap<DocKey, DocBucket>,
@@ -376,7 +376,7 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
     pub(crate) fn new(
         ctx: &ExecutorContext<'_>,
         output_name: &str,
-        out_cfg: &'cfg OutputConfig,
+        out_cfg: &'cfg SinkConfig,
         cxl_emit_names: Vec<String>,
         writer_boundary: OrderedWriterBoundary,
     ) -> Self {

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1821,7 +1821,7 @@ impl PipelineExecutor {
 /// pipeline. The probe registry is keyed for lookup, not presentation; walking
 /// it directly would sort advisories by output name.
 fn collect_mapping_advisories(
-    output_configs: &[clinker_plan::config::OutputConfig],
+    output_configs: &[clinker_plan::config::SinkConfig],
     mapping_probes: &BTreeMap<String, crate::projection::MappingProbe>,
 ) -> Vec<String> {
     output_configs

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -227,14 +227,14 @@ fn validate_writer_disposition(boundary: &PhysicalWriterBoundary) -> Result<(), 
     }
 }
 
-/// Resolve the [`OutputConfig`](clinker_plan::config::OutputConfig) for the
+/// Resolve the [`SinkConfig`](clinker_plan::config::SinkConfig) for the
 /// Output named `name`, falling back to the pipeline's primary output when no
 /// per-name entry exists. Borrows `ctx` immutably, so the caller resolves it
 /// before taking any `&mut ctx`.
 fn resolve_out_cfg<'a>(
     ctx: &'a ExecutorContext<'_>,
     name: &str,
-) -> &'a clinker_plan::config::OutputConfig {
+) -> &'a clinker_plan::config::SinkConfig {
     ctx.output_configs
         .iter()
         .find(|o| o.name == *name)
@@ -754,7 +754,7 @@ fn record_has_widened_extras(record: &Record) -> bool {
 /// minority.
 fn build_csv_union_schema(
     unbuffered: &[(Record, crate::executor::stream_event::SourceRowId)],
-    out_cfg: &clinker_plan::config::OutputConfig,
+    out_cfg: &clinker_plan::config::SinkConfig,
     cxl_emit_names_opt: Option<&[String]>,
 ) -> Arc<Schema> {
     let mut union: IndexSet<Box<str>> = IndexSet::new();
@@ -1290,14 +1290,14 @@ fn missing_output_input_error(
 /// state both write paths share. Bundling the four cross-branch borrows
 /// (error sink, the write / projection cumulative timers, and the
 /// stage-metric collector) with the per-call write descriptor (output
-/// name, resolved [`OutputConfig`](clinker_plan::config::OutputConfig), explicit
+/// name, resolved [`SinkConfig`](clinker_plan::config::SinkConfig), explicit
 /// CXL emit names, and the projected output schema) keeps the fan-out and
 /// single-writer helpers below clippy's argument threshold and gives them
 /// one shared shape — a change to how an Output write is attributed (e.g.
 /// a new metric guard) lands on the struct, not on two signatures.
 struct FanOutContext<'a> {
     name: &'a str,
-    out_cfg: &'a clinker_plan::config::OutputConfig,
+    out_cfg: &'a clinker_plan::config::SinkConfig,
     cxl_emit_names_opt: Option<&'a [String]>,
     output_schema: &'a Arc<clinker_record::Schema>,
     output_errors: &'a mut Vec<PipelineError>,

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -19,7 +19,7 @@ use clinker_format::traits::FormatWriter;
 use clinker_format::x12::Charset;
 use clinker_format::x12::writer::{X12Writer, X12WriterConfig};
 use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
-use clinker_plan::config::{OutputConfig, OutputFormat};
+use clinker_plan::config::{OutputFormat, SinkConfig};
 use clinker_plan::error::PipelineError;
 
 /// Output writer registry. Holds two parallel maps:
@@ -212,7 +212,7 @@ fn build_swift_writer_config(
 /// Fixed-width output requires an explicit single-record column list specifying
 /// names, widths, and optionally start positions, justification, and padding.
 fn extract_output_field_defs(
-    output: &OutputConfig,
+    output: &SinkConfig,
 ) -> Result<Vec<clinker_format::Column>, PipelineError> {
     let schema = output.schema.as_ref().ok_or_else(|| {
         PipelineError::Config(clinker_plan::config::ConfigError::Validation(
@@ -265,7 +265,7 @@ fn resolve_envelope_spec(
 }
 
 fn build_writer_factory(
-    output: &OutputConfig,
+    output: &SinkConfig,
     repeat_header: bool,
     field_defs: Option<Vec<clinker_format::Column>>,
 ) -> Result<WriterFactory, PipelineError> {
@@ -442,7 +442,7 @@ fn build_writer_factory(
 /// For split outputs: creates a `SplittingWriter` with a file factory and writer factory.
 /// For non-split outputs: creates a single writer wrapped in `CountedFormatWriter`.
 pub(crate) fn build_format_writer(
-    output: &OutputConfig,
+    output: &SinkConfig,
     raw_writer: Box<dyn Write + Send>,
     schema: Arc<Schema>,
     output_staging: crate::output::staging::OutputStagingRegistry,

--- a/crates/clinker-exec/src/executor/streaming.rs
+++ b/crates/clinker-exec/src/executor/streaming.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema};
 
 use clinker_format::traits::FormatWriter;
-use clinker_plan::config::{ErrorStrategy, OutputConfig, PipelineConfig};
+use clinker_plan::config::{ErrorStrategy, PipelineConfig, SinkConfig};
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::certify_streaming_edge;
 
@@ -67,7 +67,7 @@ pub(super) fn compute_streaming_output_specs(
     config: &PipelineConfig,
     fused_transforms: &HashSet<petgraph::graph::NodeIndex>,
     init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
-    output_configs: &[OutputConfig],
+    output_configs: &[SinkConfig],
     writers: &WriterRegistry,
 ) -> Vec<StreamingOutputSpec> {
     use clinker_plan::plan::execution::PlanNode;
@@ -173,7 +173,7 @@ pub(crate) struct StreamingOutputSpec {
     /// as the upstream-node label in the streaming task's E314
     /// schema-mismatch diagnostics.
     pub(crate) producer_name: String,
-    pub(crate) out_cfg: OutputConfig,
+    pub(crate) out_cfg: SinkConfig,
     /// Compile-time input schema for the Output; used by the streaming
     /// task to run the same `check_input_schema` invariant the buffered
     /// path enforces (E314 SchemaMismatch diagnostics).
@@ -227,7 +227,7 @@ pub(crate) struct StreamingOutputTaskOutput {
     /// This Output's config, so the fold can size a probe entry the dispatcher
     /// arms never created. Owned for the same reason the rest of
     /// [`StreamingOutputSpec`] is: the thread outlives the borrow.
-    pub(crate) out_cfg: OutputConfig,
+    pub(crate) out_cfg: SinkConfig,
 }
 
 impl StreamingOutputTaskOutput {

--- a/crates/clinker-exec/src/output/sidecar.rs
+++ b/crates/clinker-exec/src/output/sidecar.rs
@@ -1,6 +1,6 @@
 //! Provenance sidecar JSON writer.
 //!
-//! When `OutputConfig.write_meta` is `true`, a JSON file at
+//! When `SinkConfig.write_meta` is `true`, a JSON file at
 //! `<resolved_path>.meta.json` is emitted after the main stream is
 //! flushed. The sidecar answers "which pipeline produced this file?"
 //! without requiring the user to embed a hash in the filename.

--- a/crates/clinker-exec/src/partial.rs
+++ b/crates/clinker-exec/src/partial.rs
@@ -1,12 +1,12 @@
 //! Per-item fallback parser for graceful degradation in external tooling.
 //!
 //! Walks the unified `nodes:` array directly. Sources and outputs
-//! deserialize into `SourceConfig`/`OutputConfig` via the Body wrappers;
+//! deserialize into `SourceConfig`/`SinkConfig` via the Body wrappers;
 //! transforms/aggregates/routes produce a lightweight [`PartialTransform`]
 //! tile with only the fields the canvas renders.
 
 use clinker_plan::config::{
-    ErrorHandlingConfig, OutputConfig, PipelineMeta, SourceConfig, interpolate_env_vars,
+    ErrorHandlingConfig, PipelineMeta, SinkConfig, SourceConfig, interpolate_env_vars,
 };
 
 #[derive(Debug, Clone)]
@@ -35,7 +35,7 @@ pub struct PartialPipelineConfig {
     pub pipeline: Result<PipelineMeta, String>,
     pub inputs: Vec<PartialItem<SourceConfig>>,
     pub transformations: Vec<PartialItem<PartialTransform>>,
-    pub outputs: Vec<PartialItem<OutputConfig>>,
+    pub outputs: Vec<PartialItem<SinkConfig>>,
     pub error_handling: Result<ErrorHandlingConfig, String>,
     pub notes: Option<serde_json::Value>,
     pub errors: Vec<String>,
@@ -68,7 +68,7 @@ pub fn parse_partial_config(yaml: &str) -> Result<PartialPipelineConfig, String>
 
     let mut inputs: Vec<PartialItem<SourceConfig>> = Vec::new();
     let mut transformations: Vec<PartialItem<PartialTransform>> = Vec::new();
-    let mut outputs: Vec<PartialItem<OutputConfig>> = Vec::new();
+    let mut outputs: Vec<PartialItem<SinkConfig>> = Vec::new();
 
     if let Some(nodes_value) = obj.get("nodes")
         && let Some(nodes_arr) = nodes_value.as_array()
@@ -108,7 +108,7 @@ fn project_partial_nodes(
     nodes_arr: &[serde_json::Value],
     inputs: &mut Vec<PartialItem<SourceConfig>>,
     transformations: &mut Vec<PartialItem<PartialTransform>>,
-    outputs: &mut Vec<PartialItem<OutputConfig>>,
+    outputs: &mut Vec<PartialItem<SinkConfig>>,
     errors: &mut Vec<String>,
 ) {
     for (i, node) in nodes_arr.iter().enumerate() {
@@ -147,7 +147,7 @@ fn project_partial_nodes(
                 }
             }
             "output" => {
-                match serde_json::from_value::<OutputConfig>(merge_name_into(&config, &name)) {
+                match serde_json::from_value::<SinkConfig>(merge_name_into(&config, &name)) {
                     Ok(out) => outputs.push(PartialItem::Ok(out)),
                     Err(e) => {
                         let msg = format!("nodes[{i}] ({name}): {e}");

--- a/crates/clinker-exec/src/projection.rs
+++ b/crates/clinker-exec/src/projection.rs
@@ -5,7 +5,7 @@ use clinker_record::{Record, SchemaBuilder, Value, round_decimal_to_scale};
 use cxl::typecheck::Type;
 use indexmap::IndexMap;
 
-use clinker_plan::config::OutputConfig;
+use clinker_plan::config::SinkConfig;
 
 /// Apply schema aliases to emitted fields: rename keys from original to alias names.
 ///
@@ -34,7 +34,7 @@ pub fn apply_aliases(emitted: &mut IndexMap<String, Value>, aliases: &HashMap<St
 pub fn project_output(
     input_record: &Record,
     emitted: &IndexMap<String, Value>,
-    config: &OutputConfig,
+    config: &SinkConfig,
 ) -> Record {
     project_output_with_meta(input_record, emitted, &IndexMap::new(), config)
 }
@@ -52,7 +52,7 @@ pub fn project_output_with_meta(
     input_record: &Record,
     _emitted: &IndexMap<String, Value>,
     _metadata: &IndexMap<String, Value>,
-    config: &OutputConfig,
+    config: &SinkConfig,
 ) -> Record {
     project_output_from_record(input_record, config, None)
 }
@@ -78,7 +78,7 @@ pub fn project_output_with_meta(
 /// still governs everything the block does not list.
 pub fn project_output_from_record(
     input_record: &Record,
-    config: &OutputConfig,
+    config: &SinkConfig,
     cxl_emit_names: Option<&[String]>,
 ) -> Record {
     project_output_probed(input_record, config, cxl_emit_names, None)
@@ -93,7 +93,7 @@ pub fn project_output_from_record(
 /// the ad-hoc and test projections, which produce no report.
 pub fn project_output_probed(
     input_record: &Record,
-    config: &OutputConfig,
+    config: &SinkConfig,
     cxl_emit_names: Option<&[String]>,
     mut probe: Option<&mut MappingProbe>,
 ) -> Record {
@@ -354,7 +354,7 @@ pub fn project_output_probed(
 /// [`MappingProbe::discard_staged_record`] before staging another record.
 pub(crate) fn project_output_staged(
     input_record: &Record,
-    config: &OutputConfig,
+    config: &SinkConfig,
     cxl_emit_names: Option<&[String]>,
     probe: &mut MappingProbe,
 ) -> Record {
@@ -383,7 +383,7 @@ pub(crate) fn project_output_staged(
 /// path only clears and sets reusable flags.
 ///
 /// Self-describing on purpose: it carries the source names it was built from
-/// rather than re-reading them out of an [`OutputConfig`] at report time. The
+/// rather than re-reading them out of an [`SinkConfig`] at report time. The
 /// report is produced after the dispatch walk, where the only handle left is
 /// the Output's name, and matching that name back to a config is a lookup that
 /// can miss — a miss would report one Output's entries under another's name.
@@ -412,7 +412,7 @@ pub struct MappingProbe {
 impl MappingProbe {
     /// A probe sized for `config`'s mapping block. Cheap for an Output with no
     /// `mapping:` — it allocates nothing and reports nothing.
-    pub fn for_config(config: &OutputConfig) -> Self {
+    pub fn for_config(config: &SinkConfig) -> Self {
         let (sources, outputs): (Vec<Box<str>>, Vec<Box<str>>) =
             config.mapping.as_ref().map_or_else(
                 || (Vec::new(), Vec::new()),
@@ -513,7 +513,7 @@ impl MappingProbe {
     /// column look populated. The checks mirror the gather/exclude/mapping
     /// visibility rules in [`project_output_probed`] and allocate no
     /// per-record state.
-    pub(crate) fn observe_committed_record(&mut self, record: &Record, config: &OutputConfig) {
+    pub(crate) fn observe_committed_record(&mut self, record: &Record, config: &SinkConfig) {
         self.note_record();
         let Some(mapping) = config.mapping.as_ref() else {
             return;
@@ -615,7 +615,7 @@ impl MappingProbe {
 
 /// Whether `name` is present in the temporary field map built by the output
 /// projection after its visibility and `exclude:` rules run.
-fn projection_field_is_present(record: &Record, config: &OutputConfig, name: &str) -> bool {
+fn projection_field_is_present(record: &Record, config: &SinkConfig, name: &str) -> bool {
     if config
         .exclude
         .as_ref()
@@ -647,7 +647,7 @@ fn projection_field_is_present(record: &Record, config: &OutputConfig, name: &st
 
 /// Under `include_unmapped: false`, only correlation columns can be appended
 /// after the declared mapping, and only when the author explicitly opts in.
-fn correlation_field_is_present(record: &Record, config: &OutputConfig, name: &str) -> bool {
+fn correlation_field_is_present(record: &Record, config: &SinkConfig, name: &str) -> bool {
     if !config.include_correlation_keys
         || config
             .exclude
@@ -686,7 +686,7 @@ fn correlation_field_is_present(record: &Record, config: &OutputConfig, name: &s
 /// through untouched. Blocking/streaming: pure per-record transform, no
 /// buffering; cost is proportional to the declared column count and is skipped
 /// entirely for the schema-less outputs (CSV/JSON without a `schema:` block).
-fn round_declared_output_decimals(record: &mut Record, config: &OutputConfig) {
+fn round_declared_output_decimals(record: &mut Record, config: &SinkConfig) {
     let Some(columns) = config.schema.as_ref().and_then(|s| s.as_columns()) else {
         return;
     };
@@ -762,7 +762,7 @@ mod tests {
         input.set("full_name", Value::String("Alice Smith".into()));
         let emitted = IndexMap::new();
 
-        let config = OutputConfig {
+        let config = SinkConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),
@@ -805,7 +805,7 @@ mod tests {
         let input = make_input();
         let emitted = IndexMap::new();
 
-        let config = OutputConfig {
+        let config = SinkConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),
@@ -842,7 +842,7 @@ mod tests {
 
         let mapping = OutputMapping::new(vec![MappingEntry::rename("given_name", "first_name")]);
 
-        let config = OutputConfig {
+        let config = SinkConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),
@@ -891,8 +891,8 @@ mod tests {
         )
     }
 
-    fn fast_path_output_config(include_correlation_keys: bool) -> OutputConfig {
-        OutputConfig {
+    fn fast_path_output_config(include_correlation_keys: bool) -> SinkConfig {
+        SinkConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),
@@ -992,7 +992,7 @@ mod tests {
         // but a mapping under `include_unmapped: false` emits only what it
         // lists, which would conflate this test with the selection semantic it
         // is not about.
-        let config_slow = OutputConfig {
+        let config_slow = SinkConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),
@@ -1375,7 +1375,7 @@ mod tests {
                 Value::Map(Box::new(sidecar)),
             ],
         );
-        let config = OutputConfig {
+        let config = SinkConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),
@@ -1445,7 +1445,7 @@ mod tests {
         ));
         input.set_doc_ctx(Arc::clone(&ctx));
 
-        let config = OutputConfig {
+        let config = SinkConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),
@@ -1487,8 +1487,8 @@ mod tests {
     /// keys) carrying an optional output `schema:`. `cxl_emit_names = None`
     /// keeps every user field, so a declared decimal column reaches the
     /// rounding pass.
-    fn scale_config(schema: Option<SourceSchema>) -> OutputConfig {
-        OutputConfig {
+    fn scale_config(schema: Option<SourceSchema>) -> SinkConfig {
+        SinkConfig {
             name: "out".into(),
             format: clinker_plan::config::OutputFormat::Csv(None),
             path: "/tmp/out.csv".into(),

--- a/crates/clinker-exec/tests/output_policy.rs
+++ b/crates/clinker-exec/tests/output_policy.rs
@@ -1,7 +1,7 @@
 //! End-to-end tests for the output collision policy and path templating.
 //!
 //! Covers each `if_exists` policy through `open_output`, the path-template
-//! interaction with `OutputConfig`, and a multi-threaded race test that
+//! interaction with `SinkConfig`, and a multi-threaded race test that
 //! exercises destination-local reservations under concurrent contention.
 
 use std::collections::HashMap;

--- a/crates/clinker-lineage/src/dataset.rs
+++ b/crates/clinker-lineage/src/dataset.rs
@@ -21,7 +21,7 @@
 
 use std::path::Path;
 
-use clinker_plan::config::{OutputConfig, SourceConfig};
+use clinker_plan::config::{SinkConfig, SourceConfig};
 use clinker_plan::plan::execution::PlanNode;
 
 use crate::openlineage::Dataset;
@@ -166,13 +166,13 @@ pub(crate) fn source_dataset_identity(source: &SourceConfig, base_dir: &Path) ->
     DatasetId::file(name)
 }
 
-/// Dataset identity of an output node from its parsed [`OutputConfig`].
+/// Dataset identity of an output node from its parsed [`SinkConfig`].
 ///
 /// Always [`FILE_NAMESPACE`] + the absolutized output path. The path may be a
 /// template carrying tokens (e.g. `{source_file}`) or driving per-file `split:`
 /// fan-out; tokens are **not** resolved at plan time — the literal template
 /// form is kept verbatim as the dataset name.
-pub(crate) fn output_dataset_identity(output: &OutputConfig, base_dir: &Path) -> DatasetId {
+pub(crate) fn output_dataset_identity(output: &SinkConfig, base_dir: &Path) -> DatasetId {
     DatasetId::file(absolutize(base_dir, &output.path))
 }
 
@@ -308,7 +308,7 @@ mod tests {
         serde_json::from_value(value).expect("valid source config")
     }
 
-    fn output_config(value: serde_json::Value) -> OutputConfig {
+    fn output_config(value: serde_json::Value) -> SinkConfig {
         serde_json::from_value(value).expect("valid output config")
     }
 

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -9,7 +9,6 @@ pub mod fs_type;
 pub mod multi_value;
 pub mod node_header;
 pub mod observability;
-pub mod output;
 pub mod output_mapping;
 pub mod patch;
 pub mod path_template;
@@ -18,6 +17,7 @@ pub mod pipeline_node;
 pub mod record_path;
 pub mod route;
 pub mod scoped_var;
+pub mod sink;
 pub mod sort;
 pub mod source;
 pub mod storage;
@@ -46,7 +46,6 @@ pub use fs_type::{
 };
 pub use node_header::{MergeHeader, NodeHeader, NodeInput, SourceHeader};
 pub use observability::*;
-pub use output::*;
 pub use output_mapping::{MappingEntry, OutputMapping};
 pub use patch::{
     BodySourcePatchMap, ColumnPatch, DiscriminatorPatch, EnvelopeFieldOp, NestedSectionOp,
@@ -60,6 +59,7 @@ pub use pipeline_node::{
 };
 pub use route::*;
 pub use scoped_var::*;
+pub use sink::*;
 pub use sort::*;
 pub use source::*;
 pub use storage::{

--- a/crates/clinker-plan/src/config/multi_value.rs
+++ b/crates/clinker-plan/src/config/multi_value.rs
@@ -33,7 +33,7 @@ use clinker_format::{Column, OnConflict, SourceSchema, SplitToRowsMode, under_fi
 use crate::config::format::{InputFormat, OutputFormat};
 use crate::config::pipeline_node::PipelineNode;
 use crate::config::source::SourceConfig;
-use crate::config::{OutputConfig, XmlOutputOptions};
+use crate::config::{SinkConfig, XmlOutputOptions};
 use crate::yaml::Spanned;
 
 /// Whether an output format can encode a `multiple: true` field.
@@ -934,7 +934,7 @@ pub fn source_node_faults(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeFault> {
 /// can arise at runtime (a `match: collect` combine output), so a static
 /// requirement would reject a legitimate override; an entry that never matches
 /// an array is simply an inert override.
-fn validate_join_declarations(output: &OutputConfig) -> Vec<DeclarationFault> {
+fn validate_join_declarations(output: &SinkConfig) -> Vec<DeclarationFault> {
     let mut faults = Vec::new();
     let entries = output.join_values.as_deref().unwrap_or(&[]);
     if entries.is_empty() {

--- a/crates/clinker-plan/src/config/path_template.rs
+++ b/crates/clinker-plan/src/config/path_template.rs
@@ -1,6 +1,6 @@
 //! Output path templating with conditional emit.
 //!
-//! Templates appear in `OutputConfig.path` and use `{token}` braces to
+//! Templates appear in `SinkConfig.path` and use `{token}` braces to
 //! interpolate plan-time values (source filename, channel, pipeline
 //! hash, run timestamp, ids) plus the runtime collision counter `{n}`.
 //! Literal braces escape as `{{` and `}}`.

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -293,7 +293,7 @@ impl PipelineConfig {
     }
 
     /// Public iterator over output nodes.
-    pub fn output_configs(&self) -> impl Iterator<Item = &OutputConfig> + '_ {
+    pub fn output_configs(&self) -> impl Iterator<Item = &SinkConfig> + '_ {
         self.nodes.iter().filter_map(|n| match &n.value {
             PipelineNode::Output { config: body, .. } => Some(&body.output),
             _ => None,
@@ -779,7 +779,7 @@ impl PipelineConfig {
         // two compile sites have converged onto this one.
         let source_configs: Vec<crate::config::SourceConfig> =
             self.source_configs().cloned().collect();
-        let output_configs: Vec<crate::config::OutputConfig> =
+        let output_configs: Vec<crate::config::SinkConfig> =
             self.output_configs().cloned().collect();
         let primary_source: String = source_configs
             .first()

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -1728,7 +1728,7 @@ pub struct CombineBody {
 #[derive(Debug, Clone, Serialize)]
 pub struct OutputBody {
     #[serde(flatten)]
-    pub output: crate::config::OutputConfig,
+    pub output: crate::config::SinkConfig,
 }
 
 impl<'de> Deserialize<'de> for OutputBody {
@@ -1753,7 +1753,7 @@ impl<'de> Deserialize<'de> for OutputBody {
                 // loses nested item locations. Delegate the native map stream
                 // directly so `OutputMapping` can retain each sequence item's
                 // span for E364/E365.
-                let output = crate::config::OutputConfig::deserialize(
+                let output = crate::config::SinkConfig::deserialize(
                     de::value::MapAccessDeserializer::new(map),
                 )?;
                 Ok(OutputBody { output })

--- a/crates/clinker-plan/src/config/sink.rs
+++ b/crates/clinker-plan/src/config/sink.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 /// Output destination configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OutputConfig {
+pub struct SinkConfig {
     pub name: String,
     pub path: String,
     /// Typed runtime path segments populated during template resolution.
@@ -106,7 +106,7 @@ pub struct OutputConfig {
     pub notes: Option<serde_json::Value>,
 }
 
-impl OutputConfig {
+impl SinkConfig {
     #[must_use]
     pub fn has_per_record_path_tokens(&self) -> bool {
         self.resolved_path_template.as_ref().map_or_else(

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1554,7 +1554,7 @@ pub(crate) fn validate_log_event_shapes(
 /// is what covers the open-row and sidecar cases.
 fn validate_output_mapping_columns(
     node_name: &str,
-    output: &crate::config::OutputConfig,
+    output: &crate::config::SinkConfig,
     upstream: &Row,
     span: Span,
     diags: &mut Vec<Diagnostic>,

--- a/crates/clinker-plan/src/plan/execution/dag.rs
+++ b/crates/clinker-plan/src/plan/execution/dag.rs
@@ -575,7 +575,7 @@ pub enum ParallelismClass {
 ///
 /// A projection-shaped summary of each Output node, carried on the execution
 /// plan alongside the graph. The executor does not read it — it projects from
-/// the `OutputConfig` on the node's resolved payload — so the fields here exist
+/// the `SinkConfig` on the node's resolved payload — so the fields here exist
 /// to describe the plan, not to drive it; `clinker --explain` reports the count.
 /// `mapping` mirrors [`crate::config::OutputMapping::entries`] so the summary
 /// cannot disagree with the config about the block's shape or direction.

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -40,7 +40,7 @@ use serde::Serialize;
 
 use std::sync::Arc;
 
-use crate::config::{AggregateConfig, OutputConfig, RouteMode, SortField, SourceConfig};
+use crate::config::{AggregateConfig, RouteMode, SinkConfig, SortField, SourceConfig};
 use crate::plan::composition_body::CompositionBodyId;
 use crate::plan::index::{AnalyticWindowSpec, IndexSpec};
 use crate::plan::row_type::QualifiedField;
@@ -688,7 +688,7 @@ pub struct PlanTransformPayload {
 /// Fully-resolved Output payload.
 #[derive(Debug, Clone)]
 pub struct PlanOutputPayload {
-    pub output: OutputConfig,
+    pub output: SinkConfig,
     pub validated_path: Option<crate::security::ValidatedPath>,
     /// Plan-time flag: this Output's path template uses a per-record
     /// token (`{source_file}` / `{source_path}`) AND its parent


### PR DESCRIPTION
## Summary

- Rename the terminal configuration type from `OutputConfig` to `SinkConfig` across every current Rust owner.
- Move the defining module from `config/output.rs` to `config/sink.rs`.
- Keep `PipelineNode::Output`, `PlanNode::Output`, and authored `type: output` unchanged so their later cutovers remain independently reviewable.
- Add no alias, re-export, dual type, or compatibility shim.

This is one closed-symbol compile boundary: splitting the definition from its exhaustive consumers would leave the workspace uncompilable.

## Verification

- `cargo check --workspace --locked --offline`
- `cargo test -p clinker-exec --test output_policy --locked --offline` — 9 passed
- `cargo test -p clinker-plan --lib --locked --offline` — 949 passed
- `cargo test -p clinker-lineage dataset:: --locked --offline` — 23 passed
- `cargo fmt --all --check`
- `git diff --check`
- Source inventory confirms zero `OutputConfig` occurrences and exactly 19 `SinkConfig` owner files.

## Contract impact

This is a mechanical Rust type/module rename with identical row values, routing, execution work, and retained state. Existing lineage behavior is preserved, and no telemetry or memory-consumer changes are triggered.
