### PR TITLE
Rename authored terminal nodes to Sink

### DIFF
--- a/crates/clinker-benchmarks/src/runner.rs
+++ b/crates/clinker-benchmarks/src/runner.rs
@@ -136,7 +136,7 @@ fn rewrite_split_output_paths(
     config: &mut clinker_plan::config::PipelineConfig,
 ) -> Option<TempDir> {
     let has_split = config.nodes.iter().any(|n| {
-        matches!(&n.value, PipelineNode::Output { config: body, .. } if body.output.split.is_some())
+        matches!(&n.value, PipelineNode::Sink { config: body, .. } if body.output.split.is_some())
     });
     if !has_split {
         return None;
@@ -159,7 +159,7 @@ fn rewrite_split_output_paths(
     unsafe { std::env::set_var("CLINKER_ALLOW_ABSOLUTE_PATHS", "1") };
 
     for node in &mut config.nodes {
-        if let PipelineNode::Output { config: body, .. } = &mut node.value
+        if let PipelineNode::Sink { config: body, .. } = &mut node.value
             && body.output.split.is_some()
         {
             let filename = std::path::Path::new(&body.output.path)

--- a/crates/clinker-exec/tests/bench_config_validation.rs
+++ b/crates/clinker-exec/tests/bench_config_validation.rs
@@ -240,7 +240,7 @@ fn test_multi_output_route_targets_match_outputs() {
                 // Helper: check if any node has this port as its input
                 let has_downstream = |expected: &NodeInput| {
                     config.nodes.iter().any(|n| match &n.value {
-                        PipelineNode::Output { header, .. }
+                        PipelineNode::Sink { header, .. }
                         | PipelineNode::Transform { header, .. }
                         | PipelineNode::Aggregate { header, .. }
                         | PipelineNode::Route { header, .. } => header.input.value == *expected,

--- a/crates/clinker-exec/tests/node_taxonomy_lift_test.rs
+++ b/crates/clinker-exec/tests/node_taxonomy_lift_test.rs
@@ -100,9 +100,9 @@ inputs:
 }
 
 #[test]
-fn test_pipeline_node_parses_output() {
+fn test_pipeline_node_parses_sink() {
     let yaml = r#"
-type: output
+type: sink
 name: out_us
 input: rejoin
 config:
@@ -111,7 +111,35 @@ config:
   path: out_us.csv
 "#;
     let node = parse_node(yaml);
-    assert!(matches!(node.value, PipelineNode::Output { .. }));
+    assert!(matches!(node.value, PipelineNode::Sink { .. }));
+}
+
+#[test]
+fn test_pipeline_node_rejects_retired_output_with_e376_correction() {
+    let yaml = r#"
+type: output
+name: retired
+input: rejoin
+config:
+  name: retired
+  type: csv
+  path: retired.csv
+"#;
+    let err = from_str::<Spanned<PipelineNode>>(yaml)
+        .expect_err("the retired terminal discriminator must be rejected");
+    let message = err.to_string();
+    assert!(
+        message.contains("E376"),
+        "missing diagnostic code: {message}"
+    );
+    assert!(
+        message.contains("retired `type: output` spelling"),
+        "missing offending spelling: {message}"
+    );
+    assert!(
+        message.contains("Correction: type: sink"),
+        "missing paste-ready correction: {message}"
+    );
 }
 
 #[test]
@@ -201,7 +229,7 @@ nodes:
     input: src
     config:
       cxl: "emit foo = 1"
-  - type: output
+  - type: sink
     name: out
     input: clean
     config:
@@ -497,7 +525,7 @@ nodes:
     input: src
     config:
       cxl: "emit foo = 1"
-  - type: output
+  - type: sink
     name: out
     input: clean
     config:
@@ -529,7 +557,7 @@ nodes:
       schema:
         - { name: amount, type: string }
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -607,7 +635,7 @@ nodes:
       schema:
         - { name: amount, type: string }
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -782,7 +810,7 @@ nodes:
     input: src
     config:
       cxl: "emit bogus = not_a_column + 1"
-  - type: output
+  - type: sink
     name: out
     input: t
     config:
@@ -848,7 +876,7 @@ nodes:
     input: src
     config:
       cxl: "emit doubled = amount * 2"
-  - type: output
+  - type: sink
     name: out
     input: t
     config:

--- a/crates/clinker-plan/src/config/error.rs
+++ b/crates/clinker-plan/src/config/error.rs
@@ -285,7 +285,7 @@ fn resolve_and_hash_external_schemas(config: &mut PipelineConfig) -> Result<(), 
                 }
                 _ => continue,
             },
-            crate::config::PipelineNode::Output {
+            crate::config::PipelineNode::Sink {
                 header,
                 config: body,
             } => match &body.output.schema {
@@ -322,7 +322,7 @@ fn resolve_and_hash_external_schemas(config: &mut PipelineConfig) -> Result<(), 
             crate::config::PipelineNode::Source { config: body, .. } => {
                 body.schema = inline;
             }
-            crate::config::PipelineNode::Output { config: body, .. } => {
+            crate::config::PipelineNode::Sink { config: body, .. } => {
                 body.output.schema = Some(inline);
             }
             _ => {}
@@ -480,7 +480,7 @@ mod external_schema_tests {
 
     fn output_schema(config: &PipelineConfig) -> Option<&crate::config::SourceSchema> {
         config.nodes.iter().find_map(|n| match &n.value {
-            crate::config::PipelineNode::Output { config, .. } => config.output.schema.as_ref(),
+            crate::config::PipelineNode::Sink { config, .. } => config.output.schema.as_ref(),
             _ => None,
         })
     }
@@ -493,7 +493,7 @@ mod external_schema_tests {
             "pipeline:\n  name: ext_schema_test\n\
              nodes:\n  - type: source\n    name: src\n    config:\n      \
              name: src\n      type: csv\n      path: /tmp/in.csv\n      \
-             schema: '{}'\n  - type: output\n    name: out\n    input: src\n    \
+             schema: '{}'\n  - type: sink\n    name: out\n    input: src\n    \
              config:\n      name: out\n      type: csv\n      path: /tmp/out.csv\n",
             schema_path.display()
         );
@@ -562,7 +562,7 @@ mod external_schema_tests {
              nodes:\n  - type: source\n    name: src\n    config:\n      \
              name: src\n      type: csv\n      path: /tmp/in.csv\n      \
              schema:\n        - {{ name: average, type: decimal, scale: 2 }}\n        \
-             - {{ name: name, type: string }}\n  - type: output\n    name: out\n    \
+             - {{ name: name, type: string }}\n  - type: sink\n    name: out\n    \
              input: src\n    config:\n      name: out\n      type: csv\n      \
              path: /tmp/out.csv\n      schema: '{}'\n",
             schema_path.display()
@@ -605,7 +605,7 @@ mod external_schema_tests {
         let pipeline = "pipeline:\n  name: inline\n\
              nodes:\n  - type: source\n    name: src\n    config:\n      \
              name: src\n      type: csv\n      path: /tmp/in.csv\n      \
-             schema:\n        - { name: amount, type: int }\n  - type: output\n    \
+             schema:\n        - { name: amount, type: int }\n  - type: sink\n    \
              name: out\n    input: src\n    config:\n      name: out\n      \
              type: csv\n      path: /tmp/out.csv\n";
         let p = dir.path().join("pipeline.yaml");
@@ -628,7 +628,7 @@ mod external_schema_tests {
         let yaml = "pipeline:\n  name: read_once\n\
              nodes:\n  - type: source\n    name: src\n    config:\n      \
              name: src\n      type: csv\n      path: /tmp/in.csv\n      \
-             schema:\n        - { name: amount, type: int }\n  - type: output\n    \
+             schema:\n        - { name: amount, type: int }\n  - type: sink\n    \
              name: out\n    input: src\n    config:\n      name: out\n      \
              type: csv\n      path: /tmp/out.csv\n";
         let dir = tempfile::tempdir().unwrap();

--- a/crates/clinker-plan/src/config/multi_value.rs
+++ b/crates/clinker-plan/src/config/multi_value.rs
@@ -1122,7 +1122,7 @@ pub fn output_node_faults(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeFault> {
     let mut faults = Vec::new();
     let reachability = source_data_reachability(nodes);
     for (node_index, spanned) in nodes.iter().enumerate() {
-        let PipelineNode::Output {
+        let PipelineNode::Sink {
             header,
             config: body,
         } = &spanned.value

--- a/crates/clinker-plan/src/config/output_mapping.rs
+++ b/crates/clinker-plan/src/config/output_mapping.rs
@@ -627,7 +627,7 @@ pub(crate) fn output_mapping_faults_spanned(
 
     let mut faults = Vec::new();
     for (node_index, spanned) in nodes.iter().enumerate() {
-        let PipelineNode::Output {
+        let PipelineNode::Sink {
             header,
             config: body,
         } = &spanned.value
@@ -933,7 +933,7 @@ mod tests {
             format!(
                 "  - type: source\n    name: src\n    config:\n      name: src\n      \
                  type: csv\n      path: in.csv\n      schema:\n        - {{ name: sku, \
-                 type: string }}\n        - {{ name: qty, type: int }}\n  - type: output\n    \
+                 type: string }}\n        - {{ name: qty, type: int }}\n  - type: sink\n    \
                  name: out\n    input: src\n    config:\n      name: out\n      type: csv\n      \
                  path: out.csv\n{extra}      mapping:{mapping_value}"
             )

--- a/crates/clinker-plan/src/config/path_template.rs
+++ b/crates/clinker-plan/src/config/path_template.rs
@@ -358,7 +358,7 @@ pub fn resolve_output_path_templates_in_place(
         .nodes
         .iter()
         .filter_map(|s| match &s.value {
-            PipelineNode::Output { config: body, .. } => Some(body.output.name.clone()),
+            PipelineNode::Sink { config: body, .. } => Some(body.output.name.clone()),
             _ => None,
         })
         .collect();
@@ -369,7 +369,7 @@ pub fn resolve_output_path_templates_in_place(
         .collect();
 
     for spanned in config.nodes.iter_mut() {
-        let PipelineNode::Output { config: body, .. } = &mut spanned.value else {
+        let PipelineNode::Sink { config: body, .. } = &mut spanned.value else {
             continue;
         };
         let output_name = body.output.name.clone();

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -295,7 +295,7 @@ impl PipelineConfig {
     /// Public iterator over output nodes.
     pub fn output_configs(&self) -> impl Iterator<Item = &SinkConfig> + '_ {
         self.nodes.iter().filter_map(|n| match &n.value {
-            PipelineNode::Output { config: body, .. } => Some(&body.output),
+            PipelineNode::Sink { config: body, .. } => Some(&body.output),
             _ => None,
         })
     }
@@ -345,7 +345,7 @@ impl PipelineConfig {
             PipelineNode::Source { config: body, .. } if body.source.name == stage_name => {
                 body.source.notes.as_ref()
             }
-            PipelineNode::Output { config: body, .. } if body.output.name == stage_name => {
+            PipelineNode::Sink { config: body, .. } if body.output.name == stage_name => {
                 body.output.notes.as_ref()
             }
             PipelineNode::Transform { header, .. }
@@ -372,7 +372,7 @@ impl PipelineConfig {
                     body.source.notes = notes;
                     return;
                 }
-                PipelineNode::Output { config: body, .. } if body.output.name == stage_name => {
+                PipelineNode::Sink { config: body, .. } if body.output.name == stage_name => {
                     body.output.notes = notes;
                     return;
                 }
@@ -818,7 +818,7 @@ impl PipelineConfig {
                     analytic_window: None,
                 }),
                 PipelineNode::Source { .. }
-                | PipelineNode::Output { .. }
+                | PipelineNode::Sink { .. }
                 | PipelineNode::Merge { .. }
                 | PipelineNode::Reshape { .. }
                 | PipelineNode::Cull { .. }
@@ -1436,7 +1436,7 @@ impl PipelineConfig {
                 | PipelineNode::Route { header, .. }
                 | PipelineNode::Reshape { header, .. }
                 | PipelineNode::Cull { header, .. }
-                | PipelineNode::Output { header, .. } => {
+                | PipelineNode::Sink { header, .. } => {
                     wire(&input_full_reference(&header.input.value), None);
                 }
                 PipelineNode::Composition {
@@ -2714,7 +2714,7 @@ fn resolve_all_input_references(
             | PipelineNode::Route { header, .. }
             | PipelineNode::Reshape { header, .. }
             | PipelineNode::Cull { header, .. }
-            | PipelineNode::Output { header, .. } => {
+            | PipelineNode::Sink { header, .. } => {
                 emit(consumer_name, None, &header.input);
             }
             PipelineNode::Merge { header, .. } => {
@@ -2991,7 +2991,7 @@ fn stream_cardinality<'a>(
         | PipelineNode::Route { .. }
         | PipelineNode::Cull { .. }
         | PipelineNode::Reshape { .. }
-        | PipelineNode::Output { .. } => join_input_cardinality(by_name, node, visited),
+        | PipelineNode::Sink { .. } => join_input_cardinality(by_name, node, visited),
     }
 }
 
@@ -3992,7 +3992,7 @@ pub(crate) fn lower_node_to_plan_node(
                 output_schema: schema_from_bound(),
             })
         }
-        PipelineNode::Output { config, .. } => Some(PlanNode::Output {
+        PipelineNode::Sink { config, .. } => Some(PlanNode::Output {
             name: name.to_string(),
             id,
             span,
@@ -5685,7 +5685,7 @@ nodes:
         - {{ name: a, type: string }}
       options:
 {options_body}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -5712,7 +5712,7 @@ nodes:
       path: in.csv
       schema:
         - {{ name: a, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -5831,7 +5831,7 @@ nodes:
       path: in.csv
       schema:
         - {{ name: a, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -5916,7 +5916,7 @@ mod inert_metadata_tests {
 
     fn pipeline(metadata: &str) -> String {
         format!(
-            "pipeline:\n  name: inert_metadata\n{metadata}nodes:\n  - type: source\n    name: src\n    config:\n      name: src\n      type: csv\n      path: in.csv\n      schema: [{{ name: id, type: int }}]\n  - type: output\n    name: out\n    input: src\n    config: {{ name: out, type: csv, path: out.csv }}\n"
+            "pipeline:\n  name: inert_metadata\n{metadata}nodes:\n  - type: source\n    name: src\n    config:\n      name: src\n      type: csv\n      path: in.csv\n      schema: [{{ name: id, type: int }}]\n  - type: sink\n    name: out\n    input: src\n    config: {{ name: out, type: csv, path: out.csv }}\n"
         )
     }
 
@@ -6037,7 +6037,7 @@ nodes:
       path: in.csv
       schema:
         - {{ name: a, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -112,7 +112,7 @@ pub enum PipelineNode {
         header: CombineHeader,
         config: CombineBody,
     },
-    Output {
+    Sink {
         #[serde(flatten)]
         header: NodeHeader,
         config: OutputBody,
@@ -422,11 +422,23 @@ impl<'de> Deserialize<'de> for PipelineNode {
                         Ok(PipelineNode::Combine { header, config })
                     }
                     "output" => {
+                        let entry = clinker_core_types::diagnostic::registry_entry("E376")
+                            .ok_or_else(|| {
+                                de::Error::custom(
+                                    "internal error: reserved E376 diagnostic is missing",
+                                )
+                            })?;
+                        Err(de::Error::custom(format!(
+                            "{}: {}. Correction: {}",
+                            entry.code, entry.meaning, entry.correction
+                        )))
+                    }
+                    "sink" => {
                         let payload = OutputPayload::deserialize(
                             de::value::MapAccessDeserializer::new(dispatch),
                         )?;
                         let (header, config) = payload.into_variant_parts();
-                        Ok(PipelineNode::Output { header, config })
+                        Ok(PipelineNode::Sink { header, config })
                     }
                     "reshape" => {
                         let payload = ReshapePayload::deserialize(
@@ -464,7 +476,7 @@ impl<'de> Deserialize<'de> for PipelineNode {
                             "route",
                             "merge",
                             "combine",
-                            "output",
+                            "sink",
                             "reshape",
                             "cull",
                             "envelope",
@@ -520,7 +532,7 @@ impl SourcePayload {
     }
 }
 
-// ---- Transform / Aggregate / Route / Output (consumer NodeHeader) ----
+// ---- Transform / Aggregate / Route / Sink (consumer NodeHeader) ----
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -958,7 +970,7 @@ impl PipelineNode {
             }
             PipelineNode::Source { .. }
             | PipelineNode::Merge { .. }
-            | PipelineNode::Output { .. }
+            | PipelineNode::Sink { .. }
             | PipelineNode::Composition { .. } => {}
         }
     }
@@ -970,7 +982,7 @@ impl PipelineNode {
             PipelineNode::Transform { header, .. }
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
+            | PipelineNode::Sink { header, .. }
             | PipelineNode::Reshape { header, .. }
             | PipelineNode::Cull { header, .. }
             | PipelineNode::Composition { header, .. } => &header.name,
@@ -989,7 +1001,7 @@ impl PipelineNode {
             PipelineNode::Transform { header, .. }
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
+            | PipelineNode::Sink { header, .. }
             | PipelineNode::Reshape { header, .. }
             | PipelineNode::Cull { header, .. }
             | PipelineNode::Composition { header, .. } => Some(header.input.value.name()),
@@ -1007,7 +1019,7 @@ impl PipelineNode {
     ///
     /// `Source` has no inputs and yields an empty vector. The
     /// single-input consumer variants (`Transform`, `Aggregate`,
-    /// `Route`, `Output`, `Composition`) yield their one `input:`. The
+    /// `Route`, `Sink`, `Composition`) yield their one `input:`. The
     /// multi-input variants yield each entry of their input collection:
     /// `Merge` walks its ordered `inputs:` list, `Combine` walks its
     /// named `input:` map in insertion order.
@@ -1022,7 +1034,7 @@ impl PipelineNode {
             PipelineNode::Transform { header, .. }
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
+            | PipelineNode::Sink { header, .. }
             | PipelineNode::Reshape { header, .. }
             | PipelineNode::Cull { header, .. }
             | PipelineNode::Composition { header, .. } => vec![header.input.value.name()],
@@ -1071,7 +1083,7 @@ impl PipelineNode {
             PipelineNode::Route { .. } => "route",
             PipelineNode::Merge { .. } => "merge",
             PipelineNode::Combine { .. } => "combine",
-            PipelineNode::Output { .. } => "output",
+            PipelineNode::Sink { .. } => "sink",
             PipelineNode::Reshape { .. } => "reshape",
             PipelineNode::Cull { .. } => "cull",
             PipelineNode::Envelope { .. } => "envelope",
@@ -1080,7 +1092,7 @@ impl PipelineNode {
     }
 
     /// The single upstream input reference for the single-input consumer
-    /// variants (`Transform`, `Aggregate`, `Route`, `Output`, `Reshape`,
+    /// variants (`Transform`, `Aggregate`, `Route`, `Sink`, `Reshape`,
     /// `Cull`, `Composition`). Returns `None` for `Source` (no input) and for
     /// the multi-input / multi-port variants (`Merge`, `Combine`, `Envelope`),
     /// whose wiring the caller must walk explicitly through their own input
@@ -1094,7 +1106,7 @@ impl PipelineNode {
             PipelineNode::Transform { header, .. }
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
+            | PipelineNode::Sink { header, .. }
             | PipelineNode::Reshape { header, .. }
             | PipelineNode::Cull { header, .. }
             | PipelineNode::Composition { header, .. } => Some(&header.input.value),
@@ -1116,7 +1128,7 @@ impl PipelineNode {
             PipelineNode::Transform { header, .. }
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
+            | PipelineNode::Sink { header, .. }
             | PipelineNode::Reshape { header, .. }
             | PipelineNode::Cull { header, .. }
             | PipelineNode::Composition { header, .. } => {
@@ -1139,7 +1151,7 @@ impl PipelineNode {
     /// overlay op engine's `set config.cxl` uses to replace a stage's logic
     /// wholesale; the supplied [`CxlSource`] carries the op's span so a later
     /// typecheck error anchors to the override, not the base pipeline. Every
-    /// other variant (`Source`, `Route`, `Merge`, `Output`, `Reshape`, `Cull`,
+    /// other variant (`Source`, `Route`, `Merge`, `Sink`, `Reshape`, `Cull`,
     /// `Envelope`, `Composition`) has no single primary `cxl:` field and is
     /// left unchanged.
     pub fn set_primary_cxl(&mut self, cxl: CxlSource) -> bool {
@@ -1159,7 +1171,7 @@ impl PipelineNode {
             PipelineNode::Source { .. }
             | PipelineNode::Route { .. }
             | PipelineNode::Merge { .. }
-            | PipelineNode::Output { .. }
+            | PipelineNode::Sink { .. }
             | PipelineNode::Reshape { .. }
             | PipelineNode::Cull { .. }
             | PipelineNode::Envelope { .. }
@@ -2063,7 +2075,7 @@ nodes:
     resources:
       db: "postgres://localhost"
 
-  - type: output
+  - type: sink
     name: out
     input: totals
     config:
@@ -2089,7 +2101,7 @@ nodes:
             &doc.nodes[5].value,
             PipelineNode::Composition { .. }
         ));
-        assert!(matches!(&doc.nodes[6].value, PipelineNode::Output { .. }));
+        assert!(matches!(&doc.nodes[6].value, PipelineNode::Sink { .. }));
     }
 
     /// Verifies unknown node types produce a clear error naming the tag.

--- a/crates/clinker-plan/src/overlay_ops.rs
+++ b/crates/clinker-plan/src/overlay_ops.rs
@@ -1248,7 +1248,7 @@ fn reroute_single_ref(node: &mut PipelineNode, from: &str, to: &str) {
         PipelineNode::Transform { header, .. }
         | PipelineNode::Aggregate { header, .. }
         | PipelineNode::Route { header, .. }
-        | PipelineNode::Output { header, .. }
+        | PipelineNode::Sink { header, .. }
         | PipelineNode::Reshape { header, .. }
         | PipelineNode::Cull { header, .. }
         | PipelineNode::Composition { header, .. } => repoint(&mut header.input.value, from, to),
@@ -2527,7 +2527,7 @@ nodes:
         - { name: amount, type: int }
         - { name: cust_id, type: string }
         - { name: order_notes, type: string }
-  - type: output
+  - type: sink
     name: sink
     input: orders
     config:

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1397,7 +1397,7 @@ pub(crate) fn validate_output_path_collisions(
     }
 
     for n in nodes {
-        let PipelineNode::Output { config, .. } = &n.value else {
+        let PipelineNode::Sink { config, .. } = &n.value else {
             continue;
         };
         let p = config.output.path.as_str();
@@ -2925,7 +2925,7 @@ fn bind_schema_inner(
                     artifacts.typed_insert(node_id, Arc::new(synthetic_typed_program(row)));
                 }
             }
-            PipelineNode::Output { header, config } => {
+            PipelineNode::Sink { header, config } => {
                 if let Some(upstream) = upstream_schema(&header.input.value, schema_by_name) {
                     let row = upstream.clone();
                     validate_output_mapping_columns(&name, &config.output, &row, span, diags);
@@ -3351,7 +3351,7 @@ fn bind_composition(
                         }
                     }
                 }
-                PipelineNode::Output { config, .. } => {
+                PipelineNode::Sink { config, .. } => {
                     if let crate::config::OutputFormat::Csv(Some(opts)) = &config.output.format
                         && let Some(delimiter) = opts.delimiter.as_deref()
                     {
@@ -3399,7 +3399,7 @@ fn bind_composition(
                     SourceSchema::File(rel) => (rel, format!("source {:?}", config.source.name)),
                     _ => continue,
                 },
-                PipelineNode::Output { config, .. } => match &config.output.schema {
+                PipelineNode::Sink { config, .. } => match &config.output.schema {
                     Some(SourceSchema::File(rel)) => {
                         (rel, format!("output {:?}", config.output.name))
                     }
@@ -3428,7 +3428,7 @@ fn bind_composition(
         for (idx, inline) in resolved {
             match &mut body_file.nodes[idx].value {
                 PipelineNode::Source { config, .. } => config.schema = inline,
-                PipelineNode::Output { config, .. } => config.output.schema = Some(inline),
+                PipelineNode::Sink { config, .. } => config.output.schema = Some(inline),
                 _ => {}
             }
         }
@@ -3836,7 +3836,7 @@ fn bind_composition(
             | PipelineNode::Route { header, .. }
             | PipelineNode::Reshape { header, .. }
             | PipelineNode::Cull { header, .. }
-            | PipelineNode::Output { header, .. } => {
+            | PipelineNode::Sink { header, .. } => {
                 let r = match &header.input.value {
                     crate::config::node_header::NodeInput::Single(s) => s.clone(),
                     crate::config::node_header::NodeInput::Port { node, port } => {
@@ -3961,7 +3961,7 @@ fn bind_composition(
             | PipelineNode::Route { header, .. }
             | PipelineNode::Reshape { header, .. }
             | PipelineNode::Cull { header, .. }
-            | PipelineNode::Output { header, .. } => {
+            | PipelineNode::Sink { header, .. } => {
                 vec![match &header.input.value {
                     crate::config::node_header::NodeInput::Single(s) => s.clone(),
                     crate::config::node_header::NodeInput::Port { node, port } => {

--- a/crates/clinker-plan/src/security.rs
+++ b/crates/clinker-plan/src/security.rs
@@ -282,7 +282,7 @@ pub fn validate_all_config_paths(
             PipelineNode::Source { config, .. } => {
                 (Some(config.source.path_str()), config.source.name.as_str())
             }
-            PipelineNode::Output { config, .. } => (
+            PipelineNode::Sink { config, .. } => (
                 Some(config.output.path.as_str()),
                 config.output.name.as_str(),
             ),
@@ -537,7 +537,7 @@ nodes:
     input: src
     config:
       cxl: "emit x = a"
-  - type: output
+  - type: sink
     name: dest
     input: t1
     config:

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -4063,7 +4063,7 @@ fn apply_cli_force_policy(config: &mut clinker_plan::config::PipelineConfig, for
         return;
     }
     for node in &mut config.nodes {
-        if let clinker_plan::config::PipelineNode::Output { config: body, .. } = &mut node.value
+        if let clinker_plan::config::PipelineNode::Sink { config: body, .. } = &mut node.value
             && body.output.if_exists == clinker_plan::config::IfExistsPolicy::Error
         {
             body.output.if_exists = clinker_plan::config::IfExistsPolicy::Overwrite;
@@ -8239,7 +8239,7 @@ nodes:
       path: orders.csv
       schema:
         - { name: a, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -8276,7 +8276,7 @@ nodes:
       path: orders.csv
       schema:
         - { name: a, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:


### PR DESCRIPTION
## Summary

- rename the authored terminal node variant from `Output` to `Sink`
- make `type: sink` the accepted YAML discriminator and reject the retired `type: output` spelling with E376 and a pasteable correction
- preserve output-port, artifact, composition-output, and runtime plan terminology for the later compile-atomic runtime cutover

This is stacked on #1088. The remaining runtime variant and repository corpus migrations will be submitted as dependent PRs; this intermediate branch should not merge on its own.

## Validation

- `cargo check --workspace --locked --offline`
- `cargo test -p clinker-exec --test node_taxonomy_lift_test --locked --offline`
- `cargo test -p clinker-core-types --test registry_no_orphan_codes --locked --offline`
- focused planner variant parse test
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

This changes author vocabulary and plan parsing only. It does not change row values or routing, introduce execution work, or retain input-growing state, so no lineage, telemetry, or memory-budget changes are triggered in this slice.
