### PR TITLE
Rename compiled terminal nodes and dispatch to Sink

### DIFF
--- a/crates/clinker-exec/src/executor/correlation_dispatch.rs
+++ b/crates/clinker-exec/src/executor/correlation_dispatch.rs
@@ -459,7 +459,7 @@ fn order_clean_slots(
             detail: "correlation writer queue contains mixed physical boundaries".to_string(),
         });
     }
-    let boundary = crate::executor::output_dispatch::OrderedWriterBoundary::for_output(
+    let boundary = crate::executor::sink_dispatch::OrderedWriterBoundary::for_sink(
         current_dag,
         output_id,
         WriterBoundaryMode::CorrelationDeferred,

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -68,7 +68,7 @@ enum DispatchFaultKind {
     Merge,
     Sort,
     Envelope,
-    Output,
+    Sink,
     Cull,
     Reshape,
 }
@@ -86,7 +86,7 @@ impl DispatchFaultKind {
             "dispatch_merge" => Some(Self::Merge),
             "dispatch_sort" => Some(Self::Sort),
             "dispatch_envelope" => Some(Self::Envelope),
-            "dispatch_output" => Some(Self::Output),
+            "dispatch_sink" => Some(Self::Sink),
             "dispatch_cull" => Some(Self::Cull),
             "dispatch_reshape" => Some(Self::Reshape),
             _ => None,
@@ -1583,7 +1583,7 @@ pub(crate) struct ExecutorContext<'a> {
     /// has already been moved into the streaming task and there is no
     /// buffered batch to drain. Empty when no streaming chain
     /// qualified.
-    pub(crate) streaming_output_nodes: HashSet<NodeIndex>,
+    pub(crate) streaming_sink_nodes: HashSet<NodeIndex>,
 
     /// `producer → Aggregate` edges whose ingest streams. Keyed by the
     /// producer's `NodeIndex`, valued by the consuming `Aggregate`'s
@@ -3917,7 +3917,7 @@ pub(crate) fn transform_fused_consume(
     // Streaming inter-stage handoff: when a single streaming-eligible
     // Output downstream of this fused Transform installed its sender under
     // this node's index at executor entry (per `classify_stream_nodes` /
-    // `compute_streaming_output_specs`), take it here. Each flushed batch
+    // `compute_streaming_sink_specs`), take it here. Each flushed batch
     // is then sent straight to the writer thread over the bounded channel
     // — the blocking `send` is the back-pressure pivot, so peak
     // inter-stage memory is one batch plus the channel's bound, never the
@@ -4522,8 +4522,8 @@ pub(crate) fn dispatch_plan_node(
                 node_idx,
                 &node,
             ),
-            DispatchFaultKind::Output => {
-                crate::executor::output_dispatch::dispatch_output(ctx, current_dag, node_idx, &node)
+            DispatchFaultKind::Sink => {
+                crate::executor::sink_dispatch::dispatch_sink(ctx, current_dag, node_idx, &node)
             }
             DispatchFaultKind::Cull => {
                 crate::executor::cull_dispatch::dispatch_cull(ctx, current_dag, node_idx, &node)
@@ -4571,8 +4571,8 @@ pub(crate) fn dispatch_plan_node(
             )?;
         }
 
-        PlanNode::Output { .. } => {
-            crate::executor::output_dispatch::dispatch_output(ctx, current_dag, node_idx, &node)?;
+        PlanNode::Sink { .. } => {
+            crate::executor::sink_dispatch::dispatch_sink(ctx, current_dag, node_idx, &node)?;
         }
 
         PlanNode::Reshape { .. } => {

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -65,7 +65,7 @@ use crate::executor::dispatch::{
     source_name_arc_of,
 };
 use crate::executor::node_buffer::NodeBuffer;
-use crate::executor::output_dispatch::OrderedWriterBoundary;
+use crate::executor::sink_dispatch::OrderedWriterBoundary;
 use crate::executor::stream_event::{SourceRowId, StreamEvent};
 use crate::executor::structured_output_guard::StructuredOutputDocumentGuard;
 use crate::executor::{DlqEntry, build_format_writer};

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -20,13 +20,13 @@ pub(crate) mod invariant;
 pub(crate) mod merge_dispatch;
 pub mod node_buffer;
 pub(crate) mod node_buffer_spill;
-pub(crate) mod output_dispatch;
 mod params;
 mod registry;
 pub(crate) mod reshape_dispatch;
 mod route;
 pub(crate) mod route_dispatch;
 mod schema_check;
+pub(crate) mod sink_dispatch;
 pub(crate) mod sort_dispatch;
 pub(crate) mod source_dispatch;
 pub mod source_stream;
@@ -61,7 +61,7 @@ pub use storage_validate::{
 };
 pub use stream_event::{OutputDeliveryId, SourceRowId};
 pub(crate) use streaming::StreamingOutputTaskOutput;
-use streaming::{compute_streaming_output_specs, streaming_output};
+use streaming::{compute_streaming_sink_specs, streaming_sink};
 pub(crate) use transform::{
     WindowedEvalCtx, evaluate_single_transform, evaluate_single_transform_windowed,
 };
@@ -1331,7 +1331,7 @@ impl PipelineExecutor {
         // `JoinHandle`s are stored on the context so the dispatcher can
         // join them at end-of-DAG and fold the per-thread counter /
         // timer / error accounting back into the context.
-        let streaming_specs = compute_streaming_output_specs(
+        let streaming_specs = compute_streaming_sink_specs(
             plan,
             config,
             &fused_transforms,
@@ -1343,7 +1343,7 @@ impl PipelineExecutor {
             petgraph::graph::NodeIndex,
             crossbeam_channel::Sender<crate::executor::stream_event::StreamEvent>,
         > = HashMap::new();
-        let mut streaming_output_nodes: HashSet<petgraph::graph::NodeIndex> = HashSet::new();
+        let mut streaming_sink_nodes: HashSet<petgraph::graph::NodeIndex> = HashSet::new();
         let mut streaming_output_tasks: Vec<std::thread::JoinHandle<StreamingOutputTaskOutput>> =
             Vec::new();
         let mut streaming_charge_consumers: HashMap<
@@ -1357,7 +1357,7 @@ impl PipelineExecutor {
             let raw_writer = writers
                 .single
                 .remove(&spec.output_name)
-                .expect("compute_streaming_output_specs verified writers.single contains output");
+                .expect("compute_streaming_sink_specs verified writers.single contains output");
             // 256 is the bounded channel capacity. The writer thread
             // typically clears each record in microseconds; capacity
             // above ~256 buys no measured throughput but burns memory
@@ -1387,14 +1387,14 @@ impl PipelineExecutor {
             let writer_charge_handle = charge_handle.clone();
             let handle = std::thread::Builder::new()
                 .name(format!("clinker-output-{output_name}"))
-                .spawn(move || streaming_output(rx, raw_writer, spec, writer_charge_handle))
+                .spawn(move || streaming_sink(rx, raw_writer, spec, writer_charge_handle))
                 .map_err(|e| PipelineError::Internal {
                     op: "streaming-output-spawn",
                     node: output_name,
                     detail: format!("failed to spawn streaming output thread: {e}"),
                 })?;
             streaming_output_senders.insert(producer_idx, tx);
-            streaming_output_nodes.insert(output_idx);
+            streaming_sink_nodes.insert(output_idx);
             streaming_output_tasks.push(handle);
             streaming_charge_consumers.insert(producer_idx, (charge_consumer_id, charge_handle));
         }
@@ -1469,7 +1469,7 @@ impl PipelineExecutor {
                 params.telemetry_producer.clone(),
             ),
             streaming_output_senders,
-            streaming_output_nodes,
+            streaming_sink_nodes,
             streaming_aggregate_ingest_edges,
             streaming_combine_probe_edges,
             streaming_output_tasks,
@@ -1582,7 +1582,7 @@ impl PipelineExecutor {
                 Ok(out) => out.fold_into(&mut ctx),
                 Err(_panic) => {
                     ctx.output_errors.push(PipelineError::Internal {
-                        op: "streaming_output",
+                        op: "streaming_sink",
                         node: String::from("<unknown>"),
                         detail: String::from("streaming output thread panicked"),
                     });

--- a/crates/clinker-exec/src/executor/sink_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sink_dispatch.rs
@@ -1,11 +1,11 @@
-//! `PlanNode::Output` dispatch arm.
+//! `PlanNode::Sink` dispatch arm.
 //!
 //! Holds the sink-writer body lifted out of
 //! [`crate::executor::dispatch::dispatch_plan_node`]: writer init, output
 //! schema mapping, `include_unmapped` passthrough, the per-record fan-out
 //! to source-file-keyed writers, the correlation-buffer capture path, and
-//! the streaming-fused output short-circuit. The dispatcher's `Output` arm
-//! is a single delegating call into [`dispatch_output`].
+//! the streaming-fused output short-circuit. The dispatcher's `Sink` arm
+//! is a single delegating call into [`dispatch_sink`].
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -53,7 +53,7 @@ type OrderedRecordStream<'a> = Box<dyn Iterator<Item = OrderedRecord> + 'a>;
 impl OrderedWriterBoundary {
     /// Resolve the one compiled boundary for `output_id` and assert that the
     /// runtime path matches its planner-selected mode.
-    pub(crate) fn for_output(
+    pub(crate) fn for_sink(
         current_dag: &ExecutionPlanDag,
         output_id: clinker_plan::plan::PlanNodeId,
         expected_mode: WriterBoundaryMode,
@@ -246,7 +246,7 @@ fn resolve_out_cfg<'a>(
 /// schema-check), the upstream node name (for E314 diagnostics), and the CXL
 /// emit names (for `include_unmapped: false` projection). Owned so the caller
 /// can hold them across the `&mut ctx` write phase.
-struct OutputInputs {
+struct SinkInputs {
     expected_input_schema: Option<Arc<clinker_record::Schema>>,
     upstream_name: String,
     cxl_emit_names: Vec<String>,
@@ -256,14 +256,14 @@ struct OutputInputs {
 /// dispatch passes the live executor context directly; the feature-gated
 /// mismatch matrix uses the inert carrier to prove rejection precedes writer
 /// lookup, publication, correlation buffering, and input-buffer access.
-pub(crate) enum OutputDispatchContext<'borrow, 'plan> {
+pub(crate) enum SinkDispatchContext<'borrow, 'plan> {
     Live(&'borrow mut ExecutorContext<'plan>),
     #[cfg(feature = "test-utils")]
     Inert,
 }
 
 impl<'borrow, 'plan> From<&'borrow mut ExecutorContext<'plan>>
-    for OutputDispatchContext<'borrow, 'plan>
+    for SinkDispatchContext<'borrow, 'plan>
 {
     fn from(ctx: &'borrow mut ExecutorContext<'plan>) -> Self {
         Self::Live(ctx)
@@ -275,20 +275,20 @@ impl crate::executor::dispatch::DispatchFaultGuard {
     /// Execute the real output boundary with an inert context so tests can
     /// prove a wrong node returns before writer or publication state is read.
     #[doc(hidden)]
-    pub fn dispatch_output_mismatch_for_testing(
+    pub fn dispatch_sink_mismatch_for_testing(
         current_dag: &ExecutionPlanDag,
         node_idx: NodeIndex,
         node: &PlanNode,
     ) -> Result<(), PipelineError> {
-        dispatch_output(OutputDispatchContext::Inert, current_dag, node_idx, node)
+        dispatch_sink(SinkDispatchContext::Inert, current_dag, node_idx, node)
     }
 }
 
-/// Derive the [`OutputInputs`] for `node_idx` from the plan. Shared by the
-/// records-only, document-DLQ, and envelope Output arms so the input-binding
+/// Derive the [`SinkInputs`] for `node_idx` from the plan. Shared by the
+/// records-only, document-DLQ, and envelope Sink arms so the input-binding
 /// preamble lives in one place.
-fn resolve_output_inputs(current_dag: &ExecutionPlanDag, node_idx: NodeIndex) -> OutputInputs {
-    OutputInputs {
+fn resolve_sink_inputs(current_dag: &ExecutionPlanDag, node_idx: NodeIndex) -> SinkInputs {
+    SinkInputs {
         expected_input_schema: current_dag.graph[node_idx]
             .expected_input_schema_in(current_dag)
             .cloned(),
@@ -302,15 +302,15 @@ fn resolve_output_inputs(current_dag: &ExecutionPlanDag, node_idx: NodeIndex) ->
     }
 }
 
-/// Execute the `Output` arm for `node_idx`: open the writer(s), map records
+/// Execute the `Sink` arm for `node_idx`: open the writer(s), map records
 /// onto the declared output schema (passing unmapped fields through when
 /// configured), and write — taking the per-record fan-out path for
 /// source-file-keyed outputs, the correlation-buffer capture path under a
 /// correlation-key pipeline, and the streaming-fused short-circuit when a
 /// streaming sender was installed. Deferred physical boundaries block only at
 /// their compiled population grain and spill through the shared sorter.
-pub(crate) fn dispatch_output<'borrow, 'plan>(
-    ctx: impl Into<OutputDispatchContext<'borrow, 'plan>>,
+pub(crate) fn dispatch_sink<'borrow, 'plan>(
+    ctx: impl Into<SinkDispatchContext<'borrow, 'plan>>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
     node: &PlanNode,
@@ -318,39 +318,39 @@ pub(crate) fn dispatch_output<'borrow, 'plan>(
 where
     'plan: 'borrow,
 {
-    let PlanNode::Output {
+    let PlanNode::Sink {
         ref name,
         ref resolved,
         ..
     } = *node
     else {
         return Err(crate::executor::invariant::dispatch_mismatch(
-            "dispatch_output",
-            "output",
+            "dispatch_sink",
+            "sink",
             node.kind_name(),
             node.name(),
         ));
     };
     #[cfg(feature = "test-utils")]
-    let OutputDispatchContext::Live(ctx) = ctx.into() else {
-        panic!("output dispatcher accessed inert context after accepting an output node")
+    let SinkDispatchContext::Live(ctx) = ctx.into() else {
+        panic!("sink dispatcher accessed inert context after accepting a sink node")
     };
     #[cfg(not(feature = "test-utils"))]
-    let OutputDispatchContext::Live(ctx) = ctx.into();
+    let SinkDispatchContext::Live(ctx) = ctx.into();
     let output_id = node.id();
-    // Streaming-Output short-circuit (issue #72). The executor
-    // entry already moved this Output's writer into a
+    // Streaming-Sink short-circuit (issue #72). The executor
+    // entry already moved this Sink's writer into a
     // `std::thread` that drained records from a bounded crossbeam
     // channel populated by the fused Merge arm. Per-record
     // `write_record` already fired concurrently with Merge
     // production; the dispatcher's end-of-DAG join surface joins
     // the thread and folds its counters / timers / errors into
-    // the context. The Output's topo turn here is a no-op.
-    if ctx.streaming_output_nodes.contains(&node_idx) {
+    // the context. The Sink's topo turn here is a no-op.
+    if ctx.streaming_sink_nodes.contains(&node_idx) {
         return Ok(());
     }
     // Document-level DLQ short-circuit. When any source declares
-    // `dlq_granularity: document`, this Output's records are decided
+    // `dlq_granularity: document`, this Sink's records are decided
     // per-document: buffered until each `DocumentClose`, then flushed clean
     // to the writer or rejected (trigger + collateral) to the DLQ. The
     // driver consumes the INTERLEAVED event stream (records + closes in
@@ -358,12 +358,12 @@ where
     // below discards — an additive read of the same buffer, not a change to
     // the records-vs-puncts split contract every other operator relies on.
     if ctx.document_dlq.is_some() {
-        let writer_boundary = OrderedWriterBoundary::for_output(
+        let writer_boundary = OrderedWriterBoundary::for_sink(
             current_dag,
             output_id,
             WriterBoundaryMode::DocumentDlq,
         )?;
-        return dispatch_output_document_dlq(ctx, current_dag, node_idx, name, writer_boundary);
+        return dispatch_sink_document_dlq(ctx, current_dag, node_idx, name, writer_boundary);
     }
     // Envelope-reconstruction short-circuit. When this Output declares
     // `reconstruct_envelope: true`, its writer's `begin_document` /
@@ -374,12 +374,9 @@ where
     // boundaries stream each body record; deferred boundaries sort one
     // document through the bounded shared spill path before framing its body.
     if resolve_out_cfg(ctx, name).reconstruct_envelope {
-        let writer_boundary = OrderedWriterBoundary::for_output(
-            current_dag,
-            output_id,
-            WriterBoundaryMode::Envelope,
-        )?;
-        return dispatch_output_envelope(ctx, current_dag, node_idx, name, writer_boundary);
+        let writer_boundary =
+            OrderedWriterBoundary::for_sink(current_dag, output_id, WriterBoundaryMode::Envelope)?;
+        return dispatch_sink_envelope(ctx, current_dag, node_idx, name, writer_boundary);
     }
     let correlation_deferred = ctx.correlation_buffers.is_some();
     let expected_mode = if correlation_deferred {
@@ -392,7 +389,7 @@ where
     } else {
         WriterBoundaryMode::RecordsOnly
     };
-    let writer_boundary = OrderedWriterBoundary::for_output(current_dag, output_id, expected_mode)?;
+    let writer_boundary = OrderedWriterBoundary::for_sink(current_dag, output_id, expected_mode)?;
     // Get input records: check own buffer first (Route
     // nodes store records at the successor's index), then
     // fall back to predecessor buffers.
@@ -409,7 +406,7 @@ where
         .graph
         .edges_directed(node_idx, Direction::Incoming)
         .next()
-        .ok_or_else(|| missing_output_input_error(current_dag, node_idx, name))?;
+        .ok_or_else(|| missing_sink_input_error(current_dag, node_idx, name))?;
     let producer = edge.source();
     let producer_port = edge.weight().producer_port.as_deref();
     let input_key =
@@ -434,14 +431,14 @@ where
         input_records = writer_boundary.order_records(ctx, input_records)?;
     }
 
-    let OutputInputs {
+    let SinkInputs {
         expected_input_schema,
         upstream_name,
         cxl_emit_names,
-    } = resolve_output_inputs(current_dag, node_idx);
+    } = resolve_sink_inputs(current_dag, node_idx);
     if let Some(expected) = expected_input_schema.as_ref() {
         for (record, _) in &input_records {
-            check_input_schema(expected, record.schema(), name, "output", &upstream_name)?;
+            check_input_schema(expected, record.schema(), name, "sink", &upstream_name)?;
         }
     }
 
@@ -532,7 +529,7 @@ where
     //   already been counted at another Output during
     //   the same DAG walk. Source identity is
     //   `row_num` (per-source counter), tracked across
-    //   all Output arms via the `ok_source_rows` set
+    //   all Sink arms via the `ok_source_rows` set
     //   declared at function scope.
     //
     // Buffered records DEFER counter increments to the
@@ -782,7 +779,7 @@ fn build_csv_union_schema(
 /// DLQ. Blocking at the document grain — a buffered record is not written
 /// until its close decides the document clean; peak memory is the
 /// concurrently-open documents, spillable under budget.
-fn dispatch_output_document_dlq(
+fn dispatch_sink_document_dlq(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
@@ -790,17 +787,17 @@ fn dispatch_output_document_dlq(
     writer_boundary: OrderedWriterBoundary,
 ) -> Result<(), PipelineError> {
     let (events, _input_clone_reservation) =
-        drain_output_input_events(ctx, current_dag, node_idx, name)?;
+        drain_sink_input_events(ctx, current_dag, node_idx, name)?;
 
-    let OutputInputs {
+    let SinkInputs {
         expected_input_schema,
         upstream_name,
         cxl_emit_names,
-    } = resolve_output_inputs(current_dag, node_idx);
+    } = resolve_sink_inputs(current_dag, node_idx);
     if let Some(expected) = expected_input_schema.as_ref() {
         for event in &events {
             if let crate::executor::stream_event::StreamEvent::Record(record, _) = event {
-                check_input_schema(expected, record.schema(), name, "output", &upstream_name)?;
+                check_input_schema(expected, record.schema(), name, "sink", &upstream_name)?;
             }
         }
     }
@@ -824,14 +821,14 @@ fn dispatch_output_document_dlq(
     driver.run(ctx, events)
 }
 
-/// Drain this Output's input buffer as the INTERLEAVED `StreamEvent`
+/// Drain this Sink's input buffer as the INTERLEAVED `StreamEvent`
 /// stream, preserving record/`DocumentClose` ordering — the boundary the
 /// records-only `drain_split` path discards — and materialize it into a
 /// `Vec` for the document-DLQ driver (which buffers per document anyway, so
 /// has no use for the lazy form). Delegates the predecessor-selection walk to
-/// [`drain_output_input_event_iter`] so the two boundary-aware Output arms
+/// [`drain_sink_input_event_iter`] so the two boundary-aware Sink arms
 /// share one mechanism.
-fn drain_output_input_events(
+fn drain_sink_input_events(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
@@ -843,7 +840,7 @@ fn drain_output_input_events(
     ),
     PipelineError,
 > {
-    let input = drain_output_input_event_iter(ctx, current_dag, node_idx, name, true)?;
+    let input = drain_sink_input_event_iter(ctx, current_dag, node_idx, name, true)?;
     let (events, reservation) = input.into_parts();
     Ok((events.collect::<Result<Vec<_>, _>>()?, reservation))
 }
@@ -892,18 +889,18 @@ fn drain_output_input_events(
 /// schema-check failure fails fast like the sibling arms, but first surfaces
 /// any already-accumulated framing/write errors and flushes the open document
 /// so nothing in flight is lost.
-fn dispatch_output_envelope(
+fn dispatch_sink_envelope(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
     name: &str,
     writer_boundary: OrderedWriterBoundary,
 ) -> Result<(), PipelineError> {
-    let OutputInputs {
+    let SinkInputs {
         expected_input_schema,
         upstream_name,
         cxl_emit_names,
-    } = resolve_output_inputs(current_dag, node_idx);
+    } = resolve_sink_inputs(current_dag, node_idx);
     // Owned clone: the writer-factory closure and the projection both borrow
     // `out_cfg` across the loop's `&mut ctx` phases, so it cannot stay a
     // borrow of `ctx.output_configs`.
@@ -919,7 +916,7 @@ fn dispatch_output_envelope(
     let scan_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::SchemaScan);
     let mut any_record = false;
 
-    let mut events = drain_output_input_event_iter(ctx, current_dag, node_idx, name, false)?;
+    let mut events = drain_sink_input_event_iter(ctx, current_dag, node_idx, name, false)?;
     let mut driver = EnvelopeWriterDriver::default();
     let mut structured_guard = StructuredOutputDocumentGuard::new(&out_cfg.format);
     let mut pending = None;
@@ -973,7 +970,7 @@ fn dispatch_output_envelope(
             let checked = population.map(|item| {
                 let (record, row_num) = item?;
                 if let Some(expected) = expected_input_schema.as_ref() {
-                    check_input_schema(expected, record.schema(), name, "output", &upstream_name)?;
+                    check_input_schema(expected, record.schema(), name, "sink", &upstream_name)?;
                 }
                 Ok((record, row_num))
             });
@@ -1122,7 +1119,7 @@ impl EnvelopeWriterDriver {
         let writer = self.writer.as_mut().expect("writer opened above");
         if let Err(e) = writer.write_record(projected) {
             // A `join_values` `on_conflict: error` collision is routed to the DLQ
-            // on the record-granularity Output arms (buffered + streaming). This
+            // on the record-granularity Sink arms (buffered + streaming). This
             // envelope-reconstruction arm holds only the projected record and no
             // `ctx` here, and a collision interacts with the per-document framing
             // it drives, so — like the correlation-commit and document-DLQ arms —
@@ -1193,22 +1190,22 @@ impl EnvelopeWriterDriver {
     }
 }
 
-/// Lazily drain this Output's input as the INTERLEAVED `StreamEvent` stream,
+/// Lazily drain this Sink's input as the INTERLEAVED `StreamEvent` stream,
 /// preserving record/boundary ordering — the envelope-reconstruction analog
-/// of [`drain_output_input_events`], but yielding an iterator rather than a
+/// of [`drain_sink_input_events`], but yielding an iterator rather than a
 /// `Vec` so a spilled predecessor buffer streams from disk one event at a
 /// time instead of materializing. Mirrors the per-record path's own-slot-first
 /// selection, then lets the producer-declared reader ledger choose a shared
 /// sequential scan or transfer the authoritative predecessor generation to
 /// its final reader. A spill-backed scan opens one chunk at a time.
-#[must_use = "an Output input must retain its scan reservation"]
-struct OutputInputEventIter {
+#[must_use = "a Sink input must retain its scan reservation"]
+struct SinkInputEventIter {
     events:
         Box<dyn Iterator<Item = Result<crate::executor::stream_event::StreamEvent, PipelineError>>>,
     reservation: Option<TransientNodeBufferReservation>,
 }
 
-impl OutputInputEventIter {
+impl SinkInputEventIter {
     fn into_parts(
         self,
     ) -> (
@@ -1219,7 +1216,7 @@ impl OutputInputEventIter {
     }
 }
 
-impl Iterator for OutputInputEventIter {
+impl Iterator for SinkInputEventIter {
     type Item = Result<crate::executor::stream_event::StreamEvent, PipelineError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -1227,19 +1224,19 @@ impl Iterator for OutputInputEventIter {
     }
 }
 
-fn drain_output_input_event_iter(
+fn drain_sink_input_event_iter(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
     name: &str,
     materializes: bool,
-) -> Result<OutputInputEventIter, PipelineError> {
+) -> Result<SinkInputEventIter, PipelineError> {
     use petgraph::visit::EdgeRef;
     let edge = current_dag
         .graph
         .edges_directed(node_idx, Direction::Incoming)
         .next()
-        .ok_or_else(|| missing_output_input_error(current_dag, node_idx, name))?;
+        .ok_or_else(|| missing_sink_input_error(current_dag, node_idx, name))?;
     let producer = edge.source();
     let producer_port = edge.weight().producer_port.as_deref();
     let input_key =
@@ -1256,16 +1253,16 @@ fn drain_output_input_event_iter(
     } else {
         input.into_parts()
     };
-    Ok(OutputInputEventIter {
+    Ok(SinkInputEventIter {
         events: Box::new(input.drain()),
         reservation,
     })
 }
 
-/// Build the fail-loud diagnostic only after every valid Output input location
+/// Build the fail-loud diagnostic only after every valid Sink input location
 /// (own slot, predecessor drain, or predecessor shared scan) has been checked.
 #[cold]
-fn missing_output_input_error(
+fn missing_sink_input_error(
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
     name: &str,
@@ -1286,14 +1283,14 @@ fn missing_output_input_error(
     }
 }
 
-/// The Output node's resolved write target plus the run-scoped writer
+/// The Sink node's resolved write target plus the run-scoped writer
 /// state both write paths share. Bundling the four cross-branch borrows
 /// (error sink, the write / projection cumulative timers, and the
 /// stage-metric collector) with the per-call write descriptor (output
 /// name, resolved [`SinkConfig`](clinker_plan::config::SinkConfig), explicit
 /// CXL emit names, and the projected output schema) keeps the fan-out and
 /// single-writer helpers below clippy's argument threshold and gives them
-/// one shared shape — a change to how an Output write is attributed (e.g.
+/// one shared shape — a change to how a Sink write is attributed (e.g.
 /// a new metric guard) lands on the struct, not on two signatures.
 struct FanOutContext<'a> {
     name: &'a str,
@@ -1304,7 +1301,7 @@ struct FanOutContext<'a> {
     write_timer: &'a mut crate::executor::stage_metrics::CumulativeTimer,
     projection_timer: &'a mut crate::executor::stage_metrics::CumulativeTimer,
     collector: &'a mut crate::executor::stage_metrics::StageCollector,
-    /// This Output's `mapping:` resolution evidence, carried in so the per-record
+    /// This Sink's `mapping:` resolution evidence, carried in so the per-record
     /// projections below feed the same probe the rest of the run's arms do.
     mapping_probe: Option<&'a mut crate::projection::MappingProbe>,
     /// The run's error strategy, so a `join_values` `on_conflict: error`
@@ -1571,14 +1568,14 @@ mod tests {
         }
     }
 
-    fn output_clone_fixture() -> NodeBuffer {
+    fn sink_input_clone_fixture() -> NodeBuffer {
         let schema = Arc::new(Schema::new(vec!["id".into()]));
         NodeBuffer::memory_from_records(vec![(Record::new(schema, vec![Value::Integer(1)]), 1)])
     }
 
     #[test]
-    fn ordinary_output_materialization_preflight_returns_node_buffer_e310_at_baseline() {
-        let input = output_clone_fixture();
+    fn ordinary_sink_materialization_preflight_returns_node_buffer_e310_at_baseline() {
+        let input = sink_input_clone_fixture();
         let clone_bytes = input.estimated_memory_bytes();
         let hard_limit = 100 * 1024 * 1024 * 1024;
         let baseline_usage = hard_limit - clone_bytes + 1;
@@ -1612,8 +1609,8 @@ mod tests {
     }
 
     #[test]
-    fn envelope_output_iterator_holds_materialization_charge_through_iteration() {
-        let mut input = output_clone_fixture();
+    fn envelope_sink_iterator_holds_materialization_charge_through_iteration() {
+        let mut input = sink_input_clone_fixture();
         let clone_bytes = input.estimated_memory_bytes();
         let budget = Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
             100 * 1024 * 1024 * 1024,
@@ -1624,7 +1621,7 @@ mod tests {
         let reservation = reserve_node_buffer_materialization(clone_bytes, &budget, "envelope_out")
             .expect("roomy Output materialization");
         let reread = input.reread().expect("re-readable Output input");
-        let mut events = OutputInputEventIter {
+        let mut events = SinkInputEventIter {
             events: Box::new(reread.drain()),
             reservation: Some(reservation),
         };

--- a/crates/clinker-exec/src/executor/streaming.rs
+++ b/crates/clinker-exec/src/executor/streaming.rs
@@ -5,7 +5,7 @@
 //! slot, moving each such consumer onto its own thread fed by a bounded
 //! channel. The channel-drain + per-record-discharge skeleton
 //! ([`drain_streaming_channel`]) is parameterized over a
-//! [`StreamingConsumer`], with [`OutputStreamConsumer`] (a file-writer)
+//! [`StreamingConsumer`], with [`SinkStreamConsumer`] (a file-writer)
 //! as the sole instantiation today. The eligibility verdict comes from the
 //! plan layer's `certify_streaming_edge`, so this runtime install can never
 //! disagree with the `--explain` buffer-class annotation.
@@ -22,7 +22,7 @@ use clinker_plan::config::{ErrorStrategy, PipelineConfig, SinkConfig};
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::certify_streaming_edge;
 
-use super::output_dispatch::OrderedWriterBoundary;
+use super::sink_dispatch::OrderedWriterBoundary;
 use super::stream_event::{OutputDeliveryId, Punctuation, StreamEvent};
 use super::structured_output_guard::StructuredOutputDocumentGuard;
 use super::{DlqEntry, WriterRegistry, build_format_writer, dispatch, stage_metrics};
@@ -36,10 +36,10 @@ use super::{DlqEntry, WriterRegistry, build_format_writer, dispatch, stage_metri
 /// it; the authoritative rate check still runs at join for what did accumulate.
 const STREAMING_DLQ_BUFFER_CAP: u64 = 65_536;
 
-/// Identify fused producer → single `Output` chains eligible for
-/// streaming writes and build a [`StreamingOutputSpec`] for each.
+/// Identify fused producer → single `Sink` chains eligible for
+/// streaming writes and build a [`StreamingSinkSpec`] for each.
 ///
-/// The buffered Output arm waits until its producer has emitted every
+/// The buffered Sink arm waits until its producer has emitted every
 /// record before invoking the writer; under a slow upstream Source this
 /// defeats the live back-pressure the Source ingest channel delivers,
 /// because every record sits in the producer's `node_buffers` slot until
@@ -59,17 +59,17 @@ const STREAMING_DLQ_BUFFER_CAP: u64 = 65_536;
 /// `out_cfg`, and projection metadata are all Output-specific.
 ///
 /// Returns the list of streaming specs (one per qualifying Output). Empty
-/// for pipelines that don't match the topology, leaving every Output on
+/// for pipelines that don't match the topology, leaving every Sink on
 /// the existing buffered path. See
 /// https://github.com/rustpunk/clinker/issues/72 for the rationale.
-pub(super) fn compute_streaming_output_specs(
+pub(super) fn compute_streaming_sink_specs(
     plan: &clinker_plan::plan::execution::ExecutionPlanDag,
     config: &PipelineConfig,
     fused_transforms: &HashSet<petgraph::graph::NodeIndex>,
     init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
     output_configs: &[SinkConfig],
     writers: &WriterRegistry,
-) -> Vec<StreamingOutputSpec> {
+) -> Vec<StreamingSinkSpec> {
     use clinker_plan::plan::execution::PlanNode;
 
     // Pipeline-wide correlation buffering disables streaming for every
@@ -90,9 +90,9 @@ pub(super) fn compute_streaming_output_specs(
         return Vec::new();
     }
 
-    let mut specs: Vec<StreamingOutputSpec> = Vec::new();
+    let mut specs: Vec<StreamingSinkSpec> = Vec::new();
     for output_idx in plan.graph.node_indices() {
-        let PlanNode::Output {
+        let PlanNode::Sink {
             name: output_name, ..
         } = &plan.graph[output_idx]
         else {
@@ -124,7 +124,7 @@ pub(super) fn compute_streaming_output_specs(
             .expected_input_schema_in(plan)
             .cloned();
         let cxl_emit_names: Vec<String> = plan.graph[output_idx].cxl_emit_names_in(plan);
-        let Ok(writer_boundary) = OrderedWriterBoundary::for_output(
+        let Ok(writer_boundary) = OrderedWriterBoundary::for_sink(
             plan,
             plan.graph[output_idx].id(),
             clinker_plan::plan::execution::WriterBoundaryMode::Streaming,
@@ -135,7 +135,7 @@ pub(super) fn compute_streaming_output_specs(
             continue;
         };
 
-        specs.push(StreamingOutputSpec {
+        specs.push(StreamingSinkSpec {
             producer_idx,
             output_idx,
             consumer: plan.graph[output_idx].id(),
@@ -155,18 +155,18 @@ pub(super) fn compute_streaming_output_specs(
 /// entry. Carries every field the thread needs in owned form so it can run
 /// independently of the borrowed `&PipelineConfig` / `&ExecutionPlanDag`
 /// references that anchor the dispatcher's `ExecutorContext`.
-pub(crate) struct StreamingOutputSpec {
+pub(crate) struct StreamingSinkSpec {
     /// `NodeIndex` of the upstream producer node whose arm writes records
     /// into the streaming channel — either a fused `Merge.interleave` or
     /// a fused `Source → Transform`. The producer arm looks up its sender
     /// in [`dispatch::ExecutorContext::streaming_output_senders`] keyed by
     /// this index.
     pub(crate) producer_idx: petgraph::graph::NodeIndex,
-    /// `NodeIndex` of the downstream `Output` node. The Output arm
+    /// `NodeIndex` of the downstream `Sink` node. The Sink arm
     /// short-circuits when its index appears in
-    /// [`dispatch::ExecutorContext::streaming_output_nodes`].
+    /// [`dispatch::ExecutorContext::streaming_sink_nodes`].
     pub(crate) output_idx: petgraph::graph::NodeIndex,
-    /// Stable compiled identity of the terminal Output consumer.
+    /// Stable compiled identity of the terminal Sink consumer.
     pub(crate) consumer: clinker_plan::plan::PlanNodeId,
     pub(crate) output_name: String,
     /// Name of the upstream producer (`Merge` or fused `Transform`), used
@@ -224,9 +224,9 @@ pub(crate) struct StreamingOutputTaskOutput {
     /// The Output this task wrote, so the fold can key the probe without
     /// reaching back into the consumer's `spec`.
     pub(crate) output_name: String,
-    /// This Output's config, so the fold can size a probe entry the dispatcher
+    /// This Sink's config, so the fold can size a probe entry the dispatcher
     /// arms never created. Owned for the same reason the rest of
-    /// [`StreamingOutputSpec`] is: the thread outlives the borrow.
+    /// [`StreamingSinkSpec`] is: the thread outlives the borrow.
     pub(crate) out_cfg: SinkConfig,
 }
 
@@ -380,8 +380,8 @@ pub(super) fn drain_streaming_channel<C: StreamingConsumer>(
 /// record, and flushes at channel close. Errors are accumulated into
 /// `out` rather than aborting so the dispatcher can surface them alongside
 /// any sibling `output_errors`.
-struct OutputStreamConsumer {
-    spec: StreamingOutputSpec,
+struct SinkStreamConsumer {
+    spec: StreamingSinkSpec,
     out: StreamingOutputTaskOutput,
     /// Pending `SchemaScan` timer, finished on the first writer build (or
     /// on close for the empty-stream case).
@@ -393,8 +393,8 @@ struct OutputStreamConsumer {
     structured_guard: StructuredOutputDocumentGuard,
 }
 
-impl OutputStreamConsumer {
-    fn new(raw_writer: Box<dyn Write + Send>, spec: StreamingOutputSpec) -> Self {
+impl SinkStreamConsumer {
+    fn new(raw_writer: Box<dyn Write + Send>, spec: StreamingSinkSpec) -> Self {
         debug_assert!(spec.writer_boundary.is_incremental_streaming());
         let structured_guard = StructuredOutputDocumentGuard::new(&spec.out_cfg.format);
         let mapping_probe = crate::projection::MappingProbe::for_config(&spec.out_cfg);
@@ -426,7 +426,7 @@ impl OutputStreamConsumer {
     }
 }
 
-impl StreamingConsumer for OutputStreamConsumer {
+impl StreamingConsumer for SinkStreamConsumer {
     fn on_record(
         &mut self,
         record: Record,
@@ -443,7 +443,7 @@ impl StreamingConsumer for OutputStreamConsumer {
                 expected,
                 record.schema(),
                 &self.spec.output_name,
-                "output",
+                "sink",
                 &self.spec.producer_name,
             )
         {
@@ -560,7 +560,7 @@ impl StreamingConsumer for OutputStreamConsumer {
                     // scale with the stream.
                     if self.out.dlq_pending.len() as u64 >= STREAMING_DLQ_BUFFER_CAP {
                         self.out.errors.push(PipelineError::Internal {
-                            op: "streaming_output",
+                            op: "streaming_sink",
                             node: self.spec.output_name.clone(),
                             detail: format!(
                                 "more than {STREAMING_DLQ_BUFFER_CAP} `join_values` collisions \
@@ -612,19 +612,19 @@ impl StreamingConsumer for OutputStreamConsumer {
     }
 }
 
-/// Streaming-output writer thread body — the `Output` instantiation of the
+/// Streaming-output writer thread body — the `Sink` instantiation of the
 /// generalized streaming-consumer substrate. Builds an
-/// [`OutputStreamConsumer`] over the writer lifecycle and drives it with
+/// [`SinkStreamConsumer`] over the writer lifecycle and drives it with
 /// [`drain_streaming_channel`], returning the folded-back per-task
-/// counters. See [`StreamingOutputSpec`] for the eligibility predicate and
+/// counters. See [`StreamingSinkSpec`] for the eligibility predicate and
 /// https://github.com/rustpunk/clinker/issues/72 for the rationale.
-pub(super) fn streaming_output(
+pub(super) fn streaming_sink(
     rx: crossbeam_channel::Receiver<StreamEvent>,
     raw_writer: Box<dyn Write + Send>,
-    spec: StreamingOutputSpec,
+    spec: StreamingSinkSpec,
     charge_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
 ) -> StreamingOutputTaskOutput {
-    let mut consumer = OutputStreamConsumer::new(raw_writer, spec);
+    let mut consumer = SinkStreamConsumer::new(raw_writer, spec);
     drain_streaming_channel(&rx, &charge_handle, &mut consumer);
     consumer.out
 }

--- a/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
@@ -94,7 +94,7 @@ fn relaxed_aggregate_seeds_a_deferred_region_with_downstream_members() {
     let output_idx = plan
         .graph
         .node_indices()
-        .find(|&i| matches!(&plan.graph[i], PlanNode::Output { name, .. } if name == "out"))
+        .find(|&i| matches!(&plan.graph[i], PlanNode::Sink { name, .. } if name == "out"))
         .expect("Output 'out' must be present");
 
     let region = plan

--- a/crates/clinker-exec/tests/fan_out_writers_test.rs
+++ b/crates/clinker-exec/tests/fan_out_writers_test.rs
@@ -31,7 +31,7 @@ nodes:
       schema:
         - { name: order_id, type: string }
         - { name: amount, type: float }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -135,10 +135,10 @@ fn fan_out_flag_set_when_template_uses_source_file_token() {
         .find(|i| dag.graph[*i].name() == "out")
         .expect("output node 'out' exists");
     use clinker_plan::plan::execution::PlanNode;
-    let PlanNode::Output { resolved, .. } = &dag.graph[out_idx] else {
-        panic!("expected Output variant");
+    let PlanNode::Sink { resolved, .. } = &dag.graph[out_idx] else {
+        panic!("expected Sink variant");
     };
-    let payload = resolved.as_ref().expect("Output payload populated");
+    let payload = resolved.as_ref().expect("Sink payload populated");
     assert!(
         payload.fan_out_per_source_file,
         "Output 'out' uses {{source_file}} token + has FilePartitioned input \

--- a/crates/clinker-exec/tests/invariant_errors.rs
+++ b/crates/clinker-exec/tests/invariant_errors.rs
@@ -49,7 +49,7 @@ nodes:
       cxl: |
         emit id = id
         emit renamed = label
-  - type: output
+  - type: sink
     name: out
     input: rename
     config:
@@ -204,12 +204,12 @@ fn dispatch_mismatch_cases() -> [DispatchMismatchCase; 12] {
             invoke: DispatchFaultGuard::dispatch_envelope_mismatch_for_testing,
         },
         DispatchMismatchCase {
-            matrix_name: "output",
-            dispatcher: "dispatch_output",
-            expected_kind: "output",
+            matrix_name: "sink",
+            dispatcher: "dispatch_sink",
+            expected_kind: "sink",
             actual_kind: "transform",
             node_name: "rename",
-            invoke: DispatchFaultGuard::dispatch_output_mismatch_for_testing,
+            invoke: DispatchFaultGuard::dispatch_sink_mismatch_for_testing,
         },
         DispatchMismatchCase {
             matrix_name: "cull",
@@ -486,7 +486,7 @@ fn exhaustive_twelve_dispatcher_matrix() {
             "merge",
             "sort",
             "envelope",
-            "output",
+            "sink",
             "cull",
             "reshape",
         ],

--- a/crates/clinker-exec/tests/node_taxonomy_lift_test.rs
+++ b/crates/clinker-exec/tests/node_taxonomy_lift_test.rs
@@ -620,7 +620,7 @@ nodes:
 }
 
 #[test]
-fn test_compile_lowered_output_carries_resolved_payload() {
+fn test_compile_lowered_sink_carries_resolved_payload() {
     use clinker_plan::plan::execution::PlanNode;
     let yaml = r#"
 pipeline:
@@ -650,13 +650,13 @@ nodes:
     let has = plan.dag().graph.node_weights().any(|n| {
         matches!(
             n,
-            PlanNode::Output {
+            PlanNode::Sink {
                 resolved: Some(_),
                 ..
             }
         )
     });
-    assert!(has, "Output resolved payload missing");
+    assert!(has, "Sink resolved payload missing");
 }
 
 #[test]

--- a/crates/clinker-exec/tests/source_row_identity_effects.rs
+++ b/crates/clinker-exec/tests/source_row_identity_effects.rs
@@ -113,7 +113,7 @@ nodes:
         audit: value > 0
         report: value > 0
       default: audit
-  - type: output
+  - type: sink
     name: audit
     input: fanout
     config:
@@ -121,7 +121,7 @@ nodes:
       type: csv
       path: audit.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: report
     input: fanout
     config:
@@ -180,7 +180,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [src_a, src_b]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -237,7 +237,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [src_a, src_b]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -297,7 +297,7 @@ nodes:
         audit: id != ""
         report: id != ""
       default: audit
-  - type: output
+  - type: sink
     name: audit
     input: fanout
     config:
@@ -305,7 +305,7 @@ nodes:
       type: csv
       path: audit.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: report
     input: fanout
     config:
@@ -358,7 +358,7 @@ fn deliveries_state_retains_row_and_terminal_consumer_identity() {
     let compact = |source: &str| source.split_whitespace().collect::<String>();
     let dispatch = compact(include_str!("../src/executor/dispatch.rs"));
     let streaming = compact(include_str!("../src/executor/streaming.rs"));
-    let output = compact(include_str!("../src/executor/output_dispatch.rs"));
+    let output = compact(include_str!("../src/executor/sink_dispatch.rs"));
     let correlation = compact(include_str!("../src/executor/correlation_dispatch.rs"));
 
     assert!(

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -200,7 +200,7 @@ pub fn column_lineage_external(
     build_column_lineage(
         compiled,
         &|node, key| match node {
-            PlanNode::Source { .. } | PlanNode::Output { .. } => {
+            PlanNode::Source { .. } | PlanNode::Sink { .. } => {
                 Ok(Some(identities.require(key)?.dataset_id().clone()))
             }
             _ => Ok(None),
@@ -768,7 +768,7 @@ fn walk_scope(
                 cols
             }
 
-            PlanNode::Output { .. } => {
+            PlanNode::Sink { .. } => {
                 let up = single_upstream(dag, idx);
                 let mut cols = ColumnTerminals::new();
                 for_each_output_col(node, dag, |col| {
@@ -812,7 +812,7 @@ fn walk_scope(
             }
         }
 
-        if let PlanNode::Output { .. } = node
+        if let PlanNode::Sink { .. } = node
             && let Some(ds) = (ctx.resolve_dataset)(node, &node_key)?
         {
             let identity_facets = ctx
@@ -1171,7 +1171,7 @@ fn visit_scope_dataset_nodes<'a>(
         let node = &graph[idx];
         let key = qualified_node(scope, node.name());
         match node {
-            PlanNode::Source { .. } | PlanNode::Output { .. } => visit(&key, node),
+            PlanNode::Source { .. } | PlanNode::Sink { .. } => visit(&key, node),
             PlanNode::Composition { body, .. } => {
                 let Some(b) = compiled.body_of(*body) else {
                     continue;

--- a/crates/clinker-lineage/src/dataset.rs
+++ b/crates/clinker-lineage/src/dataset.rs
@@ -1,7 +1,7 @@
 //! Plan-time mapping from Clinker plan nodes to OpenLineage dataset identities.
 //!
 //! The first piece of the builder that walks a compiled plan: a pure,
-//! deterministic function from each [`PlanNode::Source`] / [`PlanNode::Output`]
+//! deterministic function from each [`PlanNode::Source`] / [`PlanNode::Sink`]
 //! to the `{namespace, name}` pair that names one logical dataset. Like
 //! `--explain`, it reads no data and touches no filesystem — paths are resolved
 //! *lexically* against the workspace root, never via [`std::fs::canonicalize`],
@@ -117,7 +117,7 @@ impl From<DatasetId> for Dataset {
 
 /// The OpenLineage dataset identity of a plan node, or `None` for nodes that are
 /// not datasets (every variant but [`Source`](PlanNode::Source) and
-/// [`Output`](PlanNode::Output)).
+/// [`Sink`](PlanNode::Sink)).
 ///
 /// `base_dir` is the workspace root — the directory containing the pipeline
 /// YAML, the same `base_dir` `clinker_plan`'s discovery layer takes. A
@@ -130,7 +130,7 @@ pub fn dataset_identity(node: &PlanNode, base_dir: &Path) -> Option<DatasetId> {
             Some(payload) => source_dataset_identity(&payload.source, base_dir),
             None => DatasetId::fallback(name.as_str()),
         }),
-        PlanNode::Output { name, resolved, .. } => Some(match resolved {
+        PlanNode::Sink { name, resolved, .. } => Some(match resolved {
             Some(payload) => output_dataset_identity(&payload.output, base_dir),
             None => DatasetId::fallback(name.as_str()),
         }),
@@ -295,7 +295,7 @@ mod tests {
     use std::sync::Arc;
 
     use clinker_core_types::span::Span;
-    use clinker_plan::plan::execution::{PlanOutputPayload, PlanSourcePayload};
+    use clinker_plan::plan::execution::{PlanSinkPayload, PlanSourcePayload};
     use clinker_plan::plan::{EntityRef, PlanNodeId};
     use clinker_record::Schema;
     use serde_json::json;
@@ -322,8 +322,8 @@ mod tests {
         }
     }
 
-    fn output_node(name: &str, resolved: Option<PlanOutputPayload>) -> PlanNode {
-        PlanNode::Output {
+    fn sink_node(name: &str, resolved: Option<PlanSinkPayload>) -> PlanNode {
+        PlanNode::Sink {
             name: name.to_string(),
             id: PlanNodeId::new(0),
             span: Span::SYNTHETIC,
@@ -496,13 +496,13 @@ mod tests {
     }
 
     #[test]
-    fn output_node_delegates_to_output_identity() {
-        let payload = PlanOutputPayload {
+    fn sink_node_delegates_to_output_identity() {
+        let payload = PlanSinkPayload {
             output: output_config(json!({"name": "out", "path": "out.csv", "type": "csv"})),
             validated_path: None,
             fan_out_per_source_file: false,
         };
-        let node = output_node("out", Some(payload));
+        let node = sink_node("out", Some(payload));
         assert_eq!(
             dataset_identity(&node, base()),
             Some(DatasetId::file("/work/out.csv".to_string()))
@@ -519,8 +519,8 @@ mod tests {
     }
 
     #[test]
-    fn unresolved_output_node_falls_back_to_node_name() {
-        let node = output_node("sink", None);
+    fn unresolved_sink_node_falls_back_to_node_name() {
+        let node = sink_node("sink", None);
         assert_eq!(
             dataset_identity(&node, base()),
             Some(DatasetId::fallback("sink"))

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3806,7 +3806,7 @@ pub(crate) fn lower_node_to_plan_node(
     let name = node.name();
     use crate::plan::composition_body::CompositionBodyId;
     use crate::plan::execution::{
-        NodeExecutionReqs, ParallelismClass, PartitionLookupKind, PlanNode, PlanOutputPayload,
+        NodeExecutionReqs, ParallelismClass, PartitionLookupKind, PlanNode, PlanSinkPayload,
         PlanSourcePayload, PlanTransformPayload, derive_parallelism_class, extract_has_distinct,
         extract_write_set,
     };
@@ -3992,11 +3992,11 @@ pub(crate) fn lower_node_to_plan_node(
                 output_schema: schema_from_bound(),
             })
         }
-        PipelineNode::Sink { config, .. } => Some(PlanNode::Output {
+        PipelineNode::Sink { config, .. } => Some(PlanNode::Sink {
             name: name.to_string(),
             id,
             span,
-            resolved: Some(Box::new(PlanOutputPayload {
+            resolved: Some(Box::new(PlanSinkPayload {
                 output: config.output.clone(),
                 validated_path: None,
                 fan_out_per_source_file: false,

--- a/crates/clinker-plan/src/plan/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/deferred_region.rs
@@ -459,7 +459,7 @@ fn continuation_bfs(
             continue;
         }
         match &graph[node] {
-            PlanNode::Output { .. } => {
+            PlanNode::Sink { .. } => {
                 outputs.insert(node);
             }
             PlanNode::Aggregation { .. } => {
@@ -603,7 +603,7 @@ fn pass_a_forward_bfs(
             continue;
         }
         match &graph[node] {
-            PlanNode::Output { .. } => {
+            PlanNode::Sink { .. } => {
                 outputs.insert(node);
                 // Do not recurse past Output — region exit boundary.
             }
@@ -645,7 +645,7 @@ fn walk_body_into_region(
 ) {
     for idx in body.graph.node_indices() {
         match &body.graph[idx] {
-            PlanNode::Output { .. } => {
+            PlanNode::Sink { .. } => {
                 outputs.insert(idx);
             }
             PlanNode::Composition { body: nested, .. } => {
@@ -1064,7 +1064,7 @@ fn propagate_through_node_for_body(node: &PlanNode, set: &mut HashSet<String>) {
                 set.insert(sf.field.clone());
             }
         }
-        PlanNode::Source { .. } | PlanNode::Output { .. } => {
+        PlanNode::Source { .. } | PlanNode::Sink { .. } => {
             // Sources and Outputs are region boundaries; never visited
             // as upstream in the propagation walk.
         }
@@ -1292,7 +1292,7 @@ fn output_consumed_columns(
         })
         .unwrap_or_default();
 
-    if let PlanNode::Output {
+    if let PlanNode::Sink {
         resolved: Some(payload),
         ..
     } = &graph[out_idx]

--- a/crates/clinker-plan/src/plan/execution/consumer_registry.rs
+++ b/crates/clinker-plan/src/plan/execution/consumer_registry.rs
@@ -90,7 +90,7 @@ impl CompiledConsumerRegistry {
                     node: target.id(),
                     input_port: edge.weight().port.clone(),
                     slot_behavior,
-                    kind: if matches!(target, PlanNode::Output { .. }) {
+                    kind: if matches!(target, PlanNode::Sink { .. }) {
                         CompiledConsumerKind::PhysicalWriterBoundary
                     } else {
                         CompiledConsumerKind::Computational
@@ -152,7 +152,7 @@ mod tests {
             resolved: None,
             output_schema: clinker_record::SchemaBuilder::new().build(),
         });
-        let output = graph.add_node(PlanNode::Output {
+        let output = graph.add_node(PlanNode::Sink {
             name: "direct".to_string(),
             id: output_id,
             span: Span::SYNTHETIC,

--- a/crates/clinker-plan/src/plan/execution/enforcer.rs
+++ b/crates/clinker-plan/src/plan/execution/enforcer.rs
@@ -508,7 +508,7 @@ impl ExecutionPlanDag {
     /// Inject the terminal [`PlanNode::CorrelationCommit`] when any
     /// source declares a `correlation_key:`.
     ///
-    /// One commit node is created and every existing [`PlanNode::Output`]
+    /// One commit node is created and every existing [`PlanNode::Sink`]
     /// gains an outgoing edge to it. Output writes from the dispatcher
     /// arm route into per-group correlation buffers keyed by group; the
     /// commit arm walks those buffers at end-of-DAG.
@@ -554,7 +554,7 @@ impl ExecutionPlanDag {
         let output_indices: Vec<NodeIndex> = self
             .graph
             .node_indices()
-            .filter(|&idx| matches!(self.graph[idx], PlanNode::Output { .. }))
+            .filter(|&idx| matches!(self.graph[idx], PlanNode::Sink { .. }))
             .collect();
         if output_indices.is_empty() {
             return Ok(());
@@ -587,7 +587,7 @@ impl ExecutionPlanDag {
     /// Whether this DAG carries the correlation-key terminal commit
     /// node. Returns `true` iff [`Self::inject_correlation_commit`]
     /// has run on a pipeline with at least one source declaring a
-    /// `correlation_key:` AND at least one [`PlanNode::Output`] was
+    /// `correlation_key:` AND at least one [`PlanNode::Sink`] was
     /// present.
     pub fn required_sorted_input(&self) -> bool {
         self.graph

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -1523,7 +1523,7 @@ impl ExecutionPlanDag {
                 PlanNode::Source { .. }
                 | PlanNode::Transform { .. }
                 | PlanNode::Envelope { .. }
-                | PlanNode::Output { .. }
+                | PlanNode::Sink { .. }
                 | PlanNode::Sort { .. }
                 | PlanNode::Composition { .. }
                 | PlanNode::CorrelationCommit { .. } => {
@@ -1661,7 +1661,7 @@ impl ExecutionPlanDag {
                 PlanNode::Source { .. }
                 | PlanNode::Transform { .. }
                 | PlanNode::Envelope { .. }
-                | PlanNode::Output { .. }
+                | PlanNode::Sink { .. }
                 | PlanNode::Sort { .. }
                 | PlanNode::Composition { .. }
                 | PlanNode::CorrelationCommit { .. } => {

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -210,15 +210,15 @@ pub enum PlanNode {
         #[serde(skip)]
         output_schema: Arc<Schema>,
     },
-    Output {
+    Sink {
         name: String,
         /// Stable node identity; see the `Source` variant's `id`.
         id: PlanNodeId,
         #[serde(skip)]
         span: Span,
-        /// Full resolved Output payload.
+        /// Full resolved Sink payload.
         #[serde(skip)]
-        resolved: Option<Box<PlanOutputPayload>>,
+        resolved: Option<Box<PlanSinkPayload>>,
     },
     /// Per-correlation-group synthesis and trigger-row mutation.
     ///
@@ -439,8 +439,8 @@ pub enum PlanNode {
     /// Planner-synthesized terminal commit node for `correlation_key` pipelines.
     ///
     /// Inserted by [`ExecutionPlanDag::inject_correlation_commit`] downstream
-    /// of every [`PlanNode::Output`] when at least one source declares a
-    /// `correlation_key:`. The Output arm redirects projected records into
+    /// of every [`PlanNode::Sink`] when at least one source declares a
+    /// `correlation_key:`. The Sink arm redirects projected records into
     /// `ExecutorContext.correlation_buffers` instead of writing to the
     /// FormatWriter; this arm walks the buffer at end-of-DAG and, per
     /// correlation group, either flushes records to the appropriate writer
@@ -685,12 +685,12 @@ pub struct PlanTransformPayload {
     pub max_expansion: u64,
 }
 
-/// Fully-resolved Output payload.
+/// Fully-resolved Sink payload.
 #[derive(Debug, Clone)]
-pub struct PlanOutputPayload {
+pub struct PlanSinkPayload {
     pub output: SinkConfig,
     pub validated_path: Option<crate::security::ValidatedPath>,
-    /// Plan-time flag: this Output's path template uses a per-record
+    /// Plan-time flag: this Sink's path template uses a per-record
     /// token (`{source_file}` / `{source_path}`) AND its parent
     /// partitioning is `FilePartitioned`. The CLI pre-opens one writer
     /// per source file and the dispatcher routes each record to the
@@ -716,7 +716,7 @@ impl PlanNode {
             | PlanNode::Transform { id, .. }
             | PlanNode::Route { id, .. }
             | PlanNode::Merge { id, .. }
-            | PlanNode::Output { id, .. }
+            | PlanNode::Sink { id, .. }
             | PlanNode::Reshape { id, .. }
             | PlanNode::Cull { id, .. }
             | PlanNode::Envelope { id, .. }
@@ -735,7 +735,7 @@ impl PlanNode {
             | PlanNode::Transform { name, .. }
             | PlanNode::Route { name, .. }
             | PlanNode::Merge { name, .. }
-            | PlanNode::Output { name, .. }
+            | PlanNode::Sink { name, .. }
             | PlanNode::Reshape { name, .. }
             | PlanNode::Cull { name, .. }
             | PlanNode::Envelope { name, .. }
@@ -755,7 +755,7 @@ impl PlanNode {
             | PlanNode::Transform { span, .. }
             | PlanNode::Route { span, .. }
             | PlanNode::Merge { span, .. }
-            | PlanNode::Output { span, .. }
+            | PlanNode::Sink { span, .. }
             | PlanNode::Reshape { span, .. }
             | PlanNode::Cull { span, .. }
             | PlanNode::Envelope { span, .. }
@@ -813,7 +813,7 @@ impl PlanNode {
                 .collect(),
             PlanNode::Route { .. }
             | PlanNode::Sort { .. }
-            | PlanNode::Output { .. }
+            | PlanNode::Sink { .. }
             | PlanNode::CorrelationCommit { .. } => {
                 let idx = match dag.index_of_or_scan(self.id()) {
                     Some(i) => i,
@@ -840,7 +840,7 @@ impl PlanNode {
             | PlanNode::Envelope { output_schema, .. }
             | PlanNode::Merge { output_schema, .. } => Some(output_schema),
             PlanNode::Route { .. }
-            | PlanNode::Output { .. }
+            | PlanNode::Sink { .. }
             | PlanNode::Sort { .. }
             | PlanNode::CorrelationCommit { .. } => None,
         }
@@ -913,7 +913,7 @@ impl PlanNode {
             PlanNode::Transform { .. } => "transform",
             PlanNode::Route { .. } => "route",
             PlanNode::Merge { .. } => "merge",
-            PlanNode::Output { .. } => "output",
+            PlanNode::Sink { .. } => "sink",
             PlanNode::Sort { .. } => "sort",
             PlanNode::Aggregation { .. } => "aggregation",
             PlanNode::Composition { .. } => "composition",
@@ -981,7 +981,7 @@ impl PlanNode {
                 format!("[route:{mode_str}] {name}")
             }
             PlanNode::Merge { name, .. } => format!("[merge] {name}"),
-            PlanNode::Output { name, .. } => format!("[output] {name}"),
+            PlanNode::Sink { name, .. } => format!("[sink] {name}"),
             PlanNode::Reshape { name, config, .. } => {
                 format!(
                     "[reshape] {name} partition_by=[{}] rules={}",
@@ -1257,7 +1257,7 @@ pub(super) fn arbitration_class(node: &PlanNode) -> ArbitrationClass {
         | PlanNode::Route { .. }
         | PlanNode::Merge { .. }
         | PlanNode::Envelope { .. }
-        | PlanNode::Output { .. }
+        | PlanNode::Sink { .. }
         | PlanNode::Composition { .. }
         | PlanNode::CorrelationCommit { .. } => ArbitrationClass {
             spill_priority: None,
@@ -1337,7 +1337,7 @@ pub(super) fn writes_spill_files(node: &PlanNode) -> bool {
         | PlanNode::Route { .. }
         | PlanNode::Merge { .. }
         | PlanNode::Envelope { .. }
-        | PlanNode::Output { .. }
+        | PlanNode::Sink { .. }
         | PlanNode::Composition { .. }
         | PlanNode::CorrelationCommit { .. } => false,
     }

--- a/crates/clinker-plan/src/plan/execution/scheduling.rs
+++ b/crates/clinker-plan/src/plan/execution/scheduling.rs
@@ -468,7 +468,7 @@ impl ExecutionPlanDag {
 
         let mut terminals = Vec::new();
         for idx in self.graph.node_indices() {
-            let PlanNode::Output {
+            let PlanNode::Sink {
                 id,
                 name,
                 resolved: Some(payload),
@@ -517,7 +517,7 @@ impl ExecutionPlanDag {
         let envelope_active = self.graph.node_weights().any(|node| {
             matches!(
                 node,
-                PlanNode::Output {
+                PlanNode::Sink {
                     resolved: Some(payload),
                     ..
                 } if payload.output.reconstruct_envelope
@@ -570,7 +570,7 @@ impl ExecutionPlanDag {
                         detail: "compiled writer consumer has no live DAG node".to_string(),
                     }
                 })?;
-                let PlanNode::Output {
+                let PlanNode::Sink {
                     id,
                     name,
                     resolved: Some(payload),
@@ -898,7 +898,7 @@ impl ExecutionPlanDag {
         let output_indices: Vec<NodeIndex> = self
             .graph
             .node_indices()
-            .filter(|i| matches!(self.graph[*i], PlanNode::Output { .. }))
+            .filter(|i| matches!(self.graph[*i], PlanNode::Sink { .. }))
             .collect();
         let parent_partitioning: HashMap<NodeIndex, PartitioningKind> = output_indices
             .iter()
@@ -921,7 +921,7 @@ impl ExecutionPlanDag {
             if !is_partitioned {
                 continue;
             }
-            let PlanNode::Output {
+            let PlanNode::Sink {
                 resolved: Some(payload),
                 ..
             } = &mut self.graph[idx]
@@ -1403,7 +1403,7 @@ fn preserves_stable_arrival(node: &PlanNode) -> bool {
         node,
         PlanNode::Source { .. }
             | PlanNode::Route { .. }
-            | PlanNode::Output { .. }
+            | PlanNode::Sink { .. }
             | PlanNode::Composition { .. }
             | PlanNode::Envelope { .. }
             | PlanNode::CorrelationCommit { .. }
@@ -1800,7 +1800,7 @@ fn compute_one(
             }
         }
 
-        PlanNode::Output { name, .. } => {
+        PlanNode::Sink { name, .. } => {
             // Terminal — properties still computed for debugging. Inherit
             // parent, rewrite provenance to point at this node when ordering
             // is non-None so explain chains through. CK set is preserved at

--- a/crates/clinker-plan/src/plan/execution/streaming_class.rs
+++ b/crates/clinker-plan/src/plan/execution/streaming_class.rs
@@ -279,7 +279,7 @@ pub fn classify_stream_nodes(
         .node_indices()
         .map(|idx| {
             let class = match &plan.graph[idx] {
-                PlanNode::Output { .. } => StreamClass::Streaming,
+                PlanNode::Sink { .. } => StreamClass::Streaming,
                 PlanNode::Source { name, .. } if fused_sources.contains(name.as_str()) => {
                     StreamClass::Streaming
                 }
@@ -497,7 +497,7 @@ pub fn certify_streaming_edge(
     // `driving_upstream` index instead — the single-incoming guard would
     // reject it.
     let producer_idx: petgraph::graph::NodeIndex = match &plan.graph[consumer_idx] {
-        PlanNode::Output { resolved, .. } => {
+        PlanNode::Sink { resolved, .. } => {
             let payload = resolved.as_deref()?;
             // Authored output sorting materializes through the bounded shared
             // SortBuffer before writing. Per-source-file fan-out and split
@@ -1129,7 +1129,7 @@ nodes:
                 combine_strategy(dag)
             );
             let combine = find_node(dag, "combine", |n| matches!(n, PlanNode::Combine { .. }));
-            let output = find_node(dag, "output", |n| matches!(n, PlanNode::Output { .. }));
+            let output = find_node(dag, "output", |n| matches!(n, PlanNode::Sink { .. }));
             // The combine→Output edge certifies as a streaming output edge,
             // resolving the block-band combine as the producer.
             assert_eq!(
@@ -1159,9 +1159,7 @@ nodes:
             let combine = find_node(dag, "combine", |node| {
                 matches!(node, PlanNode::Combine { .. })
             });
-            let output = find_node(dag, "output", |node| {
-                matches!(node, PlanNode::Output { .. })
-            });
+            let output = find_node(dag, "output", |node| matches!(node, PlanNode::Sink { .. }));
             assert_eq!(
                 certify_streaming_edge(dag, output, fused, init),
                 None,
@@ -1188,7 +1186,7 @@ nodes:
             for output in dag
                 .graph
                 .node_indices()
-                .filter(|idx| matches!(&dag.graph[*idx], PlanNode::Output { .. }))
+                .filter(|idx| matches!(&dag.graph[*idx], PlanNode::Sink { .. }))
             {
                 assert_eq!(
                     certify_streaming_edge(dag, output, fused, init),
@@ -1223,7 +1221,7 @@ nodes:
                 combine_strategy(dag)
             );
             let combine = find_node(dag, "combine", |n| matches!(n, PlanNode::Combine { .. }));
-            let output = find_node(dag, "output", |n| matches!(n, PlanNode::Output { .. }));
+            let output = find_node(dag, "output", |n| matches!(n, PlanNode::Sink { .. }));
             // The combine→Output edge certifies, resolving the equi+range
             // block-band combine as the streaming producer, and the runtime
             // classification agrees.

--- a/crates/clinker-plan/src/plan/extraction.rs
+++ b/crates/clinker-plan/src/plan/extraction.rs
@@ -439,7 +439,7 @@ mod tests {
     }
 
     fn output(name: &str, id: usize) -> PlanNode {
-        PlanNode::Output {
+        PlanNode::Sink {
             name: name.to_owned(),
             id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,

--- a/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
@@ -651,12 +651,12 @@ nodes:
         .node_indices()
         .find(|&i| bound.graph[i].name() == "body_sink")
         .expect("body output `body_sink` present in the bound body");
-    let PlanNode::Output { resolved, .. } = &bound.graph[idx] else {
-        panic!("node `body_sink` is not an Output");
+    let PlanNode::Sink { resolved, .. } = &bound.graph[idx] else {
+        panic!("node `body_sink` is not a Sink");
     };
     let payload = resolved
         .as_ref()
-        .expect("the full plan carries the body Output's resolved payload");
+        .expect("the full plan carries the body Sink's resolved payload");
     let columns = payload
         .output
         .schema

--- a/crates/clinker-plan/src/plan/tests/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/tests/deferred_region.rs
@@ -160,7 +160,7 @@ nodes:
       cxl: |
         emit dept_name = dept
         emit grand_total = total
-  - type: output
+  - type: sink
     name: out
     input: rename
     config:
@@ -251,7 +251,7 @@ nodes:
       cxl: |
         emit dept_keep = dept
         emit running_total = total
-  - type: output
+  - type: sink
     name: out
     input: project
     config:
@@ -353,7 +353,7 @@ nodes:
       cxl: |
         emit region = region
         emit grand = grand
-  - type: output
+  - type: sink
     name: out
     input: t2
     config:
@@ -463,7 +463,7 @@ nodes:
       cxl: |
         emit customer_id = customer_id
         emit name = name
-  - type: output
+  - type: sink
     name: out
     input: tail
     config:
@@ -584,7 +584,7 @@ nodes:
       cxl: |
         emit dept = dept
         emit total = total
-  - type: output
+  - type: sink
     name: out
     input: parent_t
     config:
@@ -748,7 +748,7 @@ nodes:
     use: ../compositions/outer_wrap.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: outer
     config:
@@ -899,7 +899,7 @@ nodes:
       cxl: |
         emit dept = dept
         emit total = total
-  - type: output
+  - type: sink
     name: out
     input: parent_t
     config:
@@ -1066,7 +1066,7 @@ nodes:
       cxl: |
         emit dept = dept
         emit total = total
-  - type: output
+  - type: sink
     name: out
     input: parent_t
     config:
@@ -1121,7 +1121,7 @@ nodes:
         body_cont.members
     );
     // The outer body has no Outputs of its own (body Outputs surface
-    // through `output_port_to_node_idx`, not as PlanNode::Output), so
+    // through `output_port_to_node_idx`, not as PlanNode::Sink), so
     // the continuation's `outputs` set is empty.
     assert!(
         body_cont.outputs.is_empty(),
@@ -1168,7 +1168,7 @@ nodes:
         big: total > 1000
         medium: total > 100
       default: small
-  - type: output
+  - type: sink
     name: out_big
     input: classify.big
     config:
@@ -1176,7 +1176,7 @@ nodes:
       type: csv
       path: big.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_medium
     input: classify.medium
     config:
@@ -1184,7 +1184,7 @@ nodes:
       type: csv
       path: medium.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_small
     input: classify.small
     config:
@@ -1293,7 +1293,7 @@ nodes:
       cxl: |
         emit dept = dept
         emit total = total
-  - type: output
+  - type: sink
     name: out
     input: parent_t
     config:
@@ -1404,7 +1404,7 @@ nodes:
       cxl: |
         emit dept = dept
         emit total = total
-  - type: output
+  - type: sink
     name: out
     input: parent_t
     config:
@@ -1543,7 +1543,7 @@ nodes:
       cxl: |
         emit dept = dept
         emit total = total
-  - type: output
+  - type: sink
     name: out
     input: parent_t
     config:
@@ -1672,7 +1672,7 @@ nodes:
     config:
       cxl: |
         emit dept = dept
-  - type: output
+  - type: sink
     name: out_a
     input: parent_a
     config:
@@ -1692,7 +1692,7 @@ nodes:
     config:
       cxl: |
         emit total = total
-  - type: output
+  - type: sink
     name: out_b
     input: parent_b
     config:
@@ -1910,7 +1910,7 @@ nodes:
       cxl: |
         emit dept = dept
         emit total = total
-  - type: output
+  - type: sink
     name: out
     input: parent_t
     config:

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -4084,9 +4084,7 @@ fn output_is_fan_out(
         .node_indices()
         .find(|i| dag.graph[*i].name() == output_name)
         .and_then(|i| match &dag.graph[i] {
-            PlanNode::Output { resolved, .. } => {
-                resolved.as_ref().map(|r| r.fan_out_per_source_file)
-            }
+            PlanNode::Sink { resolved, .. } => resolved.as_ref().map(|r| r.fan_out_per_source_file),
             _ => None,
         })
         .unwrap_or(false)


### PR DESCRIPTION
## Summary

- rename the compiled terminal node from `PlanNode::Output` to `PlanNode::Sink` across every constructor and exhaustive match owner
- move `executor/output_dispatch.rs` to `executor/sink_dispatch.rs` and rename its terminal-specific dispatch API
- preserve output ports, output paths and artifacts, writer results, and existing execution behavior
- keep lineage traversal explicit under the renamed variant

This is stacked on #1089. Repository-wide authored fixture migration and the observability backfill will be submitted as dependent PRs; this intermediate branch should not merge on its own.

## Validation

- `cargo check --workspace --locked --offline`
- node taxonomy — 33 passed
- fan-out writers — 2 passed
- deferred regions — 14 passed
- source-row identity effects — 5 passed
- feature-enabled invariant matrix — 4 passed
- Sink dispatcher unit tests — 9 passed
- lineage dataset tests — 23 passed
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

The compile-atomic rename preserves row values, routing, execution work, and retained state. Lineage remains explicit and behaviorally unchanged. No new telemetry lifecycle or input-growing state is introduced in this slice; the dependent observability PR completes the fixed-cardinality Sink signal vocabulary before the stack lands.
