### PR TITLE
Unify numeric observations across format readers

### DIFF
--- a/crates/clinker-exec/src/pipeline/schema_coerce.rs
+++ b/crates/clinker-exec/src/pipeline/schema_coerce.rs
@@ -52,7 +52,10 @@ use clinker_record::{FieldMetadata, Record, Schema, SchemaBuilder, Value, coerci
 use cxl::typecheck::Type;
 use indexmap::IndexMap;
 
-use clinker_format::{Column, RECORD_TYPE_COLUMN, RecordType};
+use clinker_format::{
+    Column, NumericObservation, NumericObserver, RECORD_TYPE_COLUMN, RecordType,
+    observe_schema_numeric,
+};
 use clinker_plan::config::pipeline_node::{OnUnmapped, WIDENED_SIDECAR_COLUMN};
 
 /// Exhaustive admission policy for one output-schema slot.
@@ -231,6 +234,9 @@ pub struct CoercingReader {
     policy: OnUnmapped,
     /// Source identifier for diagnostics.
     source_name: Box<str>,
+    /// Optional authoring-only sink for the canonical string-to-schema numeric
+    /// boundary. It is invoked synchronously per scalar and retains no records.
+    numeric_observer: Option<NumericObserver>,
 }
 
 impl CoercingReader {
@@ -251,7 +257,36 @@ impl CoercingReader {
         source_name: &str,
         pretyped: bool,
     ) -> Result<Self, FormatError> {
-        Self::new_inner(inner, schema_decl, policy, source_name, pretyped, None)
+        Self::new_inner(
+            inner,
+            schema_decl,
+            policy,
+            source_name,
+            pretyped,
+            None,
+            None,
+        )
+    }
+
+    /// Build a coercing reader that streams numeric parser observations to an
+    /// authoring-only observer.
+    pub fn new_observing(
+        inner: Box<dyn FormatReader>,
+        schema_decl: &[Column],
+        policy: OnUnmapped,
+        source_name: &str,
+        pretyped: bool,
+        observer: NumericObserver,
+    ) -> Result<Self, FormatError> {
+        Self::new_inner(
+            inner,
+            schema_decl,
+            policy,
+            source_name,
+            pretyped,
+            None,
+            Some(observer),
+        )
     }
 
     /// Build a coercing reader for a discriminator-driven positional source.
@@ -271,6 +306,7 @@ impl CoercingReader {
             source_name,
             true,
             Some(MultiRecordProofs::new(record_types)?),
+            None,
         )
     }
 
@@ -281,6 +317,7 @@ impl CoercingReader {
         source_name: &str,
         pretyped: bool,
         multi_record_proofs: Option<MultiRecordProofs>,
+        numeric_observer: Option<NumericObserver>,
     ) -> Result<Self, FormatError> {
         // Trigger schema discovery on the inner reader so the first
         // record isn't gated behind an on-demand schema call.
@@ -405,6 +442,7 @@ impl CoercingReader {
             widened_idx,
             policy,
             source_name: source_name.into(),
+            numeric_observer,
         })
     }
 
@@ -517,6 +555,15 @@ impl CoercingReader {
                         &self.declared_types[i],
                     ),
                 };
+            let rules = DeclaredValueRules {
+                format,
+                precision,
+                scale,
+                nullable,
+                empty_is_null,
+                field: cols[i].as_ref(),
+                numeric_observer: self.numeric_observer.as_ref(),
+            };
             let conversion = if self.multiple[i] {
                 // A `multiple:` column's declared type describes each ELEMENT,
                 // so the same scalar admission rule applies element-wise. A
@@ -527,16 +574,8 @@ impl CoercingReader {
                         .iter()
                         .enumerate()
                         .map(|(index, item)| {
-                            validate_declared_value(
-                                item,
-                                target,
-                                format,
-                                precision,
-                                scale,
-                                nullable,
-                                empty_is_null,
-                            )
-                            .map_err(|message| format!("element {}: {message}", index + 1))
+                            validate_declared_value(item, target, &rules)
+                                .map_err(|message| format!("element {}: {message}", index + 1))
                         })
                         .collect::<Result<Vec<_>, _>>()
                         .map(Value::Array),
@@ -551,36 +590,12 @@ impl CoercingReader {
                     // cannot put a scalar in a slot the planner typed as an
                     // array and have every downstream array expression read it
                     // as the wrong shape.
-                    Value::Null => validate_declared_value(
-                        &raw,
-                        target,
-                        format,
-                        precision,
-                        scale,
-                        nullable,
-                        empty_is_null,
-                    ),
-                    scalar => validate_declared_value(
-                        scalar,
-                        target,
-                        format,
-                        precision,
-                        scale,
-                        nullable,
-                        empty_is_null,
-                    )
-                    .map(|value| Value::Array(vec![value])),
+                    Value::Null => validate_declared_value(&raw, target, &rules),
+                    scalar => validate_declared_value(scalar, target, &rules)
+                        .map(|value| Value::Array(vec![value])),
                 }
             } else {
-                validate_declared_value(
-                    &raw,
-                    target,
-                    format,
-                    precision,
-                    scale,
-                    nullable,
-                    empty_is_null,
-                )
+                validate_declared_value(&raw, target, &rules)
             };
             let coerced = match conversion {
                 Ok(value) => value,
@@ -691,6 +706,16 @@ fn declared_type_target(ty: &Type, pretyped: bool) -> DeclaredTypeTarget {
     }
 }
 
+struct DeclaredValueRules<'a> {
+    format: Option<&'a str>,
+    precision: Option<u8>,
+    scale: Option<u8>,
+    nullable: bool,
+    empty_is_null: bool,
+    field: &'a str,
+    numeric_observer: Option<&'a NumericObserver>,
+}
+
 /// Admit a decoded scalar according to its explicit declared-type target.
 ///
 /// This function is shared by ordinary scalar columns and every element of a
@@ -699,14 +724,20 @@ fn declared_type_target(ty: &Type, pretyped: bool) -> DeclaredTypeTarget {
 fn validate_declared_value(
     value: &Value,
     target: &DeclaredTypeTarget,
-    format: Option<&str>,
-    precision: Option<u8>,
-    scale: Option<u8>,
-    nullable: bool,
-    empty_is_null: bool,
+    rules: &DeclaredValueRules<'_>,
 ) -> Result<Value, String> {
-    if empty_is_null && matches!(value, Value::String(text) if text.is_empty()) {
+    if rules.empty_is_null && matches!(value, Value::String(text) if text.is_empty()) {
+        if matches!(target, DeclaredTypeTarget::Coerce(Type::Numeric))
+            && let Some(observer) = rules.numeric_observer
+        {
+            observer.observe(rules.field, observe_schema_numeric(&Value::Null));
+        }
         return Ok(Value::Null);
+    }
+    if matches!(target, DeclaredTypeTarget::Coerce(Type::Numeric))
+        && let Some(observer) = rules.numeric_observer
+    {
+        observer.observe(rules.field, observe_schema_numeric(value));
     }
 
     if matches!(value, Value::Null) {
@@ -717,7 +748,7 @@ fn validate_declared_value(
             }
             | DeclaredTypeTarget::AcceptAny
             | DeclaredTypeTarget::EngineManaged => Ok(Value::Null),
-            _ if nullable => Ok(Value::Null),
+            _ if rules.nullable => Ok(Value::Null),
             DeclaredTypeTarget::Coerce(declared)
             | DeclaredTypeTarget::ValidateExact(declared)
             | DeclaredTypeTarget::ReaderProven { declared, .. } => {
@@ -728,7 +759,7 @@ fn validate_declared_value(
 
     match target {
         DeclaredTypeTarget::Coerce(declared) => {
-            coerce_value(value, declared, format, precision, scale)
+            coerce_value(value, declared, rules.format, rules.precision, rules.scale)
         }
         DeclaredTypeTarget::ValidateExact(declared) => {
             if native_value_matches(value, declared) {
@@ -741,7 +772,7 @@ fn validate_declared_value(
             }
         }
         DeclaredTypeTarget::ReaderProven { declared, .. } => {
-            validate_reader_proof(value, declared, precision, scale)
+            validate_reader_proof(value, declared, rules.precision, rules.scale)
         }
         DeclaredTypeTarget::AcceptAny | DeclaredTypeTarget::EngineManaged => Ok(value.clone()),
     }
@@ -831,6 +862,59 @@ fn native_value_name(value: &Value) -> &'static str {
     }
 }
 
+/// Runtime numeric-union coercion paired with the parser-owned observation
+/// used by schema guessing.
+#[derive(Debug)]
+#[must_use]
+pub struct ObservedSchemaNumeric {
+    result: Result<Value, String>,
+    observation: NumericObservation,
+}
+
+impl ObservedSchemaNumeric {
+    pub fn result(&self) -> Result<&Value, &str> {
+        self.result.as_ref().map_err(String::as_str)
+    }
+
+    pub fn observation(&self) -> &NumericObservation {
+        &self.observation
+    }
+
+    pub fn into_result(self) -> Result<Value, String> {
+        self.result
+    }
+}
+
+/// Coerce one decoded value through the runtime `numeric` boundary and return
+/// the exact observation from that same parse.
+pub fn coerce_numeric_with_observation(value: &Value) -> ObservedSchemaNumeric {
+    let observation = observe_schema_numeric(value);
+    let result = match value {
+        Value::Null => Ok(Value::Null),
+        Value::Integer(_) => Ok(value.clone()),
+        Value::Float(number) if number.is_finite() => Ok(value.clone()),
+        Value::Float(_) => Err("non-finite float is outside the declared type".into()),
+        Value::Bool(value) => Ok(Value::Integer(i64::from(*value))),
+        Value::String(_) => match observation.parser_outcome() {
+            clinker_format::NumericParserOutcome::Integer(number) => Ok(Value::Integer(*number)),
+            clinker_format::NumericParserOutcome::Float(number) => Ok(Value::Float(*number)),
+            clinker_format::NumericParserOutcome::Rejected(
+                clinker_format::NumericIssue::NonFinite,
+            ) => Err("non-finite float is outside the declared type".into()),
+            clinker_format::NumericParserOutcome::NoValue
+            | clinker_format::NumericParserOutcome::NonNumeric
+            | clinker_format::NumericParserOutcome::Rejected(_) => {
+                Err("value cannot be parsed as Float".into())
+            }
+        },
+        other => Err(format!("cannot coerce {} to Float", other.type_name())),
+    };
+    ObservedSchemaNumeric {
+        result,
+        observation,
+    }
+}
+
 /// Coerce a value transactionally to its declared type.
 ///
 /// `format` is the column's `format:` strftime string, honored for `date` /
@@ -887,26 +971,7 @@ fn coerce_value(
         Type::Bool => coercion::coerce_to_bool(value),
         Type::Date => coercion::coerce_to_date(value, &chain),
         Type::DateTime => coercion::coerce_to_datetime(value, &chain),
-        Type::Numeric => {
-            let converted = match value {
-                Value::Integer(_) => return Ok(value.clone()),
-                Value::Float(number) if number.is_finite() => return Ok(value.clone()),
-                Value::Float(_) => {
-                    return Err("non-finite float is outside the declared type".into());
-                }
-                // Textual numeric input prefers an exact integer parse, then a
-                // finite float. Native floats never take the integer branch
-                // above, so a fractional value cannot be truncated merely
-                // because the union also admits integers.
-                _ => coercion::coerce_to_int(value)
-                    .or_else(|_| coercion::coerce_to_float(value))
-                    .map_err(coercion_failure_reason)?,
-            };
-            if matches!(converted, Value::Float(number) if !number.is_finite()) {
-                return Err("non-finite float is outside the declared type".into());
-            }
-            return Ok(converted);
-        }
+        Type::Numeric => return coerce_numeric_with_observation(value).into_result(),
         _ => return Err(format!("unsupported declared coercion target {target}")),
     };
     converted.map_err(coercion_failure_reason)

--- a/crates/clinker-exec/tests/numeric_guess_parity.rs
+++ b/crates/clinker-exec/tests/numeric_guess_parity.rs
@@ -1,0 +1,575 @@
+use clinker_exec::pipeline::schema_coerce::{CoercingReader, coerce_numeric_with_observation};
+use clinker_format::edifact::{EdifactReader, EdifactReaderConfig};
+use clinker_format::fixed_width::field::{
+    coerce_scalar_with_constraints, coerce_scalar_with_constraints_observed,
+};
+use clinker_format::hl7::{Hl7Reader, Hl7ReaderConfig};
+use clinker_format::json::reader::{JsonMode, JsonReader, JsonReaderConfig};
+use clinker_format::multi_record::{CsvDialect, MultiRecordReader, MultiRecordSpec};
+use clinker_format::numeric_observation::{
+    NumericBoundary, NumericIssue, NumericObservation, NumericObserver, NumericParserOutcome,
+    NumericVote, observe_json_number, observe_json_value, observe_positional_numeric,
+    observe_schema_numeric, observe_xml_scalar,
+};
+use clinker_format::schema::{Column, Discriminator, RecordType};
+use clinker_format::swift::{SwiftReader, SwiftReaderConfig};
+use clinker_format::traits::FormatReader;
+use clinker_format::x12::{X12Reader, X12ReaderConfig};
+use clinker_format::xml::reader::{XmlReader, XmlReaderConfig};
+use clinker_plan::config::pipeline_node::OnUnmapped;
+use clinker_record::Value;
+use clinker_record::schema_def::LineSeparator;
+use cxl::typecheck::Type;
+use std::io::Cursor;
+use std::sync::{Arc, Mutex};
+
+type ObservedEvent = (String, NumericObservation);
+type ObservationLog = Arc<Mutex<Vec<ObservedEvent>>>;
+
+fn json_number(lexeme: &str) -> serde_json::Number {
+    serde_json::from_str::<serde_json::Value>(lexeme)
+        .expect("test lexeme is valid JSON")
+        .as_number()
+        .expect("test value is a JSON number")
+        .clone()
+}
+
+#[test]
+fn json_exact_numbers_preserve_the_parser_result_and_guess_vote() {
+    let cases = [
+        ("-9223372036854775808", NumericVote::Int),
+        ("9223372036854775807", NumericVote::Int),
+        ("1e3", NumericVote::Float),
+        ("0.1", NumericVote::Float),
+        ("5e-324", NumericVote::Float),
+        ("1.7976931348623157e308", NumericVote::Float),
+    ];
+
+    for (lexeme, expected_vote) in cases {
+        let number = json_number(lexeme);
+        let observation = observe_json_number(&number);
+        assert_eq!(observation.boundary(), NumericBoundary::Json);
+        // serde_json's arbitrary-precision representation preserves every
+        // significant digit but canonicalizes exponent spelling (for example
+        // `1e3` to `1e+3`). The observer exposes that exact parser-owned form.
+        assert_eq!(
+            observation.lexeme().complete(),
+            Some(number.to_string().as_str())
+        );
+        assert_eq!(observation.vote(), expected_vote, "lexeme {lexeme}");
+    }
+}
+
+#[test]
+fn json_lossy_or_out_of_range_numbers_remain_unresolved() {
+    let cases = [
+        ("9223372036854775808", NumericIssue::UnsafeIntegerWidening),
+        ("-9223372036854775809", NumericIssue::UnsafeIntegerWidening),
+        ("1e999", NumericIssue::NonFinite),
+        ("1e-999", NumericIssue::UnderflowToZero),
+        ("0.10000000000000001", NumericIssue::PrecisionLoss),
+    ];
+
+    for (lexeme, expected_issue) in cases {
+        let observation = observe_json_number(&json_number(lexeme));
+        assert_eq!(
+            observation.vote(),
+            NumericVote::Unresolved(expected_issue),
+            "lexeme {lexeme}; parser outcome {:?}",
+            observation.parser_outcome()
+        );
+    }
+}
+
+#[test]
+fn json_signed_zero_and_float_compatibility_are_explicit() {
+    // serde_json's parser-owned arbitrary-precision representation
+    // canonicalizes integer `-0` to `0`; guess follows that real boundary.
+    let json_zero = observe_json_number(&json_number("-0"));
+    assert_eq!(json_zero.lexeme().complete(), Some("0"));
+    assert_eq!(json_zero.vote(), NumericVote::Int);
+    // Text formats retain the spelling and therefore expose the
+    // representation-changing conversion.
+    assert_eq!(
+        observe_positional_numeric("-0").vote(),
+        NumericVote::Unresolved(NumericIssue::RepresentationChanged)
+    );
+
+    let exact = observe_json_number(&json_number("9007199254740992"));
+    assert_eq!(exact.vote(), NumericVote::Int);
+    assert!(matches!(
+        exact.float_acceptance(),
+        clinker_format::NumericAcceptance::Accepted(_)
+    ));
+
+    let unsafe_widening = observe_json_number(&json_number("9007199254740993"));
+    assert_eq!(unsafe_widening.vote(), NumericVote::Int);
+    assert_eq!(
+        unsafe_widening.float_acceptance(),
+        &clinker_format::NumericAcceptance::Rejected(NumericIssue::UnsafeIntegerWidening)
+    );
+}
+
+#[test]
+fn xml_inference_observation_matches_the_real_inference_order() {
+    let integer = observe_xml_scalar("42");
+    assert_eq!(integer.boundary(), NumericBoundary::Xml);
+    assert_eq!(integer.parser_outcome(), &NumericParserOutcome::Integer(42));
+    assert_eq!(integer.vote(), NumericVote::Int);
+
+    let float = observe_xml_scalar("4.2e1");
+    assert_eq!(float.parser_outcome(), &NumericParserOutcome::Float(42.0));
+    assert_eq!(float.vote(), NumericVote::Float);
+
+    assert_eq!(
+        observe_xml_scalar("").parser_outcome(),
+        &NumericParserOutcome::NoValue
+    );
+    assert_eq!(
+        observe_xml_scalar("42x").parser_outcome(),
+        &NumericParserOutcome::NonNumeric
+    );
+
+    let non_finite = observe_xml_scalar("1e999");
+    assert!(matches!(
+        non_finite.parser_outcome(),
+        NumericParserOutcome::Float(value) if value.is_infinite()
+    ));
+    assert_eq!(
+        non_finite.vote(),
+        NumericVote::Unresolved(NumericIssue::NonFinite)
+    );
+}
+
+#[test]
+fn null_missing_and_numeric_default_states_stay_distinct() {
+    let null = observe_json_value(&serde_json::Value::Null).expect("null observation");
+    assert_eq!(null.vote(), NumericVote::NoValue);
+    assert_eq!(null.parser_outcome(), &NumericParserOutcome::NoValue);
+
+    // A missing field produces no scalar and therefore no parser observation;
+    // the caller applies required/default policy before asking a default to
+    // vote through the schema boundary.
+    let missing = serde_json::json!({});
+    assert!(missing.get("n").and_then(observe_json_value).is_none());
+
+    let default = observe_schema_numeric(&Value::String("7".into()));
+    assert_eq!(default.boundary(), NumericBoundary::SchemaCoerce);
+    assert_eq!(default.vote(), NumericVote::Int);
+}
+
+#[test]
+fn positional_observation_uses_int_then_finite_float_order() {
+    let integer = observe_positional_numeric("42");
+    assert_eq!(integer.boundary(), NumericBoundary::Positional);
+    assert_eq!(integer.vote(), NumericVote::Int);
+
+    let float = observe_positional_numeric("42.5");
+    assert_eq!(float.vote(), NumericVote::Float);
+
+    let non_finite = observe_positional_numeric("NaN");
+    assert_eq!(
+        non_finite.vote(),
+        NumericVote::Unresolved(NumericIssue::NonFinite)
+    );
+}
+
+fn observation_collector() -> (NumericObserver, ObservationLog) {
+    let observations = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&observations);
+    let observer = NumericObserver::new(move |field, observation| {
+        sink.lock()
+            .expect("observation collector lock")
+            .push((field.to_string(), observation));
+    });
+    (observer, observations)
+}
+
+fn assert_record_matches_parser(value: &Value, observation: &NumericObservation) {
+    match observation.parsed_value() {
+        Some(parsed) => assert_eq!(value, &parsed),
+        None => assert_eq!(
+            value,
+            &Value::String(
+                observation
+                    .lexeme()
+                    .complete()
+                    .expect("test lexeme fits evidence cap")
+                    .into()
+            )
+        ),
+    }
+}
+
+#[test]
+fn json_array_and_ndjson_stream_the_same_preconversion_observation() {
+    for (mode, input) in [
+        (JsonMode::Array, "[{\"n\":0.10000000000000001}]"),
+        (JsonMode::Ndjson, "{\"n\":0.10000000000000001}\n"),
+    ] {
+        let (observer, observations) = observation_collector();
+        let mut reader = JsonReader::from_reader_observing(
+            input.as_bytes(),
+            JsonReaderConfig {
+                format: Some(mode),
+                ..Default::default()
+            },
+            observer,
+        )
+        .expect("JSON reader builds");
+        reader.schema().expect("JSON schema");
+        let record = reader
+            .next_record()
+            .expect("JSON record parses")
+            .expect("one JSON record");
+        let observations = observations.lock().expect("observation collector lock");
+        let [(field, observation)] = observations.as_slice() else {
+            panic!("expected one numeric observation, got {observations:?}");
+        };
+        assert_eq!(field, "n");
+        assert_eq!(observation.boundary(), NumericBoundary::Json);
+        assert_eq!(
+            observation.vote(),
+            NumericVote::Unresolved(NumericIssue::PrecisionLoss)
+        );
+        assert_record_matches_parser(record.get("n").expect("n field"), observation);
+    }
+}
+
+#[test]
+fn json_explicit_null_streams_no_value_while_missing_streams_nothing() {
+    let (observer, observations) = observation_collector();
+    let mut reader = JsonReader::from_reader_observing(
+        b"[{\"n\":null},{}]".as_slice(),
+        JsonReaderConfig {
+            format: Some(JsonMode::Array),
+            ..Default::default()
+        },
+        observer,
+    )
+    .expect("JSON reader builds");
+    reader.schema().expect("JSON schema");
+    assert!(reader.next_record().expect("first record").is_some());
+    assert!(reader.next_record().expect("second record").is_some());
+    assert!(reader.next_record().expect("end of JSON").is_none());
+
+    let observations = observations.lock().expect("observation collector lock");
+    let [(field, observation)] = observations.as_slice() else {
+        panic!("expected only explicit null evidence, got {observations:?}");
+    };
+    assert_eq!(field, "n");
+    assert_eq!(observation.vote(), NumericVote::NoValue);
+}
+
+#[test]
+fn xml_reader_streams_the_observation_used_by_infer_value() {
+    let (observer, observations) = observation_collector();
+    let mut reader = XmlReader::from_reader_observing(
+        b"<root><row><n>1e999</n></row></root>".as_slice(),
+        XmlReaderConfig {
+            record_path: Some("root/row".into()),
+            ..Default::default()
+        },
+        observer,
+    )
+    .expect("XML reader builds");
+    reader.schema().expect("XML schema");
+    let record = reader
+        .next_record()
+        .expect("XML record parses")
+        .expect("one XML record");
+    let observations = observations.lock().expect("observation collector lock");
+    let [(field, observation)] = observations.as_slice() else {
+        panic!("expected one numeric observation, got {observations:?}");
+    };
+    assert_eq!(field, "n");
+    assert_eq!(observation.boundary(), NumericBoundary::Xml);
+    assert_eq!(
+        observation.vote(),
+        NumericVote::Unresolved(NumericIssue::NonFinite)
+    );
+    assert_record_matches_parser(record.get("n").expect("n field"), observation);
+}
+
+#[test]
+fn positional_observed_result_is_the_canonical_scalar_result() {
+    for lexeme in [
+        "-9223372036854775808",
+        "9223372036854775807",
+        "9223372036854775808",
+        "0.1",
+        "1e-999",
+        "0.10000000000000001",
+        "NaN",
+        "not-a-number",
+    ] {
+        let observed =
+            coerce_scalar_with_constraints_observed(&Type::Numeric, None, None, None, lexeme);
+        let canonical = coerce_scalar_with_constraints(&Type::Numeric, None, None, None, lexeme);
+        assert_eq!(
+            observed.result(),
+            canonical.as_ref().map_err(String::as_str)
+        );
+        assert_eq!(
+            observed.numeric_observation().map(NumericObservation::vote),
+            Some(observe_positional_numeric(lexeme).vote())
+        );
+    }
+}
+
+#[test]
+fn schema_observation_does_not_change_existing_nonlexical_coercions() {
+    let boolean = coerce_numeric_with_observation(&Value::Bool(true));
+    assert_eq!(boolean.result(), Ok(&Value::Integer(1)));
+    assert_eq!(
+        boolean.observation().parser_outcome(),
+        &NumericParserOutcome::NonNumeric
+    );
+
+    let empty = coerce_numeric_with_observation(&Value::String("".into()));
+    assert_eq!(empty.result(), Err("value cannot be parsed as Float"));
+}
+
+fn record_type(columns: Vec<Column>) -> RecordType {
+    RecordType {
+        id: "detail".into(),
+        tag: "D".into(),
+        description: None,
+        parent: None,
+        join_key: None,
+        columns,
+    }
+}
+
+#[test]
+fn multi_record_fixed_and_csv_delegate_numeric_text_to_positional_coercion() {
+    let fixed_column = Column {
+        start: Some(1),
+        width: Some(10),
+        ..Column::bare("n", Type::Numeric)
+    };
+    let fixed_spec = MultiRecordSpec {
+        discriminator: Discriminator {
+            start: Some(0),
+            width: Some(1),
+            field: None,
+        },
+        record_types: vec![record_type(vec![fixed_column])],
+        structure: Vec::new(),
+        header_tags: Vec::new(),
+    };
+    let mut fixed = MultiRecordReader::new_fixed_width(
+        b"D42.5      \n".as_slice(),
+        fixed_spec,
+        LineSeparator::Lf,
+    )
+    .expect("fixed-width multi-record reader builds");
+    let fixed_record = fixed
+        .next_record()
+        .expect("fixed-width multi-record parse")
+        .expect("one fixed-width record");
+
+    let csv_spec = MultiRecordSpec {
+        discriminator: Discriminator {
+            start: None,
+            width: None,
+            field: Some("kind".into()),
+        },
+        record_types: vec![record_type(vec![
+            Column::bare("kind", Type::String),
+            Column::bare("n", Type::Numeric),
+        ])],
+        structure: Vec::new(),
+        header_tags: Vec::new(),
+    };
+    let mut csv = MultiRecordReader::new_csv(
+        b"D,42.5\n".as_slice(),
+        csv_spec,
+        CsvDialect {
+            delimiter: b',',
+            quote_char: b'"',
+            has_header: false,
+        },
+    )
+    .expect("CSV multi-record reader builds");
+    let csv_record = csv
+        .next_record()
+        .expect("CSV multi-record parse")
+        .expect("one CSV record");
+
+    let observed =
+        coerce_scalar_with_constraints_observed(&Type::Numeric, None, None, None, "42.5");
+    let parsed = observed.result().expect("numeric observation parses");
+    assert_eq!(fixed_record.get("n"), Some(parsed));
+    assert_eq!(csv_record.get("n"), Some(parsed));
+}
+
+#[test]
+fn raw_string_reader_families_share_the_schema_coercion_observation() {
+    // These readers all deliver raw text to this one runtime boundary. The
+    // format name is deliberately not a parsing switch: every row below must
+    // produce the same result and exactness vote.
+    for family in ["csv", "edifact", "x12", "hl7", "swift"] {
+        let value = Value::String("0.10000000000000001".into());
+        let observed = coerce_numeric_with_observation(&value);
+        assert_eq!(
+            observed.observation().boundary(),
+            NumericBoundary::SchemaCoerce,
+            "family {family}"
+        );
+        assert_eq!(
+            observed.observation().vote(),
+            NumericVote::Unresolved(NumericIssue::PrecisionLoss),
+            "family {family}"
+        );
+        assert_eq!(observed.result(), Ok(&Value::Float(0.1)), "family {family}");
+    }
+}
+
+fn assert_reader_uses_schema_numeric_observation(
+    reader: Box<dyn FormatReader>,
+    field: &str,
+    family: &str,
+) {
+    let (observer, observations) = observation_collector();
+    let mut coercing = CoercingReader::new_observing(
+        reader,
+        &[Column::bare(field, Type::Nullable(Box::new(Type::Numeric)))],
+        OnUnmapped::Drop,
+        family,
+        false,
+        observer,
+    )
+    .expect("coercing reader builds");
+
+    let mut parsed_value_seen = false;
+    while let Some(record) = coercing.next_record().expect("source record coerces") {
+        parsed_value_seen |= record.get(field) == Some(&Value::Float(0.1));
+    }
+    assert!(
+        parsed_value_seen,
+        "{family} numeric text reached schema coercion"
+    );
+
+    let observations = observations.lock().expect("observation collector lock");
+    assert!(
+        observations.iter().any(|(observed_field, observation)| {
+            observed_field == field
+                && observation.boundary() == NumericBoundary::SchemaCoerce
+                && observation.vote() == NumericVote::Unresolved(NumericIssue::PrecisionLoss)
+                && observation.parser_outcome() == &NumericParserOutcome::Float(0.1)
+        }),
+        "{family} did not publish the expected parser-owned observation: {observations:?}"
+    );
+}
+
+#[test]
+fn every_raw_string_reader_family_reaches_the_shared_schema_boundary() {
+    const LEXEME: &str = "0.10000000000000001";
+    const X12_ISA: &str = "ISA*00*          *00*          *ZZ*SENDER         \
+        *ZZ*RECEIVER       *240101*1200*U*00401*000000001*0*P*:~";
+
+    let csv = clinker_format::csv::reader::CsvReader::from_reader(
+        Cursor::new(format!("n\n{LEXEME}\n").into_bytes()),
+        clinker_format::csv::reader::CsvReaderConfig::default(),
+    );
+    assert_reader_uses_schema_numeric_observation(Box::new(csv), "n", "csv");
+
+    let edifact = format!(
+        "UNB+UNOA:1+SENDER+RECEIVER+240101:1200+REF1'\
+         UNH+M1+ORDERS:D:96A:UN'\
+         BGM+220+123+{LEXEME}'\
+         UNT+3+M1'\
+         UNZ+1+REF1'"
+    );
+    assert_reader_uses_schema_numeric_observation(
+        Box::new(EdifactReader::new(
+            Cursor::new(edifact.into_bytes()),
+            EdifactReaderConfig::default(),
+        )),
+        "e03",
+        "edifact",
+    );
+
+    let x12 = format!(
+        "{X12_ISA}\
+         GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~\
+         ST*850*0001~\
+         BEG*00*NE*PO12345**20240101~\
+         PO1*1*10*EA*{LEXEME}~\
+         SE*4*0001~\
+         GE*1*1~\
+         IEA*1*000000001~"
+    );
+    assert_reader_uses_schema_numeric_observation(
+        Box::new(X12Reader::new(
+            Cursor::new(x12.into_bytes()),
+            X12ReaderConfig::default(),
+        )),
+        "e04",
+        "x12",
+    );
+
+    let hl7 = format!(
+        "MSH|^~\\&|SENDAPP|SENDFAC|RCVAPP|RCVFAC|20240101120000||ADT^A01|MSG001|P|{LEXEME}"
+    );
+    assert_reader_uses_schema_numeric_observation(
+        Box::new(Hl7Reader::new(
+            Cursor::new(hl7.into_bytes()),
+            Hl7ReaderConfig::default(),
+        )),
+        "f11",
+        "hl7",
+    );
+
+    let swift = format!(
+        "{{1:F01BANKBEBBAXXX0000000000}}{{2:I103BANKDEFFXXXXN}}\
+         {{3:{{108:MSGREF12345}}}}\
+         {{4:\r\n:20:{LEXEME}\r\n-}}\
+         {{5:{{CHK:1234567890AB}}}}"
+    );
+    assert_reader_uses_schema_numeric_observation(
+        Box::new(SwiftReader::new(
+            Cursor::new(swift.into_bytes()),
+            SwiftReaderConfig::default(),
+        )),
+        "value",
+        "swift",
+    );
+}
+
+#[test]
+fn coercing_reader_emits_schema_observation_before_accepting_csv_text() {
+    use clinker_format::csv::reader::{CsvReader, CsvReaderConfig};
+
+    let reader = CsvReader::from_reader(
+        b"n\n42.5\n".as_slice(),
+        CsvReaderConfig {
+            delimiter: b',',
+            quote_char: b'"',
+            has_header: true,
+            ..Default::default()
+        },
+    );
+    let (observer, observations) = observation_collector();
+    let mut coercing = CoercingReader::new_observing(
+        Box::new(reader),
+        &[Column::bare("n", Type::Numeric)],
+        OnUnmapped::Drop,
+        "csv",
+        false,
+        observer,
+    )
+    .expect("coercing reader builds");
+    let record = coercing
+        .next_record()
+        .expect("coercion succeeds")
+        .expect("one CSV record");
+    let observations = observations.lock().expect("observation collector lock");
+    let [(field, observation)] = observations.as_slice() else {
+        panic!("expected one schema observation, got {observations:?}");
+    };
+    assert_eq!(field, "n");
+    assert_eq!(observation.boundary(), NumericBoundary::SchemaCoerce);
+    assert_eq!(record.get("n"), observation.parsed_value().as_ref());
+}

--- a/crates/clinker-format/src/fixed_width/field.rs
+++ b/crates/clinker-format/src/fixed_width/field.rs
@@ -17,7 +17,35 @@ use clinker_record::schema_def::{Justify, LineSeparator};
 use cxl::typecheck::Type;
 
 use crate::error::FormatError;
+use crate::numeric_observation::{NumericObservation, observe_positional_numeric_with_result};
 use crate::schema::Column;
+
+/// Result of one scalar coercion together with parser-owned numeric evidence
+/// when the declared target is `numeric`.
+///
+/// Keeping the observation outside the [`Result`] makes rejected numeric text
+/// observable without parsing it a second time merely to explain why guessing
+/// stayed unresolved.
+#[derive(Debug)]
+#[must_use]
+pub struct ObservedScalarCoercion {
+    result: Result<Value, String>,
+    numeric: Option<NumericObservation>,
+}
+
+impl ObservedScalarCoercion {
+    pub fn result(&self) -> Result<&Value, &str> {
+        self.result.as_ref().map_err(String::as_str)
+    }
+
+    pub fn numeric_observation(&self) -> Option<&NumericObservation> {
+        self.numeric.as_ref()
+    }
+
+    pub fn into_result(self) -> Result<Value, String> {
+        self.result
+    }
+}
 
 /// A fixed-width field resolved to a concrete byte range and parse policy.
 ///
@@ -463,79 +491,100 @@ pub fn coerce_scalar_with_constraints(
     scale: Option<u8>,
     raw: &str,
 ) -> Result<Value, String> {
-    match ty.unwrap_nullable() {
-        Type::Int => raw
-            .parse::<i64>()
-            .map(Value::Integer)
-            .map_err(|e| format!("cannot parse '{raw}' as int: {e}")),
-        Type::Float => parse_finite_float(raw).map(Value::Float),
-        // Exact base-10 parse into `Value::Decimal`. Never route through a
-        // binary float and never round to satisfy the authored scale.
-        Type::Decimal => {
-            let parsed =
-                clinker_record::coercion::coerce_to_decimal(&Value::String(raw.into()), None)
-                    .map_err(|e| e.to_string())?;
-            let Value::Decimal(decimal) = parsed else {
-                return Err("decimal coercion returned a non-decimal value".into());
-            };
-            let mut exact = decimal;
-            if let Some(scale) = scale {
-                let rounded =
-                    clinker_record::coercion::round_decimal_to_scale(decimal, Some(scale));
-                if rounded != decimal {
-                    return Err(format!(
-                        "decimal requires rounding to declared scale {scale}"
-                    ));
+    coerce_scalar_with_constraints_observed(ty, format, precision, scale, raw).into_result()
+}
+
+/// Coerce a positional scalar and retain the canonical numeric observation.
+/// Non-numeric declared targets return `None` for the observation.
+pub fn coerce_scalar_with_constraints_observed(
+    ty: &Type,
+    format: Option<&str>,
+    precision: Option<u8>,
+    scale: Option<u8>,
+    raw: &str,
+) -> ObservedScalarCoercion {
+    let (numeric, numeric_result) = if matches!(ty.unwrap_nullable(), Type::Numeric) {
+        let (observation, result) = observe_positional_numeric_with_result(raw);
+        (Some(observation), Some(result))
+    } else {
+        (None, None)
+    };
+    let result = (|| -> Result<Value, String> {
+        if let Some(result) = numeric_result {
+            return result;
+        }
+        match ty.unwrap_nullable() {
+            Type::Int => raw
+                .parse::<i64>()
+                .map(Value::Integer)
+                .map_err(|e| format!("cannot parse '{raw}' as int: {e}")),
+            Type::Float => parse_finite_float(raw).map(Value::Float),
+            // Exact base-10 parse into `Value::Decimal`. Never route through a
+            // binary float and never round to satisfy the authored scale.
+            Type::Decimal => {
+                let parsed =
+                    clinker_record::coercion::coerce_to_decimal(&Value::String(raw.into()), None)
+                        .map_err(|e| e.to_string())?;
+                let Value::Decimal(decimal) = parsed else {
+                    return Err("decimal coercion returned a non-decimal value".into());
+                };
+                let mut exact = decimal;
+                if let Some(scale) = scale {
+                    let rounded =
+                        clinker_record::coercion::round_decimal_to_scale(decimal, Some(scale));
+                    if rounded != decimal {
+                        return Err(format!(
+                            "decimal requires rounding to declared scale {scale}"
+                        ));
+                    }
+                    exact.rescale(u32::from(scale));
                 }
-                exact.rescale(u32::from(scale));
-            }
-            if let Some(max_digits) = precision {
-                let digits = exact.mantissa().unsigned_abs().to_string().len();
-                if digits > usize::from(max_digits) {
-                    return Err(format!(
-                        "decimal uses {digits} digits, exceeding declared precision {max_digits}"
-                    ));
+                if let Some(max_digits) = precision {
+                    let digits = exact.mantissa().unsigned_abs().to_string().len();
+                    if digits > usize::from(max_digits) {
+                        return Err(format!(
+                            "decimal uses {digits} digits, exceeding declared precision {max_digits}"
+                        ));
+                    }
                 }
+                Ok(Value::Decimal(exact))
             }
-            Ok(Value::Decimal(exact))
-        }
-        Type::Numeric => raw
-            .parse::<i64>()
-            .map(Value::Integer)
-            .or_else(|_| parse_finite_float(raw).map(Value::Float)),
-        Type::Bool => match raw.to_ascii_lowercase().as_str() {
-            "true" | "1" | "yes" | "y" => Ok(Value::Bool(true)),
-            "false" | "0" | "no" | "n" => Ok(Value::Bool(false)),
-            _ => Err(format!("cannot parse '{raw}' as bool")),
-        },
-        Type::Date => {
-            let fmt = format.unwrap_or("%Y-%m-%d");
-            NaiveDate::parse_from_str(raw, fmt)
-                .map(Value::Date)
-                .map_err(|e| format!("cannot parse '{raw}' as date with format '{fmt}': {e}"))
-        }
-        Type::DateTime => {
-            // Honor an explicit `format:` (single format); otherwise fall back
-            // to the shared default datetime chain — the same set the
-            // CSV/native coercion path uses — so a positional `date_time`
-            // column parses the common serializations (ISO-`T`, space-separated,
-            // US) it did before this became a real reader-side parse.
-            let chain: Vec<&str> = format.into_iter().collect();
-            clinker_record::coercion::coerce_to_datetime(&Value::String(raw.into()), &chain)
-                .map_err(|e| e.to_string())
-        }
-        Type::Map => Err(
-            "a positional (fixed-width / multi-record) field cannot carry a `map` value; \
+            Type::Numeric => Err("numeric parser result was not established".into()),
+            Type::Bool => match raw.to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" | "y" => Ok(Value::Bool(true)),
+                "false" | "0" | "no" | "n" => Ok(Value::Bool(false)),
+                _ => Err(format!("cannot parse '{raw}' as bool")),
+            },
+            Type::Date => {
+                let fmt = format.unwrap_or("%Y-%m-%d");
+                NaiveDate::parse_from_str(raw, fmt)
+                    .map(Value::Date)
+                    .map_err(|e| format!("cannot parse '{raw}' as date with format '{fmt}': {e}"))
+            }
+            Type::DateTime => {
+                // Honor an explicit `format:` (single format); otherwise fall back
+                // to the shared default datetime chain — the same set the
+                // CSV/native coercion path uses — so a positional `date_time`
+                // column parses the common serializations (ISO-`T`, space-separated,
+                // US) it did before this became a real reader-side parse.
+                let chain: Vec<&str> = format.into_iter().collect();
+                clinker_record::coercion::coerce_to_datetime(&Value::String(raw.into()), &chain)
+                    .map_err(|e| e.to_string())
+            }
+            Type::Map => Err(
+                "a positional (fixed-width / multi-record) field cannot carry a `map` value; \
              declare this column on a native JSON/XML source"
-                .to_string(),
-        ),
-        Type::Array => Err(
-            "a positional (fixed-width / multi-record) field cannot carry an `array` value; \
+                    .to_string(),
+            ),
+            Type::Array => Err(
+                "a positional (fixed-width / multi-record) field cannot carry an `array` value; \
              declare this column on a native JSON/XML source"
-                .to_string(),
-        ),
-        _ => Ok(Value::String(raw.into())),
-    }
+                    .to_string(),
+            ),
+            _ => Ok(Value::String(raw.into())),
+        }
+    })();
+    ObservedScalarCoercion { result, numeric }
 }
 
 fn parse_finite_float(raw: &str) -> Result<f64, String> {

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -32,6 +32,7 @@ use clinker_record::{
     coerce_to_string,
 };
 use indexmap::IndexMap;
+use serde::Deserialize;
 
 use cxl::analyzer::doc_paths::DocPath;
 
@@ -42,6 +43,7 @@ use crate::error::FormatError;
 use crate::json::body_stream::{JsonArrayStream, is_json_ws};
 use crate::json::streaming::{SectionTarget, extract_sections};
 use crate::multi_value::{SplitToRows, SplitToRowsMode, SplitValues};
+use crate::numeric_observation::{NumericObserver, observe_json_number, observe_json_value};
 use crate::record_path::{RecordPath, RecordPathSyntax};
 use crate::source::{ReopenableSource, SourceIdentity};
 use crate::traits::FormatReader;
@@ -104,6 +106,9 @@ pub struct JsonReader {
     /// sees the same content, so a path-backed input rewritten between the two
     /// passes fails loud instead of splicing a stale envelope onto a new body.
     body_identity: SourceIdentity,
+    /// Optional authoring-only sink. Observations are emitted one scalar at a
+    /// time before `serde_json::Number` becomes a record [`Value`].
+    numeric_observer: Option<NumericObserver>,
 }
 
 enum InnerReader {
@@ -150,6 +155,31 @@ impl JsonReader {
         source: ReopenableSource,
         config: JsonReaderConfig,
     ) -> Result<Self, FormatError> {
+        Self::from_source_with_observer(source, config, None)
+    }
+
+    /// Build a streaming reader that publishes exact parser-owned numeric
+    /// evidence before record-value conversion.
+    ///
+    /// The observer is called synchronously and must retain only bounded
+    /// evidence; the reader itself continues to hold at most one record.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`from_source`](Self::from_source).
+    pub fn from_source_observing(
+        source: ReopenableSource,
+        config: JsonReaderConfig,
+        observer: NumericObserver,
+    ) -> Result<Self, FormatError> {
+        Self::from_source_with_observer(source, config, Some(observer))
+    }
+
+    fn from_source_with_observer(
+        source: ReopenableSource,
+        config: JsonReaderConfig,
+        numeric_observer: Option<NumericObserver>,
+    ) -> Result<Self, FormatError> {
         // JSON runs two passes (envelope pre-scan + body stream), so the source
         // must be re-openable. A `Path`/`Buffered` source passes through; a
         // pathless `OneShot` is buffered here, on the reader-building thread —
@@ -164,6 +194,7 @@ impl JsonReader {
             deferred_first: None,
             source,
             body_identity,
+            numeric_observer,
         })
     }
 
@@ -186,6 +217,21 @@ impl JsonReader {
     ) -> Result<Self, FormatError> {
         let source = ReopenableSource::buffer(reader).map_err(FormatError::Io)?;
         Self::from_source(source, config)
+    }
+
+    /// Buffer a pathless source and publish exact numeric observations while
+    /// it streams.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`from_reader`](Self::from_reader).
+    pub fn from_reader_observing<R: Read + Send + 'static>(
+        reader: R,
+        config: JsonReaderConfig,
+        observer: NumericObserver,
+    ) -> Result<Self, FormatError> {
+        let source = ReopenableSource::buffer(reader).map_err(FormatError::Io)?;
+        Self::from_source_observing(source, config, observer)
     }
 
     /// Open a fresh `BufReader` from the source with a leading UTF-8 BOM
@@ -522,7 +568,12 @@ impl JsonReader {
         self.apply_multi_value(&mut flat);
         let columns: Vec<Box<str>> = flat.keys().map(|k| k.clone().into_boxed_str()).collect();
         let schema = Arc::new(Schema::new(columns));
-        let values: Vec<Value> = flat.values().map(json_to_value).collect();
+        let values: Vec<Value> = flat
+            .iter()
+            .map(|(field, value)| {
+                json_to_value_observing(value, Some(field), self.numeric_observer.as_ref(), false)
+            })
+            .collect();
         Ok(Record::new(schema, values))
     }
 }
@@ -850,24 +901,71 @@ fn split_text_value(value: &serde_json::Value, delimiter: &str) -> serde_json::V
 /// reuses it to recover a cell a sink wrote under `join_values`
 /// `on_conflict: encode_json`.
 pub(crate) fn json_to_value(v: &serde_json::Value) -> Value {
+    json_to_value_observing(v, None, None, false)
+}
+
+fn selective_stream_json_to_value(v: &serde_json::Value) -> Value {
+    json_to_value_observing(v, None, None, true)
+}
+
+fn json_to_value_observing(
+    v: &serde_json::Value,
+    field: Option<&str>,
+    observer: Option<&NumericObserver>,
+    recover_streamed_number: bool,
+) -> Value {
+    // The streaming selective-deserialization visitor represents an
+    // arbitrary-precision number through serde_json's reserved tagged map.
+    // Ask Number's own Deserializer to recover it rather than recognizing the
+    // private tag or reparsing its payload ourselves.
+    if recover_streamed_number
+        && v.is_object()
+        && let Ok(number) = serde_json::Number::deserialize(v)
+    {
+        let observation = observe_json_number(&number);
+        let value = observation
+            .parsed_value()
+            .unwrap_or_else(|| Value::String(number.to_string().into()));
+        if let (Some(field), Some(observer)) = (field, observer) {
+            observer.observe(field, observation);
+        }
+        return value;
+    }
     match v {
-        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Null => {
+            if let (Some(field), Some(observer), Some(observation)) =
+                (field, observer, observe_json_value(v))
+            {
+                observer.observe(field, observation);
+            }
+            Value::Null
+        }
         serde_json::Value::Bool(b) => Value::Bool(*b),
         serde_json::Value::Number(n) => {
-            if let Some(i) = n.as_i64() {
-                Value::Integer(i)
-            } else if let Some(f) = n.as_f64() {
-                Value::Float(f)
-            } else {
-                Value::String(n.to_string().into())
+            let observation = observe_json_number(n);
+            let value = observation
+                .parsed_value()
+                .unwrap_or_else(|| Value::String(n.to_string().into()));
+            if let (Some(field), Some(observer)) = (field, observer) {
+                observer.observe(field, observation);
             }
+            value
         }
         serde_json::Value::String(s) => Value::String(s.clone().into()),
-        serde_json::Value::Array(arr) => Value::Array(arr.iter().map(json_to_value).collect()),
+        serde_json::Value::Array(arr) => Value::Array(
+            arr.iter()
+                .map(|value| {
+                    json_to_value_observing(value, field, observer, recover_streamed_number)
+                })
+                .collect(),
+        ),
         serde_json::Value::Object(obj) => {
             let mut map: IndexMap<Box<str>, Value> = IndexMap::with_capacity(obj.len());
             for (k, val) in obj {
-                map.insert(k.as_str().into(), json_to_value(val));
+                map.insert(
+                    k.as_str().into(),
+                    json_to_value_observing(val, field, observer, recover_streamed_number),
+                );
             }
             Value::Map(Box::new(map))
         }
@@ -930,7 +1028,7 @@ fn coerce_json_section_fields(
             Some(v) if !v.is_null() => v,
             _ => continue,
         };
-        let intermediate = json_to_value(json_val);
+        let intermediate = selective_stream_json_to_value(json_val);
         let coerced = match ty {
             EnvelopeFieldType::String => coerce_to_string(&intermediate),
             EnvelopeFieldType::Int => coerce_to_int(&intermediate),

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hl7;
 pub mod json;
 pub mod multi_record;
 pub mod multi_value;
+pub mod numeric_observation;
 pub mod record_path;
 pub mod schema;
 pub(crate) mod segment_tokenizer;
@@ -33,6 +34,11 @@ pub use envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 pub use error::FormatError;
 pub use multi_value::{
     JoinValues, OnConflict, SplitToRows, SplitToRowsMode, SplitValues, under_field_path,
+};
+pub use numeric_observation::{
+    NumericAcceptance, NumericBoundary, NumericIssue, NumericLexeme, NumericObservation,
+    NumericObserver, NumericParserOutcome, NumericVote, observe_json_number, observe_json_value,
+    observe_positional_numeric, observe_schema_numeric, observe_xml_scalar,
 };
 pub use record_path::{RecordPath, RecordPathError, RecordPathSyntax};
 pub use schema::{

--- a/crates/clinker-format/src/numeric_observation.rs
+++ b/crates/clinker-format/src/numeric_observation.rs
@@ -1,0 +1,599 @@
+//! Exact numeric evidence produced next to Clinker's canonical format parsers.
+//!
+//! Schema guessing consumes these observations instead of parsing numeric text
+//! independently.  An observation deliberately keeps two facts separate:
+//! the value the real parser produced, and the narrower exact vote that is safe
+//! to turn into a concrete schema.  A finite `f64` parse can therefore be
+//! recorded while underflow or discarded decimal significance still leaves
+//! the guess unresolved.
+
+use std::fmt;
+use std::sync::Arc;
+
+use clinker_record::Value;
+
+/// Maximum combined bytes retained from one untrusted numeric lexeme.
+pub const MAX_NUMERIC_LEXEME_EVIDENCE_BYTES: usize = 128;
+
+/// The parser boundary that produced an observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumericBoundary {
+    Json,
+    Xml,
+    Positional,
+    SchemaCoerce,
+}
+
+/// Why a parser result cannot safely choose a concrete numeric schema.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumericIssue {
+    InvalidNumeric,
+    IntegerOverflow,
+    NonFinite,
+    UnsafeIntegerWidening,
+    UnderflowToZero,
+    PrecisionLoss,
+    RepresentationChanged,
+}
+
+/// The exact result of the real parser path, before any guess policy is used.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NumericParserOutcome {
+    NoValue,
+    Integer(i64),
+    Float(f64),
+    NonNumeric,
+    Rejected(NumericIssue),
+}
+
+/// Exact acceptance of a lexeme by one candidate concrete numeric type.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NumericAcceptance<T> {
+    NoValue,
+    Accepted(T),
+    Rejected(NumericIssue),
+}
+
+/// The type vote a schema-guess aggregator may consume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NumericVote {
+    NoValue,
+    Int,
+    Float,
+    Unresolved(NumericIssue),
+}
+
+/// Bounded representative bytes from one original lexeme.
+///
+/// Short lexemes are retained in full. Long lexemes retain a UTF-8-safe head
+/// and tail whose combined byte length never exceeds
+/// [`MAX_NUMERIC_LEXEME_EVIDENCE_BYTES`]. The parser and exactness checks still
+/// consume the borrowed complete input; only retained report evidence is
+/// capped.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NumericLexeme {
+    head: Box<str>,
+    tail: Box<str>,
+    original_bytes: usize,
+}
+
+impl NumericLexeme {
+    fn new(raw: &str) -> Self {
+        if raw.len() <= MAX_NUMERIC_LEXEME_EVIDENCE_BYTES {
+            return Self {
+                head: raw.into(),
+                tail: "".into(),
+                original_bytes: raw.len(),
+            };
+        }
+
+        let head_budget = MAX_NUMERIC_LEXEME_EVIDENCE_BYTES / 2;
+        let tail_budget = MAX_NUMERIC_LEXEME_EVIDENCE_BYTES - head_budget;
+
+        let mut head_end = head_budget;
+        while !raw.is_char_boundary(head_end) {
+            head_end -= 1;
+        }
+
+        let mut tail_start = raw.len() - tail_budget;
+        while !raw.is_char_boundary(tail_start) {
+            tail_start += 1;
+        }
+
+        Self {
+            head: raw[..head_end].into(),
+            tail: raw[tail_start..].into(),
+            original_bytes: raw.len(),
+        }
+    }
+
+    /// Complete lexeme when it fit inside the evidence cap.
+    pub fn complete(&self) -> Option<&str> {
+        self.tail.is_empty().then_some(self.head.as_ref())
+    }
+
+    pub fn head(&self) -> &str {
+        &self.head
+    }
+
+    pub fn tail(&self) -> &str {
+        &self.tail
+    }
+
+    pub fn original_bytes(&self) -> usize {
+        self.original_bytes
+    }
+
+    pub fn is_truncated(&self) -> bool {
+        !self.tail.is_empty()
+    }
+}
+
+/// One parser-owned observation of a scalar lexeme.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NumericObservation {
+    boundary: NumericBoundary,
+    lexeme: NumericLexeme,
+    parser_outcome: NumericParserOutcome,
+    int_acceptance: NumericAcceptance<i64>,
+    float_acceptance: NumericAcceptance<f64>,
+    vote: NumericVote,
+}
+
+impl NumericObservation {
+    pub fn boundary(&self) -> NumericBoundary {
+        self.boundary
+    }
+
+    pub fn lexeme(&self) -> &NumericLexeme {
+        &self.lexeme
+    }
+
+    pub fn parser_outcome(&self) -> &NumericParserOutcome {
+        &self.parser_outcome
+    }
+
+    pub fn int_acceptance(&self) -> &NumericAcceptance<i64> {
+        &self.int_acceptance
+    }
+
+    /// Exact float compatibility is retained even for an integer parser
+    /// outcome so a mixed int/float field can reject unsafe widening.
+    pub fn float_acceptance(&self) -> &NumericAcceptance<f64> {
+        &self.float_acceptance
+    }
+
+    pub fn vote(&self) -> NumericVote {
+        self.vote
+    }
+
+    /// Convert the canonical parser outcome into the native record value.
+    /// Rejected and non-numeric outcomes have no numeric value.
+    pub fn parsed_value(&self) -> Option<Value> {
+        match self.parser_outcome {
+            NumericParserOutcome::NoValue => Some(Value::Null),
+            NumericParserOutcome::Integer(value) => Some(Value::Integer(value)),
+            NumericParserOutcome::Float(value) => Some(Value::Float(value)),
+            NumericParserOutcome::NonNumeric | NumericParserOutcome::Rejected(_) => None,
+        }
+    }
+
+    fn with_boundary(mut self, boundary: NumericBoundary) -> Self {
+        self.boundary = boundary;
+        self
+    }
+}
+
+/// Cloneable callback used by streaming readers to publish one observation at
+/// a time without retaining document-sized evidence.
+type NumericObservationCallback = dyn Fn(&str, NumericObservation) + Send + Sync;
+
+#[derive(Clone)]
+pub struct NumericObserver {
+    callback: Arc<NumericObservationCallback>,
+}
+
+impl NumericObserver {
+    pub fn new<F>(callback: F) -> Self
+    where
+        F: Fn(&str, NumericObservation) + Send + Sync + 'static,
+    {
+        Self {
+            callback: Arc::new(callback),
+        }
+    }
+
+    pub fn observe(&self, field: &str, observation: NumericObservation) {
+        (self.callback)(field, observation);
+    }
+}
+
+impl fmt::Debug for NumericObserver {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("NumericObserver(..)")
+    }
+}
+
+/// Observe a number already admitted by serde_json's arbitrary-precision
+/// representation. `Number::to_string` supplies serde_json's parser-owned
+/// representation (which may canonicalize spelling); no raw-value feature or
+/// second JSON lexer is involved.
+pub fn observe_json_number(number: &serde_json::Number) -> NumericObservation {
+    let raw = number.to_string();
+    let parser_outcome = if let Some(value) = number.as_i64() {
+        NumericParserOutcome::Integer(value)
+    } else if let Some(value) = number.as_f64() {
+        NumericParserOutcome::Float(value)
+    } else if is_integer_syntax(&raw) {
+        NumericParserOutcome::Rejected(NumericIssue::IntegerOverflow)
+    } else {
+        NumericParserOutcome::Rejected(NumericIssue::NonFinite)
+    };
+    observation_from_outcome(NumericBoundary::Json, &raw, parser_outcome)
+}
+
+/// Observe the JSON scalar states that carry numeric-field evidence. Strings
+/// continue to the schema-coercion boundary; objects, arrays, and booleans are
+/// not interpreted as numeric by the format reader.
+pub fn observe_json_value(value: &serde_json::Value) -> Option<NumericObservation> {
+    match value {
+        serde_json::Value::Null => Some(observation_from_outcome(
+            NumericBoundary::Json,
+            "null",
+            NumericParserOutcome::NoValue,
+        )),
+        serde_json::Value::Number(number) => Some(observe_json_number(number)),
+        _ => None,
+    }
+}
+
+/// Observe XML's real scalar inference order: empty, signed `i64`, then `f64`
+/// for a decimal/exponent spelling, then non-numeric. Exact acceptance rejects
+/// a non-finite `f64` without changing the parser outcome.
+pub fn observe_xml_scalar(raw: &str) -> NumericObservation {
+    let parser_outcome = if raw.is_empty() {
+        NumericParserOutcome::NoValue
+    } else if let Ok(value) = raw.parse::<i64>() {
+        NumericParserOutcome::Integer(value)
+    } else if has_float_marker(raw) {
+        match raw.parse::<f64>() {
+            Ok(value) => NumericParserOutcome::Float(value),
+            Err(_) => NumericParserOutcome::NonNumeric,
+        }
+    } else {
+        NumericParserOutcome::NonNumeric
+    };
+    observation_from_outcome(NumericBoundary::Xml, raw, parser_outcome)
+}
+
+/// Observe the shared fixed-width/multi-record numeric parser: signed `i64`
+/// first, then a finite `f64`.
+pub fn observe_positional_numeric(raw: &str) -> NumericObservation {
+    observe_positional_numeric_with_result(raw).0
+}
+
+/// Run the positional parser once and retain both its ordinary result and the
+/// exact observation derived from that result.
+pub(crate) fn observe_positional_numeric_with_result(
+    raw: &str,
+) -> (NumericObservation, Result<Value, String>) {
+    let (parser_outcome, result) = if let Ok(value) = raw.parse::<i64>() {
+        (
+            NumericParserOutcome::Integer(value),
+            Ok(Value::Integer(value)),
+        )
+    } else {
+        match raw.parse::<f64>() {
+            Ok(value) if value.is_finite() => {
+                (NumericParserOutcome::Float(value), Ok(Value::Float(value)))
+            }
+            Ok(_) => (
+                NumericParserOutcome::Rejected(NumericIssue::NonFinite),
+                Err(format!(
+                    "non-finite number '{raw}' is outside the declared type"
+                )),
+            ),
+            Err(error) => (
+                if is_integer_syntax(raw) {
+                    NumericParserOutcome::Rejected(NumericIssue::IntegerOverflow)
+                } else {
+                    NumericParserOutcome::NonNumeric
+                },
+                Err(format!("cannot parse '{raw}' as float: {error}")),
+            ),
+        }
+    };
+    (
+        observation_from_outcome(NumericBoundary::Positional, raw, parser_outcome),
+        result,
+    )
+}
+
+/// Observe the executor's string-to-schema numeric boundary.
+///
+/// Native values retain their already-established type. Text uses the same
+/// int-then-finite-float path as runtime numeric coercion; composite, boolean,
+/// and temporal values are not numeric evidence.
+pub fn observe_schema_numeric(value: &Value) -> NumericObservation {
+    match value {
+        Value::Null => observation_from_outcome(
+            NumericBoundary::SchemaCoerce,
+            "",
+            NumericParserOutcome::NoValue,
+        ),
+        Value::Integer(number) => observation_from_outcome(
+            NumericBoundary::SchemaCoerce,
+            &number.to_string(),
+            NumericParserOutcome::Integer(*number),
+        ),
+        Value::Float(number) if number.is_finite() => observation_from_outcome(
+            NumericBoundary::SchemaCoerce,
+            &number.to_string(),
+            NumericParserOutcome::Float(*number),
+        ),
+        Value::Float(number) => observation_from_outcome(
+            NumericBoundary::SchemaCoerce,
+            &number.to_string(),
+            NumericParserOutcome::Rejected(NumericIssue::NonFinite),
+        ),
+        Value::String(raw) => {
+            observe_positional_numeric(raw.as_str()).with_boundary(NumericBoundary::SchemaCoerce)
+        }
+        _ => observation_from_outcome(
+            NumericBoundary::SchemaCoerce,
+            value.type_name(),
+            NumericParserOutcome::NonNumeric,
+        ),
+    }
+}
+
+fn observation_from_outcome(
+    boundary: NumericBoundary,
+    raw: &str,
+    parser_outcome: NumericParserOutcome,
+) -> NumericObservation {
+    let int_acceptance = exact_int_acceptance(raw, &parser_outcome);
+    let float_acceptance = exact_float_acceptance(raw, &parser_outcome, &int_acceptance);
+    let vote = match (&parser_outcome, &int_acceptance, &float_acceptance) {
+        (NumericParserOutcome::NoValue, _, _) => NumericVote::NoValue,
+        (NumericParserOutcome::Integer(_), NumericAcceptance::Accepted(_), _) => NumericVote::Int,
+        (NumericParserOutcome::Integer(_), NumericAcceptance::Rejected(issue), _) => {
+            NumericVote::Unresolved(*issue)
+        }
+        (NumericParserOutcome::Float(_), _, NumericAcceptance::Accepted(_)) => NumericVote::Float,
+        (NumericParserOutcome::Float(_), _, NumericAcceptance::Rejected(issue)) => {
+            NumericVote::Unresolved(*issue)
+        }
+        (NumericParserOutcome::Rejected(issue), _, _)
+        | (_, NumericAcceptance::Rejected(issue), NumericAcceptance::NoValue) => {
+            NumericVote::Unresolved(*issue)
+        }
+        (NumericParserOutcome::NonNumeric, _, _) => {
+            NumericVote::Unresolved(NumericIssue::InvalidNumeric)
+        }
+        _ => NumericVote::Unresolved(NumericIssue::InvalidNumeric),
+    };
+
+    NumericObservation {
+        boundary,
+        lexeme: NumericLexeme::new(raw),
+        parser_outcome,
+        int_acceptance,
+        float_acceptance,
+        vote,
+    }
+}
+
+fn exact_int_acceptance(
+    raw: &str,
+    parser_outcome: &NumericParserOutcome,
+) -> NumericAcceptance<i64> {
+    match parser_outcome {
+        NumericParserOutcome::NoValue => NumericAcceptance::NoValue,
+        NumericParserOutcome::Integer(value) if raw == value.to_string() => {
+            NumericAcceptance::Accepted(*value)
+        }
+        NumericParserOutcome::Integer(_) => {
+            NumericAcceptance::Rejected(NumericIssue::RepresentationChanged)
+        }
+        _ if is_integer_syntax(raw) => NumericAcceptance::Rejected(NumericIssue::IntegerOverflow),
+        _ => NumericAcceptance::Rejected(NumericIssue::InvalidNumeric),
+    }
+}
+
+fn exact_float_acceptance(
+    raw: &str,
+    parser_outcome: &NumericParserOutcome,
+    int_acceptance: &NumericAcceptance<i64>,
+) -> NumericAcceptance<f64> {
+    if matches!(parser_outcome, NumericParserOutcome::NoValue) {
+        return NumericAcceptance::NoValue;
+    }
+
+    let parsed = match raw.parse::<f64>() {
+        Ok(value) if value.is_finite() => value,
+        Ok(_) => return NumericAcceptance::Rejected(NumericIssue::NonFinite),
+        Err(_) if is_integer_syntax(raw) => {
+            return NumericAcceptance::Rejected(NumericIssue::IntegerOverflow);
+        }
+        Err(_) => return NumericAcceptance::Rejected(NumericIssue::InvalidNumeric),
+    };
+
+    if parsed == 0.0 && contains_nonzero_digit(raw) {
+        return NumericAcceptance::Rejected(NumericIssue::UnderflowToZero);
+    }
+
+    if is_integer_syntax(raw) {
+        let NumericAcceptance::Accepted(integer) = int_acceptance else {
+            return NumericAcceptance::Rejected(
+                if matches!(parser_outcome, NumericParserOutcome::Float(_)) {
+                    NumericIssue::UnsafeIntegerWidening
+                } else {
+                    match int_acceptance {
+                        NumericAcceptance::Rejected(issue) => *issue,
+                        _ => NumericIssue::UnsafeIntegerWidening,
+                    }
+                },
+            );
+        };
+        if parsed as i128 != i128::from(*integer) {
+            return NumericAcceptance::Rejected(NumericIssue::UnsafeIntegerWidening);
+        }
+        return NumericAcceptance::Accepted(parsed);
+    }
+
+    let Some(canonical) = serde_json::Number::from_f64(parsed) else {
+        return NumericAcceptance::Rejected(NumericIssue::NonFinite);
+    };
+    if !same_decimal_value(raw, &canonical.to_string()) {
+        return NumericAcceptance::Rejected(NumericIssue::PrecisionLoss);
+    }
+
+    NumericAcceptance::Accepted(parsed)
+}
+
+fn has_float_marker(raw: &str) -> bool {
+    raw.bytes().any(|byte| matches!(byte, b'.' | b'e' | b'E'))
+}
+
+fn is_integer_syntax(raw: &str) -> bool {
+    let digits = raw
+        .strip_prefix('-')
+        .or_else(|| raw.strip_prefix('+'))
+        .unwrap_or(raw);
+    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn contains_nonzero_digit(raw: &str) -> bool {
+    raw.bytes().any(|byte| matches!(byte, b'1'..=b'9'))
+}
+
+/// Compare two parser-accepted decimal spellings without accepting syntax.
+/// This is a post-parse significance check only: the canonical parser has
+/// already decided whether `raw` is numeric.
+fn same_decimal_value(left: &str, right: &str) -> bool {
+    let Some(left) = DecimalView::new(left) else {
+        return false;
+    };
+    let Some(right) = DecimalView::new(right) else {
+        return false;
+    };
+    if left.zero || right.zero {
+        return left.zero && right.zero && left.negative == right.negative;
+    }
+    left.negative == right.negative
+        && left.exponent == right.exponent
+        && left.digits().eq(right.digits())
+}
+
+struct DecimalView<'a> {
+    mantissa: &'a [u8],
+    first: usize,
+    last: usize,
+    exponent: i32,
+    negative: bool,
+    zero: bool,
+}
+
+impl<'a> DecimalView<'a> {
+    fn new(raw: &'a str) -> Option<Self> {
+        let (negative, unsigned) = match raw.as_bytes().first() {
+            Some(b'-') => (true, &raw[1..]),
+            Some(b'+') => (false, &raw[1..]),
+            _ => (false, raw),
+        };
+        let (mantissa, exponent_text) = match unsigned.find(['e', 'E']) {
+            Some(index) => (&unsigned.as_bytes()[..index], Some(&unsigned[index + 1..])),
+            None => (unsigned.as_bytes(), None),
+        };
+
+        let decimal = mantissa.iter().position(|byte| *byte == b'.');
+        let fractional_digits = decimal
+            .map(|index| mantissa.len().saturating_sub(index + 1))
+            .unwrap_or(0);
+
+        let first = mantissa.iter().position(|byte| matches!(byte, b'1'..=b'9'));
+        let Some(first) = first else {
+            return Some(Self {
+                mantissa,
+                first: 0,
+                last: 0,
+                exponent: 0,
+                negative,
+                zero: true,
+            });
+        };
+        let explicit_exponent = match exponent_text {
+            Some(text) => parse_exponent(text)?,
+            None => 0,
+        };
+        let last = mantissa
+            .iter()
+            .rposition(|byte| matches!(byte, b'1'..=b'9'))?;
+        let trailing_zeroes = mantissa[last + 1..]
+            .iter()
+            .filter(|byte| byte.is_ascii_digit())
+            .count();
+        let exponent = explicit_exponent
+            .checked_sub(i32::try_from(fractional_digits).ok()?)?
+            .checked_add(i32::try_from(trailing_zeroes).ok()?)?;
+
+        Some(Self {
+            mantissa,
+            first,
+            last,
+            exponent,
+            negative,
+            zero: false,
+        })
+    }
+
+    fn digits(&self) -> impl Iterator<Item = u8> + '_ {
+        self.mantissa[self.first..=self.last]
+            .iter()
+            .copied()
+            .filter(u8::is_ascii_digit)
+    }
+}
+
+fn parse_exponent(raw: &str) -> Option<i32> {
+    let (negative, digits) = match raw.as_bytes().first() {
+        Some(b'-') => (true, &raw[1..]),
+        Some(b'+') => (false, &raw[1..]),
+        _ => (false, raw),
+    };
+    if digits.is_empty() {
+        return None;
+    }
+    let mut value = 0i32;
+    for digit in digits.bytes() {
+        if !digit.is_ascii_digit() {
+            return None;
+        }
+        value = value
+            .checked_mul(10)?
+            .checked_add(i32::from(digit - b'0'))?;
+    }
+    Some(if negative { -value } else { value })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_lexeme_retains_head_and_tail() {
+        let raw = format!("{}e-{}", "1".repeat(200), "9".repeat(200));
+        let lexeme = NumericLexeme::new(&raw);
+        assert!(lexeme.is_truncated());
+        assert_eq!(lexeme.original_bytes(), raw.len());
+        assert!(lexeme.head().len() + lexeme.tail().len() <= MAX_NUMERIC_LEXEME_EVIDENCE_BYTES);
+    }
+
+    #[test]
+    fn decimal_equivalence_handles_exponents_without_hiding_precision_loss() {
+        assert!(same_decimal_value("1e3", "1000.0"));
+        assert!(same_decimal_value("0.1", "0.1"));
+        assert!(!same_decimal_value("0.10000000000000001", "0.1"));
+    }
+}

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -44,6 +44,9 @@ use crate::doc_index::DocArenaIndex;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
 use crate::multi_value::{SplitToRows, SplitToRowsMode, SplitValues, split_text_value};
+use crate::numeric_observation::{
+    NumericObservation, NumericObserver, NumericParserOutcome, observe_xml_scalar,
+};
 use crate::record_path::{RecordPath, RecordPathSyntax};
 use crate::source::{ReopenableSource, SourceIdentity};
 use crate::traits::FormatReader;
@@ -206,6 +209,9 @@ pub struct XmlReader {
     pending: VecDeque<Vec<(String, String)>>,
     /// Whether we've finished all records.
     done: bool,
+    /// Optional authoring-only sink receiving one bounded scalar observation
+    /// before XML inference becomes a record [`Value`].
+    numeric_observer: Option<NumericObserver>,
 }
 
 impl XmlReader {
@@ -223,6 +229,28 @@ impl XmlReader {
     pub fn from_source(
         source: ReopenableSource,
         config: XmlReaderConfig,
+    ) -> Result<Self, FormatError> {
+        Self::from_source_with_observer(source, config, None)
+    }
+
+    /// Build a streaming reader that publishes parser-owned scalar numeric
+    /// evidence before record-value conversion.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`from_source`](Self::from_source).
+    pub fn from_source_observing(
+        source: ReopenableSource,
+        config: XmlReaderConfig,
+        observer: NumericObserver,
+    ) -> Result<Self, FormatError> {
+        Self::from_source_with_observer(source, config, Some(observer))
+    }
+
+    fn from_source_with_observer(
+        source: ReopenableSource,
+        config: XmlReaderConfig,
+        numeric_observer: Option<NumericObserver>,
     ) -> Result<Self, FormatError> {
         // XML runs two passes (envelope pre-scan + body stream), so the source
         // must be re-openable. A `Path`/`Buffered` source passes through; a
@@ -250,6 +278,7 @@ impl XmlReader {
             xml_depth: 0,
             pending: VecDeque::new(),
             done: false,
+            numeric_observer,
         })
     }
 
@@ -272,6 +301,21 @@ impl XmlReader {
     ) -> Result<Self, FormatError> {
         let source = ReopenableSource::buffer(reader).map_err(FormatError::Io)?;
         Self::from_source(source, config)
+    }
+
+    /// Buffer a pathless XML source and publish numeric observations while it
+    /// streams.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`from_reader`](Self::from_reader).
+    pub fn from_reader_observing<R: Read + Send + 'static>(
+        reader: R,
+        config: XmlReaderConfig,
+        observer: NumericObserver,
+    ) -> Result<Self, FormatError> {
+        let source = ReopenableSource::buffer(reader).map_err(FormatError::Io)?;
+        Self::from_source_observing(source, config, observer)
     }
 
     /// Open a fresh `BufReader` from the source with a leading UTF-8 BOM
@@ -700,7 +744,11 @@ impl XmlReader {
         let mut columns: Vec<Box<str>> = Vec::with_capacity(fields.len());
         let mut values: Vec<Value> = Vec::with_capacity(fields.len());
         for (key, val) in fields {
-            let value = infer_value(&val);
+            let observation = observe_xml_scalar(&val);
+            let value = inferred_xml_value(&val, &observation);
+            if let Some(observer) = &self.numeric_observer {
+                observer.observe(&key, observation);
+            }
             match slot.get(key.as_str()) {
                 Some(&i) => match &mut values[i] {
                     // A repeated key on a `multiple:` column accumulates in
@@ -1242,18 +1290,12 @@ fn strip_leading_bom(reader: &mut BufReader<Box<dyn Read + Send>>) -> Result<(),
     Ok(())
 }
 
-/// Simple type inference from string values (same rules as JSON).
-fn infer_value(s: &str) -> Value {
-    if s.is_empty() {
-        return Value::Null;
-    }
-    if let Ok(i) = s.parse::<i64>() {
-        return Value::Integer(i);
-    }
-    if let Ok(f) = s.parse::<f64>()
-        && (s.contains('.') || s.contains('e') || s.contains('E'))
-    {
-        return Value::Float(f);
+fn inferred_xml_value(s: &str, observation: &NumericObservation) -> Value {
+    match observation.parser_outcome() {
+        NumericParserOutcome::NoValue => return Value::Null,
+        NumericParserOutcome::Integer(value) => return Value::Integer(*value),
+        NumericParserOutcome::Float(value) => return Value::Float(*value),
+        NumericParserOutcome::NonNumeric | NumericParserOutcome::Rejected(_) => {}
     }
     match s {
         "true" => Value::Bool(true),


### PR DESCRIPTION
## Summary

- add a parser-owned numeric observation that keeps the canonical parsed result together with bounded lexical evidence
- use the same observation path for JSON, XML, fixed-width/positional parsing, and schema coercion
- add differential tests proving inference sees the same numeric decision the real readers made across JSON array/NDJSON, XML, CSV, fixed-width, EDIFACT, X12, HL7, SWIFT, and multi-record inputs
- keep missing, explicit null, signed zero, lossy, and out-of-range states distinct

This is stacked on #1087 and provides the shared parsing boundary needed by the later schema-guessing command.

## Validation

- numeric observation unit tests — 2 passed
- `numeric_guess_parity` — 15 passed
- `cargo clippy -p clinker-format -p clinker-exec --tests --locked --offline -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

The focused gates were rerun after rebasing onto the current #1087 head.

## Runtime obligations

The observation carries a bounded head/tail lexeme and one canonical scalar result per value; it does not retain input-growing state. It does not change field values, routing, or execution lifecycle, so no lineage or telemetry additions are triggered.
