### PR TITLE
Add Sink telemetry and lineage coverage

### DIFF
--- a/crates/clinker-exec/src/executor/correlation_dispatch.rs
+++ b/crates/clinker-exec/src/executor/correlation_dispatch.rs
@@ -334,8 +334,24 @@ fn flush_clean_records_to_writers(
         if slots.is_empty() {
             continue;
         }
-        let slots = order_clean_slots(ctx, current_dag, &output_name, slots)?;
+        let mut signal = ctx.telemetry_producer.clone().map(|producer| {
+            let logical_node = ctx.qualified_node_name(&output_name);
+            crate::telemetry::SinkSignal::new(producer, logical_node.into_owned())
+        });
+        let slots = match order_clean_slots(ctx, current_dag, &output_name, slots) {
+            Ok(slots) => slots,
+            Err(error) => {
+                if let Some(mut signal) = signal.take() {
+                    signal.record_errors(1);
+                    signal.fail();
+                }
+                return Err(error);
+            }
+        };
         if slots.is_empty() {
+            if let Some(signal) = signal.take() {
+                signal.complete();
+            }
             continue;
         }
         let out_cfg = ctx
@@ -347,14 +363,23 @@ fn flush_clean_records_to_writers(
         for slot in &slots {
             if let Err(err) = structured_guard.observe(&output_name, slot.projected.doc_ctx()) {
                 ctx.output_errors.push(err);
+                if let Some(mut signal) = signal.take() {
+                    signal.record_errors(1);
+                    signal.fail();
+                }
                 continue 'outputs;
             }
         }
         let output_schema = Arc::clone(slots[0].projected.schema());
 
         let Some(raw_writer) = ctx.writers.remove(&output_name) else {
+            if let Some(mut signal) = signal.take() {
+                signal.record_records(u64::try_from(slots.len()).unwrap_or(u64::MAX));
+                signal.complete();
+            }
             continue;
         };
+        let errors_before = ctx.output_errors.len();
         match build_format_writer(
             out_cfg,
             raw_writer,
@@ -363,6 +388,7 @@ fn flush_clean_records_to_writers(
         ) {
             Ok(mut writer) => {
                 let mut write_failed = false;
+                let mut flush_failed = false;
                 let mut written_slots: Vec<&CorrelationRecordSlot> = Vec::new();
                 for slot in &slots {
                     let write_result = {
@@ -391,6 +417,7 @@ fn flush_clean_records_to_writers(
                     };
                     if let Err(e) = flush_result {
                         push_write_error(&mut ctx.output_errors, e);
+                        flush_failed = true;
                     } else if out_cfg.mapping.is_some() {
                         // Correlation records were projected before their group
                         // disposition. Observe only after this clean queue is
@@ -423,8 +450,24 @@ fn flush_clean_records_to_writers(
                 ctx.counters.ok_count += newly_ok;
                 ctx.counters.records_written += written;
                 ctx.records_emitted += written;
+                if let Some(mut signal) = signal.take() {
+                    signal.record_records(written);
+                    let new_errors = ctx.output_errors.len().saturating_sub(errors_before);
+                    signal.record_errors(u64::try_from(new_errors).unwrap_or(u64::MAX));
+                    if write_failed || flush_failed {
+                        signal.fail();
+                    } else {
+                        signal.complete();
+                    }
+                }
             }
-            Err(e) => ctx.output_errors.push(e),
+            Err(e) => {
+                ctx.output_errors.push(e);
+                if let Some(mut signal) = signal.take() {
+                    signal.record_errors(1);
+                    signal.fail();
+                }
+            }
         }
     }
     Ok(())

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1385,9 +1385,18 @@ impl PipelineExecutor {
                 crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone()),
             ));
             let writer_charge_handle = charge_handle.clone();
+            let telemetry_producer = params.telemetry_producer.clone();
             let handle = std::thread::Builder::new()
                 .name(format!("clinker-output-{output_name}"))
-                .spawn(move || streaming_sink(rx, raw_writer, spec, writer_charge_handle))
+                .spawn(move || {
+                    streaming_sink(
+                        rx,
+                        raw_writer,
+                        spec,
+                        writer_charge_handle,
+                        telemetry_producer,
+                    )
+                })
                 .map_err(|e| PipelineError::Internal {
                     op: "streaming-output-spawn",
                     node: output_name,

--- a/crates/clinker-exec/src/executor/sink_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sink_dispatch.rs
@@ -318,12 +318,7 @@ pub(crate) fn dispatch_sink<'borrow, 'plan>(
 where
     'plan: 'borrow,
 {
-    let PlanNode::Sink {
-        ref name,
-        ref resolved,
-        ..
-    } = *node
-    else {
+    let PlanNode::Sink { ref name, .. } = *node else {
         return Err(crate::executor::invariant::dispatch_mismatch(
             "dispatch_sink",
             "sink",
@@ -337,6 +332,55 @@ where
     };
     #[cfg(not(feature = "test-utils"))]
     let SinkDispatchContext::Live(ctx) = ctx.into();
+
+    // The streaming writer thread and correlation commit own their actual
+    // terminal work and close their Sink observations there. The topo-order
+    // Sink turn is respectively a no-op or a projection/buffering handoff, so
+    // reporting it here would emit a pre-write zero-record span and then miss
+    // the outcome that establishes the external bytes.
+    if ctx.streaming_sink_nodes.contains(&node_idx) || ctx.correlation_buffers.is_some() {
+        return dispatch_sink_work(ctx, current_dag, node_idx, node);
+    }
+
+    let mut signal = ctx.telemetry_producer.clone().map(|producer| {
+        let logical_node = ctx.qualified_node_name(name);
+        crate::telemetry::SinkSignal::new(producer, logical_node.into_owned())
+    });
+    let records_before = ctx.counters.records_written;
+    let errors_before = ctx.output_errors.len();
+    let result = dispatch_sink_work(ctx, current_dag, node_idx, node);
+    if let Some(mut signal) = signal.take() {
+        signal.record_records(ctx.counters.records_written.saturating_sub(records_before));
+        let new_errors = ctx.output_errors.len().saturating_sub(errors_before);
+        signal.record_errors(u64::try_from(new_errors).unwrap_or(u64::MAX));
+        if result.is_ok() && new_errors == 0 {
+            signal.complete();
+        } else {
+            signal.fail();
+        }
+    }
+    result
+}
+
+fn dispatch_sink_work(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    node: &PlanNode,
+) -> Result<(), PipelineError> {
+    let PlanNode::Sink {
+        ref name,
+        ref resolved,
+        ..
+    } = *node
+    else {
+        return Err(crate::executor::invariant::dispatch_mismatch(
+            "dispatch_sink",
+            "sink",
+            node.kind_name(),
+            node.name(),
+        ));
+    };
     let output_id = node.id();
     // Streaming-Sink short-circuit (issue #72). The executor
     // entry already moved this Sink's writer into a

--- a/crates/clinker-exec/src/executor/streaming.rs
+++ b/crates/clinker-exec/src/executor/streaming.rs
@@ -383,6 +383,10 @@ pub(super) fn drain_streaming_channel<C: StreamingConsumer>(
 struct SinkStreamConsumer {
     spec: StreamingSinkSpec,
     out: StreamingOutputTaskOutput,
+    /// Set only when channel disconnect reached the writer-finalization hook.
+    /// A fatal record error drains the channel without closing the writer work
+    /// unit, so its Sink observation must omit the completed metric.
+    closed_cleanly: bool,
     /// Pending `SchemaScan` timer, finished on the first writer build (or
     /// on close for the empty-stream case).
     scan_timer_slot: Option<stage_metrics::StageTimer>,
@@ -416,6 +420,7 @@ impl SinkStreamConsumer {
                 output_name,
                 out_cfg,
             },
+            closed_cleanly: false,
             scan_timer_slot: Some(stage_metrics::StageTimer::new(
                 stage_metrics::StageName::SchemaScan,
             )),
@@ -609,6 +614,7 @@ impl StreamingConsumer for SinkStreamConsumer {
                 self.out.errors.push(PipelineError::from(e));
             }
         }
+        self.closed_cleanly = true;
     }
 }
 
@@ -623,9 +629,22 @@ pub(super) fn streaming_sink(
     raw_writer: Box<dyn Write + Send>,
     spec: StreamingSinkSpec,
     charge_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
+    telemetry_producer: Option<crate::telemetry::TelemetryProducer>,
 ) -> StreamingOutputTaskOutput {
+    let mut signal = telemetry_producer
+        .map(|producer| crate::telemetry::SinkSignal::new(producer, spec.output_name.clone()));
     let mut consumer = SinkStreamConsumer::new(raw_writer, spec);
     drain_streaming_channel(&rx, &charge_handle, &mut consumer);
+    if let Some(mut signal) = signal.take() {
+        signal.record_records(consumer.out.records_written);
+        let errors = consumer.out.errors.len();
+        signal.record_errors(u64::try_from(errors).unwrap_or(u64::MAX));
+        if consumer.closed_cleanly && errors == 0 {
+            signal.complete();
+        } else {
+            signal.fail();
+        }
+    }
     consumer.out
 }
 

--- a/crates/clinker-exec/src/telemetry.rs
+++ b/crates/clinker-exec/src/telemetry.rs
@@ -120,14 +120,22 @@ pub enum MetricKey {
     TransformCompleted,
     TransformRecords,
     TransformErrors,
+    SinkStarted,
+    SinkCompleted,
+    SinkRecords,
+    SinkErrors,
 }
 
 impl MetricKey {
-    const ALL: [Self; 4] = [
+    const ALL: [Self; 8] = [
         Self::TransformStarted,
         Self::TransformCompleted,
         Self::TransformRecords,
         Self::TransformErrors,
+        Self::SinkStarted,
+        Self::SinkCompleted,
+        Self::SinkRecords,
+        Self::SinkErrors,
     ];
     const COUNT: usize = Self::ALL.len();
 
@@ -137,6 +145,10 @@ impl MetricKey {
             Self::TransformCompleted => 1,
             Self::TransformRecords => 2,
             Self::TransformErrors => 3,
+            Self::SinkStarted => 4,
+            Self::SinkCompleted => 5,
+            Self::SinkRecords => 6,
+            Self::SinkErrors => 7,
         }
     }
 }
@@ -146,6 +158,7 @@ impl MetricKey {
 #[serde(rename_all = "snake_case")]
 pub enum SpanName {
     Transform,
+    Sink,
 }
 
 /// Bounded span result fact.
@@ -164,7 +177,7 @@ pub enum SpanStatus {
 /// end fact, because a collector has no representation for half a span: both
 /// wall-clock boundaries are required, and independent admission of two halves
 /// lets sampling, lane routing, or a full arena deliver one without the other.
-/// The live "this transform has begun" signal is the `TransformStarted`
+/// The live "this work has begun" signal is the corresponding `*Started`
 /// metric, which is still recorded before the work runs.
 #[derive(Clone, Copy, Debug)]
 pub struct SpanFact<'a> {
@@ -179,6 +192,111 @@ pub struct SpanFact<'a> {
     /// Span boundaries as Unix nanoseconds, `started_at <= ended_at`.
     pub started_at_unix_nanos: u64,
     pub ended_at_unix_nanos: u64,
+}
+
+/// One terminal Sink work unit's fixed-cardinality lifecycle observation.
+///
+/// Construction records the live start metric. Completion records aggregate
+/// record/error counts, one completion metric, and one closed span. Dropping
+/// an unfinished observation records a bounded error outcome and an error span,
+/// which covers `?` propagation and panic unwinding without making telemetry
+/// admission part of execution control flow.
+pub(crate) struct SinkSignal {
+    producer: TelemetryProducer,
+    logical_node: Box<str>,
+    started_at_unix_nanos: u64,
+    records: u64,
+    errors: u64,
+    closed: bool,
+}
+
+impl SinkSignal {
+    /// Begin one Sink work unit. The caller constructs this immediately before
+    /// the runtime owner starts the work, never at a dispatch placeholder whose
+    /// bytes are emitted elsewhere.
+    pub(crate) fn new(producer: TelemetryProducer, logical_node: impl Into<Box<str>>) -> Self {
+        let started_at_unix_nanos = unix_nanos_now();
+        producer.record_metric(MetricKey::SinkStarted, 1);
+        Self {
+            producer,
+            logical_node: logical_node.into(),
+            started_at_unix_nanos,
+            records: 0,
+            errors: 0,
+            closed: false,
+        }
+    }
+
+    /// Add records handled by this work unit, using saturating arithmetic so
+    /// observability cannot overflow into execution behavior.
+    pub(crate) fn record_records(&mut self, records: u64) {
+        self.records = self.records.saturating_add(records);
+    }
+
+    /// Add errors observed by this work unit.
+    pub(crate) fn record_errors(&mut self, errors: u64) {
+        self.errors = self.errors.saturating_add(errors);
+    }
+
+    /// Close a work unit that reached its runtime completion boundary.
+    pub(crate) fn complete(mut self) {
+        let status = if self.errors == 0 {
+            SpanStatus::Ok
+        } else {
+            SpanStatus::Error
+        };
+        self.emit_counts();
+        self.producer.record_metric(MetricKey::SinkCompleted, 1);
+        self.close_span(status);
+    }
+
+    /// Close a work unit that returned a failure before completion.
+    pub(crate) fn fail(mut self) {
+        if self.errors == 0 {
+            self.errors = 1;
+        }
+        self.emit_counts();
+        self.close_span(SpanStatus::Error);
+    }
+
+    fn emit_counts(&self) {
+        if self.records > 0 {
+            self.producer
+                .record_metric(MetricKey::SinkRecords, self.records);
+        }
+        if self.errors > 0 {
+            self.producer
+                .record_metric(MetricKey::SinkErrors, self.errors);
+        }
+    }
+
+    fn close_span(&mut self, status: SpanStatus) {
+        if self.closed {
+            return;
+        }
+        let ended_at_unix_nanos = unix_nanos_now().max(self.started_at_unix_nanos);
+        let _ = self.producer.emit_span(SpanFact {
+            name: SpanName::Sink,
+            status,
+            logical_node: &self.logical_node,
+            started_at_unix_nanos: self.started_at_unix_nanos,
+            ended_at_unix_nanos,
+        });
+        self.closed = true;
+    }
+}
+
+impl Drop for SinkSignal {
+    fn drop(&mut self) {
+        if self.closed {
+            return;
+        }
+        if self.errors == 0 {
+            self.errors = 1;
+        }
+        self.emit_counts();
+        self.close_span(SpanStatus::Error);
+    }
 }
 
 impl Serialize for SpanFact<'_> {

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -768,12 +768,41 @@ fn walk_scope(
                 cols
             }
 
-            PlanNode::Sink { .. } => {
+            PlanNode::Sink { resolved, .. } => {
                 let up = single_upstream(dag, idx);
                 let mut cols = ColumnTerminals::new();
-                for_each_output_col(node, dag, |col| {
-                    cols.insert_nonempty(col, passthrough(&lineage, up, col));
-                });
+                let output = resolved.as_deref().map(|payload| &payload.output);
+                let excluded = |col: &str| {
+                    output
+                        .and_then(|output| output.exclude.as_ref())
+                        .is_some_and(|exclude| exclude.iter().any(|name| name == col))
+                };
+                if let Some(mapping) = output.and_then(|output| output.mapping.as_ref()) {
+                    for entry in mapping.entries() {
+                        if !excluded(&entry.source) {
+                            cols.insert_nonempty(
+                                &entry.output,
+                                passthrough(&lineage, up, &entry.source),
+                            );
+                        }
+                    }
+                    if output.is_some_and(|output| output.include_unmapped) {
+                        for_each_output_col(node, dag, |col| {
+                            if !excluded(col)
+                                && !mapping.claims_source(col)
+                                && !mapping.claims_output(col)
+                            {
+                                cols.insert_nonempty(col, passthrough(&lineage, up, col));
+                            }
+                        });
+                    }
+                } else {
+                    for_each_output_col(node, dag, |col| {
+                        if !excluded(col) {
+                            cols.insert_nonempty(col, passthrough(&lineage, up, col));
+                        }
+                    });
+                }
                 cols
             }
 
@@ -2102,6 +2131,25 @@ fn node_indirect_influence(
                 );
             }
         }
+        PlanNode::Sink { resolved, .. } => {
+            let up = single_upstream(dag, idx);
+            if let Some(sort_fields) = resolved
+                .as_deref()
+                .and_then(|payload| payload.output.sort_order.as_deref())
+            {
+                for sf in sort_fields {
+                    let field = match sf {
+                        clinker_plan::config::SortFieldSpec::Short(field) => field.as_str(),
+                        clinker_plan::config::SortFieldSpec::Full(field) => field.field.as_str(),
+                    };
+                    add_upstream_influence(
+                        &mut inf,
+                        upstream_col(lineage, up, field),
+                        IndirectSub::Sort,
+                    );
+                }
+            }
+        }
         PlanNode::Reshape { compiled_rules, .. } => {
             // A `when:` trigger cannot read `$doc`: the planner rejects any
             // envelope reference in a Reshape rule (E200, see `bind_reshape`), so
@@ -2504,7 +2552,7 @@ nodes:
         emit salary = salary
         emit full = name
         emit tier = if salary.to_int() >= 90000 then "senior" else "junior"
-  - type: output
+  - type: sink
     name: out
     input: proj
     config: { name: out, type: csv, path: out/t.csv }
@@ -2554,7 +2602,7 @@ nodes:
       cxl: |
         emit a = a
         emit k = "literal"
-  - type: output
+  - type: sink
     name: out
     input: t
     config: { name: out, type: csv, path: out/k.csv }
@@ -2591,7 +2639,7 @@ nodes:
     config:
       cxl: |
         emit final = mid
-  - type: output
+  - type: sink
     name: out
     input: t2
     config: { name: out, type: csv, path: out/chain.csv }
@@ -2631,7 +2679,7 @@ nodes:
     name: t
     input: rows
     config: { cxl: "emit city = addr.city" }
-  - type: output
+  - type: sink
     name: out
     input: t
     config:
@@ -2690,7 +2738,7 @@ nodes:
       on_miss: skip
       cxl: "emit out = a.k"
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: j
     config: { name: out, type: csv, path: out/cr.csv }
@@ -2737,7 +2785,7 @@ nodes:
           let total = it
         }
         emit out = total
-  - type: output
+  - type: sink
     name: out
     input: t
     config:
@@ -2787,11 +2835,11 @@ nodes:
       mode: exclusive
       conditions: { high: "amount > 100" }
       default: low
-  - type: output
+  - type: sink
     name: hi
     input: split.high
     config: { name: hi, type: csv, path: out/hi.csv }
-  - type: output
+  - type: sink
     name: lo
     input: split.low
     config: { name: lo, type: csv, path: out/lo.csv }
@@ -2847,11 +2895,11 @@ nodes:
       rules:
         - name: drop_big
           drop_group_when: "sum(amount) > 100"
-  - type: output
+  - type: sink
     name: out
     input: trim
     config: { name: out, type: csv, path: out/c.csv }
-  - type: output
+  - type: sink
     name: audit
     input: trim.removed
     config: { name: audit, type: csv, path: out/audit.csv }
@@ -2894,7 +2942,7 @@ nodes:
       cxl: |
         emit region = region
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: agg
     config: { name: out, type: csv, path: out/a.csv }
@@ -2948,7 +2996,7 @@ nodes:
         emit order_id = orders.order_id
         emit actor = events.actor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config: { name: out, type: csv, path: out/c.csv }
@@ -2993,7 +3041,7 @@ nodes:
           mutate:
             set:
               plan_end: "plan_start"
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config: { name: out, type: csv, path: out/r.csv }
@@ -3051,7 +3099,7 @@ nodes:
       cxl: |
         emit oid = orders.order_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config: { name: out, type: csv, path: out/cs.csv }
@@ -3103,11 +3151,11 @@ nodes:
       cxl: |
         emit region = region
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: agg
     config: { name: out, type: csv, path: out/acc.csv }
-  - type: output
+  - type: sink
     name: audit
     input: trim.removed
     config: { name: audit, type: csv, path: out/audit.csv }
@@ -3151,7 +3199,7 @@ nodes:
       cxl: |
         let x = a + b
         emit y = x
-  - type: output
+  - type: sink
     name: out
     input: t
     config: { name: out, type: csv, path: out/letbind.csv }
@@ -3194,7 +3242,7 @@ nodes:
         emit each it in items {
           emit sku = it["sku"]
         }
-  - type: output
+  - type: sink
     name: out
     input: explode
     config:
@@ -3242,7 +3290,7 @@ nodes:
       cxl: |
         emit price = list_price
         emit price = sale_price
-  - type: output
+  - type: sink
     name: out
     input: t
     config: { name: out, type: csv, path: out/dup.csv }
@@ -3286,7 +3334,7 @@ nodes:
         emit region = region
         emit total = sum(amount.to_int())
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: agg
     config: { name: out, type: csv, path: out/a.csv }
@@ -3362,7 +3410,7 @@ nodes:
           mutate:
             set:
               plan_end: "plan_start"
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config: { name: out, type: csv, path: out/r.csv }
@@ -3434,7 +3482,7 @@ nodes:
         emit amount = orders.amount
         emit actor = events.actor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config: { name: out, type: csv, path: out/c.csv }
@@ -3524,7 +3572,7 @@ nodes:
         emit product_name = products.product_name
         emit category_name = categories.category_name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config: { name: out, type: csv, path: out/nary.csv }
@@ -3595,7 +3643,7 @@ nodes:
         emit c_val = c.c_val
         emit d_val = d.d_val
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: j
     config: { name: out, type: csv, path: out/four.csv }
@@ -3657,7 +3705,7 @@ nodes:
         emit emp_name = e.name
         emit mgr_name = m.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: pairs
     config: { name: out, type: csv, path: out/selfjoin.csv }
@@ -3714,7 +3762,7 @@ nodes:
     input: payments
     config:
       cxl: |
-{indented}  - type: output
+{indented}  - type: sink
     name: out
     input: tag
     config: {{ name: out, type: csv, path: out/env.csv }}
@@ -3853,7 +3901,7 @@ nodes:
         emit k = drv.k
         emit batch = $doc.BatchInfo.batch_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: j
     config: { name: out, type: csv, path: out/cdoc.csv }
@@ -3943,7 +3991,7 @@ nodes:
         emit tag = tag
         emit declared = $doc.basic.body
         emit ghost = $doc.nope.body
-  - type: output
+  - type: sink
     name: out
     input: tag
     config: { name: out, type: csv, path: out/swiftdoc.csv }
@@ -4030,7 +4078,7 @@ nodes:
         emit k = a.k
         emit head = $doc.Head.x
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: j
     config: { name: out, type: csv, path: out/narydoc.csv }
@@ -4086,7 +4134,7 @@ nodes:
         emit region = region
         emit total = sum(amount)
         emit batch = $doc.Head.batch_id
-  - type: output
+  - type: sink
     name: out
     input: agg
     config: { name: out, type: csv, path: out/aggdoc.csv }
@@ -4137,7 +4185,7 @@ nodes:
       cxl: |
         emit region = region
         emit weighted = sum(amount * $doc.Head.fx_rate)
-  - type: output
+  - type: sink
     name: out
     input: agg
     config: { name: out, type: csv, path: out/aggdocarg.csv }
@@ -4197,7 +4245,7 @@ nodes:
           mutate:
             set:
               tag: "$doc.Head.batch_id"
-  - type: output
+  - type: sink
     name: out
     input: tagit
     config: { name: out, type: csv, path: out/rsdoc.csv }
@@ -4244,11 +4292,11 @@ nodes:
       mode: exclusive
       conditions: { high: "amount > $doc.Head.threshold" }
       default: low
-  - type: output
+  - type: sink
     name: hi
     input: split.high
     config: { name: hi, type: csv, path: out/hi.csv }
-  - type: output
+  - type: sink
     name: lo
     input: split.low
     config: { name: lo, type: csv, path: out/lo.csv }
@@ -4316,7 +4364,7 @@ nodes:
       cxl: |
         emit k = drv.k
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: j
     config: { name: out, type: csv, path: out/cjdoc.csv }
@@ -4369,11 +4417,11 @@ nodes:
       rules:
         - name: drop_over_budget
           drop_group_when: "sum(amount) > $doc.Head.threshold"
-  - type: output
+  - type: sink
     name: out
     input: trim
     config: { name: out, type: csv, path: out/cudoc.csv }
-  - type: output
+  - type: sink
     name: audit
     input: trim.removed
     config: { name: audit, type: csv, path: out/audit.csv }
@@ -4441,7 +4489,7 @@ nodes:
         emit batch_id = batch_id
         emit id = id
         emit amount = amount
-  - type: output
+  - type: sink
     name: out
     input: project
     config: { name: out, type: csv, path: out/out.csv }
@@ -4508,7 +4556,7 @@ nodes:
         emit seq = seq
         emit a_only = a_only
         emit b_only = b_only
-  - type: output
+  - type: sink
     name: out
     input: project
     config: { name: out, type: csv, path: out/out.csv }
@@ -4568,7 +4616,7 @@ nodes:
       cxl: |
         emit id = id
         emit name = name
-  - type: output
+  - type: sink
     name: out
     input: project
     config: { name: out, type: csv, path: out/out.csv }
@@ -4605,7 +4653,7 @@ nodes:
     config:
       cxl: |
         emit seg = seg_id
-  - type: output
+  - type: sink
     name: out
     input: project
     config: { name: out, type: csv, path: out/out.csv }
@@ -4652,7 +4700,7 @@ nodes:
       cxl: |
         emit rt = record_type
         emit payload = payload
-  - type: output
+  - type: sink
     name: out
     input: project
     config: { name: out, type: csv, path: out/out.csv }

--- a/crates/clinker-lineage/src/dataset.rs
+++ b/crates/clinker-lineage/src/dataset.rs
@@ -121,7 +121,7 @@ impl From<DatasetId> for Dataset {
 ///
 /// `base_dir` is the workspace root — the directory containing the pipeline
 /// YAML, the same `base_dir` `clinker_plan`'s discovery layer takes. A
-/// Source/Output whose resolved payload is unavailable (e.g. after a serde
+/// Source/Sink whose resolved payload is unavailable (e.g. after a serde
 /// round-trip, since the payload is `#[serde(skip)]`) falls back to the
 /// [`FALLBACK_NAMESPACE`] plus the node name rather than inventing a path.
 pub fn dataset_identity(node: &PlanNode, base_dir: &Path) -> Option<DatasetId> {

--- a/crates/clinker/src/observability/export.rs
+++ b/crates/clinker/src/observability/export.rs
@@ -1649,12 +1649,17 @@ fn metric_name(key: MetricKey) -> &'static str {
         MetricKey::TransformCompleted => "clinker.transform.completed",
         MetricKey::TransformRecords => "clinker.transform.records",
         MetricKey::TransformErrors => "clinker.transform.errors",
+        MetricKey::SinkStarted => "clinker.sink.started",
+        MetricKey::SinkCompleted => "clinker.sink.completed",
+        MetricKey::SinkRecords => "clinker.sink.records",
+        MetricKey::SinkErrors => "clinker.sink.errors",
     }
 }
 
 fn span_name(name: SpanName) -> &'static str {
     match name {
         SpanName::Transform => "clinker.transform",
+        SpanName::Sink => "clinker.sink",
     }
 }
 
@@ -1896,6 +1901,26 @@ mod tests {
         envelope["resourceSpans"][0]["scopeSpans"][0]["spans"]
             .as_array()
             .expect("spans")
+    }
+
+    #[test]
+    fn sink_metric_and_span_names_are_stable_and_complete() {
+        assert_eq!(
+            [
+                MetricKey::SinkStarted,
+                MetricKey::SinkCompleted,
+                MetricKey::SinkRecords,
+                MetricKey::SinkErrors,
+            ]
+            .map(metric_name),
+            [
+                "clinker.sink.started",
+                "clinker.sink.completed",
+                "clinker.sink.records",
+                "clinker.sink.errors",
+            ]
+        );
+        assert_eq!(span_name(SpanName::Sink), "clinker.sink");
     }
 
     /// Flatten one OTLP `KeyValue` list into the string attributes it carries.

--- a/crates/clinker/tests/sink_surface.rs
+++ b/crates/clinker/tests/sink_surface.rs
@@ -1,0 +1,595 @@
+//! Sink-specific observability and lineage contract tests.
+
+use std::collections::HashMap;
+use std::io::{self, Cursor, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use clinker_exec::executor::{
+    PipelineExecutor, PipelineRunParams, SourceReaders, single_file_reader,
+};
+use clinker_exec::telemetry::{
+    MetricKey, SpanFact, SpanName, SpanStatus, TelemetryArena, TelemetryProducer,
+    TelemetryReceiver, TraceSpan, unix_nanos_now,
+};
+use clinker_lineage::logical_identity::{
+    ExternalDatasetIdentity, LineageIdentityContext, LineageNodeBinding,
+};
+use clinker_lineage::{
+    OutputColumnLineage, TransformationSubtype, TransformationType, column_lineage_external,
+    column_lineage_local_diagnostic_paths,
+};
+use clinker_plan::config::{ClinkerToml, CompileContext, parse_config};
+use clinker_plan::error::PipelineError;
+
+const INPUT: &str = "id,label\n2,beta\n1,alpha\n";
+
+const SYNC_PIPELINE: &str = r#"
+pipeline: { name: sink_sync }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: input.csv
+      schema:
+        - { name: id, type: int }
+        - { name: label, type: string }
+  - type: sink
+    name: delivered
+    input: rows
+    config:
+      name: delivered
+      type: csv
+      path: delivered.csv
+      sort_order: [id]
+"#;
+
+const STREAMING_PIPELINE: &str = r#"
+pipeline: { name: sink_streaming }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: input.csv
+      schema:
+        - { name: id, type: int }
+        - { name: label, type: string }
+  - type: transform
+    name: shape
+    input: rows
+    config:
+      cxl: |
+        emit id = id
+        emit label = label
+  - type: sink
+    name: delivered
+    input: shape
+    config:
+      name: delivered
+      type: csv
+      path: delivered.csv
+"#;
+
+const CORRELATED_PIPELINE: &str = r#"
+pipeline: { name: sink_correlated }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: input.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: int }
+        - { name: label, type: string }
+  - type: sink
+    name: delivered
+    input: rows
+    config:
+      name: delivered
+      type: csv
+      path: delivered.csv
+"#;
+
+#[derive(Clone, Default)]
+struct SharedBuffer(Arc<Mutex<Vec<u8>>>);
+
+impl SharedBuffer {
+    fn bytes(&self) -> Vec<u8> {
+        self.0.lock().expect("buffer lock").clone()
+    }
+}
+
+impl Write for SharedBuffer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("buffer lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct FailingWriter;
+
+impl Write for FailingWriter {
+    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+        Err(io::Error::other("fixture writer refused bytes"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Err(io::Error::other("fixture writer refused flush"))
+    }
+}
+
+fn observability_policy() -> clinker_plan::config::ResolvedObservabilityPolicy {
+    ClinkerToml::parse(
+        r#"
+[observability]
+arena_bytes = "64KB"
+ordinary_lane_bytes = "32KB"
+high_severity_lane_bytes = "32KB"
+max_batch_bytes = "4KB"
+max_attributes_per_event = 4
+max_attribute_bytes = "256B"
+drop_policy = "drop_newest"
+sample_every = 1
+rate_limit_per_second = 100000
+rate_limit_burst = 100000
+flush_timeout_ms = 1000
+
+[observability.otlp]
+endpoint = "https://collector.invalid"
+connect_timeout_ms = 100
+request_timeout_ms = 200
+retry_max_attempts = 1
+retry_total_timeout_ms = 500
+max_response_bytes = "1KB"
+
+[observability.otlp.auth]
+mode = "none"
+"#,
+    )
+    .expect("telemetry policy parses")
+    .resolve_observability(None)
+    .expect("telemetry policy resolves")
+}
+
+fn readers() -> SourceReaders {
+    HashMap::from([(
+        "rows".to_string(),
+        single_file_reader(
+            "input.csv",
+            Box::new(Cursor::new(INPUT.as_bytes().to_vec())),
+        ),
+    )])
+}
+
+fn params(producer: TelemetryProducer) -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "sink-surface-execution".to_string(),
+        batch_id: "sink-surface-batch".to_string(),
+        telemetry_producer: Some(producer),
+        ..PipelineRunParams::default()
+    }
+}
+
+fn compile(yaml: &str) -> clinker_plan::plan::CompiledPlan {
+    parse_config(yaml)
+        .expect("pipeline parses")
+        .compile(&CompileContext::default())
+        .expect("pipeline compiles")
+}
+
+fn run_with_writer(
+    yaml: &str,
+    writer: Box<dyn Write + Send>,
+    producer: TelemetryProducer,
+) -> Result<clinker_exec::executor::ExecutionReport, PipelineError> {
+    let writers: HashMap<String, Box<dyn Write + Send>> =
+        HashMap::from([("delivered".to_string(), writer)]);
+    PipelineExecutor::run_plan_with_readers_writers(
+        &compile(yaml),
+        readers(),
+        writers,
+        &params(producer),
+    )
+}
+
+#[derive(Debug, Default)]
+struct SinkTelemetry {
+    started: u64,
+    completed: u64,
+    records: u64,
+    errors: u64,
+    spans: Vec<TraceSpan>,
+}
+
+fn drain_sink(receiver: &TelemetryReceiver) -> SinkTelemetry {
+    let mut sink = SinkTelemetry::default();
+    while let Some(batch) = receiver.try_recv_batch() {
+        sink.started += batch.metric(MetricKey::SinkStarted);
+        sink.completed += batch.metric(MetricKey::SinkCompleted);
+        sink.records += batch.metric(MetricKey::SinkRecords);
+        sink.errors += batch.metric(MetricKey::SinkErrors);
+        sink.spans.extend(
+            batch
+                .traces()
+                .iter()
+                .filter(|span| span.name == SpanName::Sink)
+                .cloned(),
+        );
+    }
+    sink
+}
+
+fn assert_success_signals(actual: &SinkTelemetry, records: u64) {
+    assert_eq!(actual.started, 1, "one real Sink work unit starts");
+    assert_eq!(actual.completed, 1, "the work unit reaches completion");
+    assert_eq!(actual.records, records, "records count handled Sink rows");
+    assert_eq!(actual.errors, 0, "the successful Sink reports no errors");
+    assert_eq!(actual.spans.len(), 1, "one work unit has one closed span");
+    assert_eq!(actual.spans[0].status, SpanStatus::Ok);
+    assert_eq!(actual.spans[0].logical_node, "delivered");
+    assert!(
+        actual.spans[0].ended_at_unix_nanos >= actual.spans[0].started_at_unix_nanos,
+        "the complete span is closed at both ends"
+    );
+}
+
+#[test]
+fn telemetry_sync_sink_reports_the_completed_writer_work() {
+    let (producer, receiver) = TelemetryArena::reserve(&observability_policy()).expect("arena");
+    let output = SharedBuffer::default();
+    let report = run_with_writer(SYNC_PIPELINE, Box::new(output.clone()), producer)
+        .expect("synchronous Sink succeeds");
+
+    assert_eq!(report.counters.records_written, 2);
+    assert_eq!(output.bytes(), b"id,label\n1,alpha\n2,beta\n");
+    assert_success_signals(&drain_sink(&receiver), 2);
+}
+
+#[test]
+fn telemetry_streaming_sink_reports_the_writer_thread_work_once() {
+    let (producer, receiver) = TelemetryArena::reserve(&observability_policy()).expect("arena");
+    let output = SharedBuffer::default();
+    let report = run_with_writer(STREAMING_PIPELINE, Box::new(output.clone()), producer)
+        .expect("streaming Sink succeeds");
+
+    assert_eq!(report.counters.records_written, 2);
+    assert_eq!(output.bytes(), b"id,label\n2,beta\n1,alpha\n");
+    assert_success_signals(&drain_sink(&receiver), 2);
+}
+
+#[test]
+fn telemetry_correlation_sink_reports_the_deferred_writer_work_once() {
+    let (producer, receiver) = TelemetryArena::reserve(&observability_policy()).expect("arena");
+    let output = SharedBuffer::default();
+    let report = run_with_writer(CORRELATED_PIPELINE, Box::new(output.clone()), producer)
+        .expect("correlation-deferred Sink succeeds");
+
+    assert_eq!(report.counters.records_written, 2);
+    assert_eq!(output.bytes(), b"id,label\n1,alpha\n2,beta\n");
+    assert_success_signals(&drain_sink(&receiver), 2);
+}
+
+#[test]
+fn telemetry_sink_failure_has_one_error_span_and_no_completion() {
+    let (producer, receiver) = TelemetryArena::reserve(&observability_policy()).expect("arena");
+    let result = run_with_writer(SYNC_PIPELINE, Box::new(FailingWriter), producer);
+    assert!(
+        result.is_err(),
+        "the writer failure must remain a run failure"
+    );
+
+    let actual = drain_sink(&receiver);
+    assert_eq!(actual.started, 1);
+    assert_eq!(actual.completed, 0, "failed work did not complete");
+    assert_eq!(
+        actual.records, 2,
+        "both rows reached the buffered writer before its flush failed"
+    );
+    assert!(
+        actual.errors >= 1,
+        "the writer failure is counted: {actual:?}"
+    );
+    assert_eq!(actual.spans.len(), 1);
+    assert_eq!(actual.spans[0].status, SpanStatus::Error);
+}
+
+#[test]
+fn telemetry_full_arena_cannot_change_sink_bytes_or_exit_status() {
+    let (producer, receiver) = TelemetryArena::reserve(&observability_policy()).expect("arena");
+    let now = unix_nanos_now();
+    while producer.snapshot().ordinary_full_drops == 0 {
+        let _ = producer.emit_span(SpanFact {
+            name: SpanName::Transform,
+            status: SpanStatus::Ok,
+            logical_node: "arena-prefill-transform-with-a-bounded-engine-identity",
+            started_at_unix_nanos: now,
+            ended_at_unix_nanos: now,
+        });
+    }
+    let drops_before = producer.snapshot().ordinary_full_drops;
+    let output = SharedBuffer::default();
+    let report = run_with_writer(SYNC_PIPELINE, Box::new(output.clone()), producer.clone())
+        .expect("telemetry admission loss cannot fail the Sink");
+
+    assert_eq!(report.counters.records_written, 2);
+    assert_eq!(output.bytes(), b"id,label\n1,alpha\n2,beta\n");
+    assert!(producer.snapshot().ordinary_full_drops > drops_before);
+    let actual = drain_sink(&receiver);
+    assert_eq!(
+        actual.started, 1,
+        "fixed metrics remain coalesced out of lane"
+    );
+    assert_eq!(actual.completed, 1);
+    assert_eq!(actual.records, 2);
+    assert!(
+        actual.spans.is_empty(),
+        "the full ordinary lane drops the optional Sink span"
+    );
+}
+
+fn local_lineage(yaml: &str) -> clinker_lineage::PlanColumnLineage {
+    column_lineage_local_diagnostic_paths(&compile(yaml), Path::new("/workspace"))
+}
+
+fn output_named<'a>(
+    lineage: &'a clinker_lineage::PlanColumnLineage,
+    suffix: &str,
+) -> &'a OutputColumnLineage {
+    lineage
+        .outputs
+        .iter()
+        .find(|output| output.dataset.name.ends_with(suffix))
+        .unwrap_or_else(|| panic!("missing output dataset ending in {suffix:?}"))
+}
+
+fn has_influence(
+    output: &OutputColumnLineage,
+    field: &str,
+    subtype: TransformationSubtype,
+) -> bool {
+    output.facet.dataset.iter().any(|input| {
+        input.field == field
+            && input.transformations.iter().any(|transformation| {
+                transformation.transformation_type == TransformationType::Indirect
+                    && transformation.subtype == Some(subtype)
+            })
+    })
+}
+
+#[test]
+fn lineage_sink_mapping_reads_the_renamed_source_column_directly() {
+    let lineage = local_lineage(
+        r#"
+pipeline: { name: mapped_sink_lineage }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: data/input.csv
+      schema:
+        - { name: customer_id, type: string }
+        - { name: region, type: string }
+  - type: sink
+    name: delivered
+    input: rows
+    config:
+      name: delivered
+      type: csv
+      path: out/mapped.csv
+      mapping:
+        - sold_to: customer_id
+      include_unmapped: false
+"#,
+    );
+    let output = output_named(&lineage, "out/mapped.csv");
+    let sold_to = output
+        .facet
+        .fields
+        .get("sold_to")
+        .expect("mapped output column has lineage");
+    assert_eq!(sold_to.input_fields.len(), 1);
+    assert_eq!(sold_to.input_fields[0].field, "customer_id");
+    assert_eq!(
+        sold_to.input_fields[0].transformations[0].transformation_type,
+        TransformationType::Direct
+    );
+    assert_eq!(
+        sold_to.input_fields[0].transformations[0].subtype,
+        Some(TransformationSubtype::Identity)
+    );
+}
+
+#[test]
+fn lineage_sink_preserves_filter_and_authored_order_influence() {
+    let lineage = local_lineage(
+        r#"
+pipeline: { name: filtered_ordered_sink_lineage }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: data/input.csv
+      schema:
+        - { name: id, type: int }
+        - { name: amount, type: int }
+  - type: route
+    name: selected
+    input: rows
+    config:
+      mode: exclusive
+      conditions: { kept: "amount > 100" }
+      default: rejected
+  - type: sink
+    name: delivered
+    input: selected.kept
+    config:
+      name: delivered
+      type: csv
+      path: out/ordered.csv
+      sort_order: [id]
+"#,
+    );
+    let output = output_named(&lineage, "out/ordered.csv");
+    assert!(has_influence(
+        output,
+        "amount",
+        TransformationSubtype::Filter
+    ));
+    assert!(has_influence(output, "id", TransformationSubtype::Sort));
+}
+
+#[test]
+fn lineage_sink_fan_out_keeps_each_branch_filter_influence() {
+    let lineage = local_lineage(
+        r#"
+pipeline: { name: fan_out_sink_lineage }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: data/input.csv
+      schema:
+        - { name: id, type: int }
+        - { name: amount, type: int }
+  - type: route
+    name: split
+    input: rows
+    config:
+      mode: exclusive
+      conditions: { high: "amount > 100" }
+      default: low
+  - type: sink
+    name: high
+    input: split.high
+    config: { name: high, type: csv, path: out/high.csv }
+  - type: sink
+    name: low
+    input: split.low
+    config: { name: low, type: csv, path: out/low.csv }
+"#,
+    );
+    assert_eq!(lineage.outputs.len(), 2);
+    for suffix in ["out/high.csv", "out/low.csv"] {
+        assert!(has_influence(
+            output_named(&lineage, suffix),
+            "amount",
+            TransformationSubtype::Filter
+        ));
+    }
+}
+
+fn binding(node: &str, dataset: &str) -> LineageNodeBinding {
+    LineageNodeBinding::new(
+        node,
+        ExternalDatasetIdentity::catalog("analytics", dataset).expect("catalog identity"),
+    )
+}
+
+#[test]
+fn lineage_two_body_scoped_sinks_keep_distinct_external_identities() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let compositions = workspace.path().join("compositions");
+    std::fs::create_dir_all(&compositions).expect("composition directory");
+    std::fs::write(
+        compositions.join("audit.comp.yaml"),
+        r#"_compose:
+  name: audit
+  inputs:
+    inp:
+      schema:
+        - { name: id, type: int }
+  outputs:
+    out: shape
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: shape
+    input: inp
+    config:
+      cxl: "emit id = id"
+  - type: sink
+    name: audit
+    input: shape
+    config: { name: audit, type: csv, path: audit.csv }
+"#,
+    )
+    .expect("write composition");
+    std::fs::create_dir_all(workspace.path().join("pipelines")).expect("pipeline directory");
+    let config = parse_config(
+        r#"
+pipeline: { name: scoped_sink_lineage }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: data/input.csv
+      schema:
+        - { name: id, type: int }
+  - type: composition
+    name: first
+    input: rows
+    use: ../compositions/audit.comp.yaml
+    inputs: { inp: rows }
+  - type: composition
+    name: second
+    input: rows
+    use: ../compositions/audit.comp.yaml
+    inputs: { inp: rows }
+  - type: sink
+    name: published
+    input: first
+    config: { name: published, type: csv, path: published.csv }
+"#,
+    )
+    .expect("pipeline parses");
+    let compiled = config
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace.path(),
+            PathBuf::from("pipelines"),
+        ))
+        .expect("pipeline compiles");
+    let identities = LineageIdentityContext::external([
+        binding("rows", "source_rows"),
+        binding("first.audit", "first_audit"),
+        binding("second.audit", "second_audit"),
+        binding("published", "published_rows"),
+    ])
+    .expect("identity context");
+    let lineage = column_lineage_external(&compiled, &identities).expect("external lineage");
+    let mut outputs: Vec<&str> = lineage
+        .outputs
+        .iter()
+        .map(|output| output.dataset.name.as_str())
+        .collect();
+    outputs.sort_unstable();
+    assert_eq!(outputs, ["first_audit", "published_rows", "second_audit"]);
+    for dataset in ["first_audit", "second_audit"] {
+        let output = lineage
+            .outputs
+            .iter()
+            .find(|output| output.dataset.name == dataset)
+            .expect("scoped Sink output");
+        let id = output.facet.fields.get("id").expect("id field lineage");
+        assert_eq!(id.input_fields[0].name, "source_rows");
+        assert_eq!(id.input_fields[0].field, "id");
+    }
+}


### PR DESCRIPTION
## Summary

- add fixed-cardinality Sink lifecycle metrics and one closed span per actual Sink work unit
- record synchronous, streaming, and correlation-deferred output at the runtime seam that establishes the bytes
- make Sink lineage explicit for mappings, exclusions, authored sort order, fan-out, and scoped external datasets
- add focused execution, admission-loss, exporter, and lineage coverage

## Validation

- `cargo check --workspace --locked --offline`
- `cargo clippy -p clinker-exec -p clinker-lineage -p clinker --tests --locked --offline -- -D warnings`
- `cargo test -p clinker-lineage --lib --locked --offline` (98 passed)
- `cargo test -p clinker --test sink_surface --locked --offline` (9 passed)
- focused telemetry tests (5 passed)
- focused lineage tests (4 passed)
- focused exporter tests (17 passed)
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This is stacked on #1090. The remaining authored Sink corpus migration is intentionally separate; the unfiltered `clinker-lineage` integration suite still contains positive `type: output` fixtures in two downstream-owned test files, so that suite is not claimed green here.

## Runtime contracts

- Telemetry is fixed-cardinality and lossy; admission failure cannot affect output bytes or exit status.
- Spans are emitted only after the actual write owner finishes, including streaming and correlation-deferred paths.
- This change adds no input-sized retained state, so no new memory consumer is required.
