### PR TITLE
Add explicit credential profile resolution

### DIFF
--- a/crates/clinker-plan/src/credentials.rs
+++ b/crates/clinker-plan/src/credentials.rs
@@ -1,0 +1,301 @@
+//! Secret-free credential requirements retained by planning.
+//!
+//! This module describes what a runtime consumer needs without representing a
+//! credential profile, secret value, or opened handle. Provider selection and
+//! lease acquisition belong to the application edge.
+
+use std::fmt;
+use std::num::NonZeroU32;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// A stable logical name for one credential requirement.
+///
+/// Names are metadata, never secret values. They use the same conservative
+/// dot-separated identifier shape as workspace resources so they remain safe
+/// in plans, fingerprints, diagnostics, and lineage metadata.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct CredentialRequirementName(Box<str>);
+
+impl CredentialRequirementName {
+    /// Parse a logical requirement name without retaining rejected input.
+    pub fn parse(value: &str) -> Result<Self, CredentialRequirementError> {
+        if !is_logical_name(value) {
+            return Err(CredentialRequirementError::InvalidRequirementName);
+        }
+        Ok(Self(value.into()))
+    }
+
+    /// Return the validated logical name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CredentialRequirementName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for CredentialRequirementName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Box::<str>::deserialize(deserializer)?;
+        Self::parse(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A stable logical identifier for a credential-provider implementation kind.
+///
+/// This is a provider kind such as a request signer, not a deployment profile,
+/// endpoint, account, or secret-store location.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct CredentialProviderKind(Box<str>);
+
+impl CredentialProviderKind {
+    /// Parse a provider kind without retaining rejected input.
+    pub fn parse(value: &str) -> Result<Self, CredentialRequirementError> {
+        if !is_logical_name(value) {
+            return Err(CredentialRequirementError::InvalidProviderKind);
+        }
+        Ok(Self(value.into()))
+    }
+
+    /// Return the validated provider kind.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CredentialProviderKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for CredentialProviderKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Box::<str>::deserialize(deserializer)?;
+        Self::parse(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Provider-neutral operations a resolved credential must support.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CredentialCapability {
+    /// Authenticate one already-admitted outbound request.
+    AuthenticateRequest,
+    /// Establish an authenticated session owned by a runtime consumer.
+    OpenSession,
+}
+
+/// Maximum scope for which one resolved credential lease may stay live.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CredentialLifetime {
+    /// The lease is scoped to a single request or equivalent operation.
+    Request,
+    /// The lease may stay live for one finite run.
+    Run,
+}
+
+/// Whether a consumer requires renewal support from its provider.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CredentialRenewal {
+    /// The consumer does not require renewal.
+    NotRequired,
+    /// The provider must support renewal for the admitted lease.
+    Required,
+}
+
+/// Whether a consumer requires revocation support from its provider.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CredentialRevocation {
+    /// The consumer does not require revocation.
+    NotRequired,
+    /// The provider must support revocation for the admitted lease.
+    Required,
+}
+
+/// Fixed capacity charged for one resolved credential handle.
+///
+/// Units are provider-neutral admission units, not bytes and not a count
+/// derived from a secret. Runtime registries use them to bound live handles.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct CredentialHandleUnits(NonZeroU32);
+
+impl CredentialHandleUnits {
+    /// Construct a non-zero capacity charge.
+    pub const fn new(units: NonZeroU32) -> Self {
+        Self(units)
+    }
+
+    /// Return the non-zero unit count.
+    pub const fn get(self) -> NonZeroU32 {
+        self.0
+    }
+}
+
+/// Complete secret-free requirements for one logical credential.
+///
+/// Capabilities are sorted and deduplicated at construction, making the value
+/// deterministic wherever it participates in serialized plan identity.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize)]
+pub struct CredentialRequirement {
+    name: CredentialRequirementName,
+    provider_kind: CredentialProviderKind,
+    capabilities: Vec<CredentialCapability>,
+    lifetime: CredentialLifetime,
+    renewal: CredentialRenewal,
+    revocation: CredentialRevocation,
+    handle_units: CredentialHandleUnits,
+}
+
+impl CredentialRequirement {
+    /// Construct a complete requirement after validating its capability set.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        name: CredentialRequirementName,
+        provider_kind: CredentialProviderKind,
+        mut capabilities: Vec<CredentialCapability>,
+        lifetime: CredentialLifetime,
+        renewal: CredentialRenewal,
+        revocation: CredentialRevocation,
+        handle_units: CredentialHandleUnits,
+    ) -> Result<Self, CredentialRequirementError> {
+        capabilities.sort_unstable();
+        capabilities.dedup();
+        if capabilities.is_empty() {
+            return Err(CredentialRequirementError::EmptyCapabilities);
+        }
+        Ok(Self {
+            name,
+            provider_kind,
+            capabilities,
+            lifetime,
+            renewal,
+            revocation,
+            handle_units,
+        })
+    }
+
+    /// Logical requirement name retained in the plan.
+    pub fn name(&self) -> &CredentialRequirementName {
+        &self.name
+    }
+
+    /// Required provider implementation kind.
+    pub fn provider_kind(&self) -> &CredentialProviderKind {
+        &self.provider_kind
+    }
+
+    /// Canonical non-empty capability set.
+    pub fn capabilities(&self) -> &[CredentialCapability] {
+        &self.capabilities
+    }
+
+    /// Maximum admitted lease lifetime.
+    pub const fn lifetime(&self) -> CredentialLifetime {
+        self.lifetime
+    }
+
+    /// Renewal support requirement.
+    pub const fn renewal(&self) -> CredentialRenewal {
+        self.renewal
+    }
+
+    /// Revocation support requirement.
+    pub const fn revocation(&self) -> CredentialRevocation {
+        self.revocation
+    }
+
+    /// Capacity units charged by a live handle.
+    pub const fn handle_units(&self) -> CredentialHandleUnits {
+        self.handle_units
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CredentialRequirementWire {
+    name: CredentialRequirementName,
+    provider_kind: CredentialProviderKind,
+    capabilities: Vec<CredentialCapability>,
+    lifetime: CredentialLifetime,
+    renewal: CredentialRenewal,
+    revocation: CredentialRevocation,
+    handle_units: CredentialHandleUnits,
+}
+
+impl<'de> Deserialize<'de> for CredentialRequirement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = CredentialRequirementWire::deserialize(deserializer)?;
+        Self::new(
+            wire.name,
+            wire.provider_kind,
+            wire.capabilities,
+            wire.lifetime,
+            wire.renewal,
+            wire.revocation,
+            wire.handle_units,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validation failures for secret-free credential requirement metadata.
+///
+/// Variants deliberately retain no rejected string or arbitrary provider
+/// payload, so both `Display` and `Debug` are safe at diagnostic boundaries.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CredentialRequirementError {
+    /// The logical requirement name is empty or malformed.
+    InvalidRequirementName,
+    /// The provider kind is empty or malformed.
+    InvalidProviderKind,
+    /// A requirement named no usable consumer operation.
+    EmptyCapabilities,
+}
+
+impl fmt::Display for CredentialRequirementError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidRequirementName => formatter.write_str(
+                "credential requirement name is invalid; use a dot-separated logical name such as `service.api`",
+            ),
+            Self::InvalidProviderKind => formatter.write_str(
+                "credential provider kind is invalid; use a dot-separated logical name such as `request-signer`",
+            ),
+            Self::EmptyCapabilities => formatter.write_str(
+                "credential requirement must name at least one provider-neutral capability",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CredentialRequirementError {}
+
+fn is_logical_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.split('.').all(|part| {
+            !part.is_empty()
+                && part.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+                })
+        })
+}

--- a/crates/clinker-plan/src/lib.rs
+++ b/crates/clinker-plan/src/lib.rs
@@ -6,6 +6,7 @@
 //! this plan to drive a run.
 
 pub mod config;
+pub mod credentials;
 pub mod error;
 pub mod overlay_ops;
 pub mod plan;

--- a/crates/clinker/src/credential_profile.rs
+++ b/crates/clinker/src/credential_profile.rs
@@ -1,0 +1,360 @@
+//! Explicit run-local credential profile resolution.
+//!
+//! Profiles and providers are supplied by the application edge. Resolution
+//! accepts one already-validated, secret-free requirement and returns one
+//! opaque lease; it never searches a plan, environment, channel, or group.
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use clinker_plan::credentials::{
+    CredentialCapability, CredentialHandleUnits, CredentialLifetime, CredentialProviderKind,
+    CredentialRenewal, CredentialRequirement, CredentialRequirementName, CredentialRevocation,
+};
+
+/// An explicitly selected deployment credential profile name.
+///
+/// This type has no default. A credential-bearing run must provide one value
+/// independently of its channel, group, or environment selection.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CredentialProfileName(Box<str>);
+
+impl CredentialProfileName {
+    /// Parse a profile name without retaining rejected input.
+    pub fn parse(value: &str) -> Result<Self, CredentialProfileNameError> {
+        if !is_profile_name(value) {
+            return Err(CredentialProfileNameError);
+        }
+        Ok(Self(value.into()))
+    }
+
+    /// Return the validated explicit profile name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for CredentialProfileName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// A malformed explicit profile name.
+///
+/// Rejected text is not retained, keeping both error representations safe.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CredentialProfileNameError;
+
+impl fmt::Display for CredentialProfileNameError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(
+            "credential profile name is invalid; choose an explicitly configured logical name",
+        )
+    }
+}
+
+impl std::error::Error for CredentialProfileNameError {}
+
+/// Opaque provider-owned state that remains live for a resolved credential.
+///
+/// The marker deliberately exposes no secret accessor. Dropping the enclosing
+/// [`LeasedCredentialHandle`] closes the lease on every ordinary exit path.
+pub trait CredentialLease: Send + Sync {}
+
+/// A closed, sanitized failure returned by a credential provider.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CredentialProviderFailure {
+    /// The configured provider could not acquire a lease at this time.
+    Unavailable,
+    /// The provider refused the logical requirement.
+    Refused,
+}
+
+impl fmt::Display for CredentialProviderFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("credential provider could not resolve the requirement")
+    }
+}
+
+impl std::error::Error for CredentialProviderFailure {}
+
+/// Provider-neutral interface used by explicit profile resolution.
+///
+/// Compatibility metadata is inspected before `resolve` is called. Provider
+/// implementations return only an opaque owned lease and a closed failure;
+/// arbitrary secret-store errors cannot cross this boundary.
+pub trait CredentialProvider {
+    /// Stable implementation kind supplied by this provider.
+    fn kind(&self) -> &CredentialProviderKind;
+
+    /// Provider-neutral operations supplied by this provider.
+    fn capabilities(&self) -> &[CredentialCapability];
+
+    /// Lease lifetimes supplied by this provider.
+    fn lifetimes(&self) -> &[CredentialLifetime];
+
+    /// Whether acquired leases can be renewed when required.
+    fn supports_renewal(&self) -> bool;
+
+    /// Whether acquired leases can be revoked when required.
+    fn supports_revocation(&self) -> bool;
+
+    /// Maximum handle-capacity units admitted for one lease.
+    fn handle_capacity(&self) -> CredentialHandleUnits;
+
+    /// Resolve one validated logical requirement to an opaque owned lease.
+    fn resolve(
+        &self,
+        requirement: &CredentialRequirement,
+    ) -> Result<Box<dyn CredentialLease>, CredentialProviderFailure>;
+}
+
+/// One explicitly named profile backed by borrowed provider registrations.
+///
+/// The borrowed slice is supplied by the run boundary; this low-level value
+/// does not allocate or retain an input-sized registry.
+pub struct CredentialProfile<'run> {
+    name: CredentialProfileName,
+    providers: &'run [&'run dyn CredentialProvider],
+}
+
+impl<'run> CredentialProfile<'run> {
+    /// Construct a named profile from a borrowed provider slice.
+    pub const fn new(
+        name: CredentialProfileName,
+        providers: &'run [&'run dyn CredentialProvider],
+    ) -> Self {
+        Self { name, providers }
+    }
+
+    /// Explicit profile name.
+    pub fn name(&self) -> &CredentialProfileName {
+        &self.name
+    }
+
+    fn matching_provider(
+        &self,
+        kind: &CredentialProviderKind,
+    ) -> Result<&'run dyn CredentialProvider, CredentialResolutionError> {
+        let mut matches = self
+            .providers
+            .iter()
+            .copied()
+            .filter(|provider| provider.kind() == kind);
+        let provider = matches.next().ok_or(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::UnknownProvider,
+        ))?;
+        if matches.next().is_some() {
+            return Err(CredentialResolutionError::new(
+                CredentialResolutionErrorKind::AmbiguousProvider,
+            ));
+        }
+        Ok(provider)
+    }
+}
+
+/// One run-local credential lease with fully redacted diagnostics.
+///
+/// This type intentionally implements neither `Serialize` nor `Clone`. The
+/// private provider-owned guard is released when the handle is dropped, while
+/// the public metadata remains limited to secret-free plan identifiers.
+pub struct LeasedCredentialHandle<'run> {
+    requirement_name: CredentialRequirementName,
+    provider_kind: CredentialProviderKind,
+    handle_units: CredentialHandleUnits,
+    _lease: Box<dyn CredentialLease>,
+    _run: PhantomData<&'run CredentialProfile<'run>>,
+}
+
+impl LeasedCredentialHandle<'_> {
+    /// Secret-free logical requirement satisfied by this handle.
+    pub fn requirement_name(&self) -> &CredentialRequirementName {
+        &self.requirement_name
+    }
+
+    /// Provider kind that owns this handle.
+    pub fn provider_kind(&self) -> &CredentialProviderKind {
+        &self.provider_kind
+    }
+
+    /// Admission units charged while this handle stays live.
+    pub const fn handle_units(&self) -> CredentialHandleUnits {
+        self.handle_units
+    }
+}
+
+impl fmt::Debug for LeasedCredentialHandle<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("LeasedCredentialHandle { credential: <redacted> }")
+    }
+}
+
+/// Stable category for an explicit profile-resolution failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CredentialResolutionErrorKind {
+    /// No supplied profile had the selected name.
+    UnknownProfile,
+    /// More than one supplied profile had the selected name.
+    AmbiguousProfile,
+    /// The selected profile had no provider of the required kind.
+    UnknownProvider,
+    /// The selected profile had duplicate providers of the required kind.
+    AmbiguousProvider,
+    /// The provider omitted at least one required operation.
+    UnsupportedCapability,
+    /// The provider cannot supply the required lease lifetime.
+    UnsupportedLifetime,
+    /// The provider cannot renew a lease that requires renewal.
+    UnsupportedRenewal,
+    /// The provider cannot revoke a lease that requires revocation.
+    UnsupportedRevocation,
+    /// The provider cannot admit the required handle-capacity units.
+    InsufficientHandleCapacity,
+    /// The provider was unavailable while acquiring the lease.
+    ProviderUnavailable,
+    /// The provider refused the logical requirement.
+    ProviderRefused,
+}
+
+/// A sanitized explicit profile-resolution failure.
+///
+/// The error stores only a closed category. It cannot echo a profile name,
+/// logical reference, provider payload, or secret through `Display` or `Debug`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CredentialResolutionError {
+    kind: CredentialResolutionErrorKind,
+}
+
+impl CredentialResolutionError {
+    const fn new(kind: CredentialResolutionErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Stable failure category for tests and structured diagnostics.
+    pub const fn kind(self) -> CredentialResolutionErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for CredentialResolutionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self.kind {
+            CredentialResolutionErrorKind::UnknownProfile => {
+                "selected credential profile is not configured; choose one explicitly configured profile"
+            }
+            CredentialResolutionErrorKind::AmbiguousProfile => {
+                "selected credential profile is configured more than once; keep exactly one profile with that name"
+            }
+            CredentialResolutionErrorKind::UnknownProvider => {
+                "selected credential profile does not contain the required provider kind"
+            }
+            CredentialResolutionErrorKind::AmbiguousProvider => {
+                "selected credential profile contains the required provider kind more than once"
+            }
+            CredentialResolutionErrorKind::UnsupportedCapability => {
+                "credential provider does not supply every required capability"
+            }
+            CredentialResolutionErrorKind::UnsupportedLifetime => {
+                "credential provider does not supply the required lease lifetime"
+            }
+            CredentialResolutionErrorKind::UnsupportedRenewal => {
+                "credential provider does not support required lease renewal"
+            }
+            CredentialResolutionErrorKind::UnsupportedRevocation => {
+                "credential provider does not support required lease revocation"
+            }
+            CredentialResolutionErrorKind::InsufficientHandleCapacity => {
+                "credential provider cannot admit the required handle capacity"
+            }
+            CredentialResolutionErrorKind::ProviderUnavailable => {
+                "credential provider was unavailable before the run began"
+            }
+            CredentialResolutionErrorKind::ProviderRefused => {
+                "credential provider refused the logical requirement before the run began"
+            }
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for CredentialResolutionError {}
+
+/// Resolve one supplied requirement through one explicitly selected profile.
+///
+/// The function performs exact profile/provider selection and all compatibility
+/// checks before the provider can acquire secret-bearing state. It does not
+/// inspect a plan or infer a profile from any other run option.
+pub fn resolve_explicit_profile<'run>(
+    selected: &CredentialProfileName,
+    profiles: &'run [CredentialProfile<'run>],
+    requirement: &CredentialRequirement,
+) -> Result<LeasedCredentialHandle<'run>, CredentialResolutionError> {
+    let mut matches = profiles.iter().filter(|profile| profile.name() == selected);
+    let profile = matches.next().ok_or(CredentialResolutionError::new(
+        CredentialResolutionErrorKind::UnknownProfile,
+    ))?;
+    if matches.next().is_some() {
+        return Err(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::AmbiguousProfile,
+        ));
+    }
+
+    let provider = profile.matching_provider(requirement.provider_kind())?;
+    if requirement
+        .capabilities()
+        .iter()
+        .any(|required| !provider.capabilities().contains(required))
+    {
+        return Err(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::UnsupportedCapability,
+        ));
+    }
+    if !provider.lifetimes().contains(&requirement.lifetime()) {
+        return Err(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::UnsupportedLifetime,
+        ));
+    }
+    if requirement.renewal() == CredentialRenewal::Required && !provider.supports_renewal() {
+        return Err(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::UnsupportedRenewal,
+        ));
+    }
+    if requirement.revocation() == CredentialRevocation::Required && !provider.supports_revocation()
+    {
+        return Err(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::UnsupportedRevocation,
+        ));
+    }
+    if provider.handle_capacity().get() < requirement.handle_units().get() {
+        return Err(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::InsufficientHandleCapacity,
+        ));
+    }
+
+    let lease = provider.resolve(requirement).map_err(|failure| {
+        CredentialResolutionError::new(match failure {
+            CredentialProviderFailure::Unavailable => {
+                CredentialResolutionErrorKind::ProviderUnavailable
+            }
+            CredentialProviderFailure::Refused => CredentialResolutionErrorKind::ProviderRefused,
+        })
+    })?;
+    Ok(LeasedCredentialHandle {
+        requirement_name: requirement.name().clone(),
+        provider_kind: requirement.provider_kind().clone(),
+        handle_units: requirement.handle_units(),
+        _lease: lease,
+        _run: PhantomData,
+    })
+}
+
+fn is_profile_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.split('.').all(|part| {
+            !part.is_empty()
+                && part.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+                })
+        })
+}

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -11,6 +11,7 @@ use clinker_plan::config::utils::parse_memory_limit_bytes_strict;
 use clinker_plan::error::PipelineError;
 
 mod capability;
+pub mod credential_profile;
 mod lifecycle;
 mod lineage;
 use lineage::*;

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -1,0 +1,368 @@
+use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use clinker_plan::credentials::{
+    CredentialCapability, CredentialHandleUnits, CredentialLifetime, CredentialProviderKind,
+    CredentialRenewal, CredentialRequirement, CredentialRequirementName, CredentialRevocation,
+};
+
+#[path = "../src/credential_profile.rs"]
+mod credential_profile;
+
+use credential_profile::{
+    CredentialLease, CredentialProfile, CredentialProfileName, CredentialProvider,
+    CredentialProviderFailure, CredentialResolutionErrorKind, LeasedCredentialHandle,
+    resolve_explicit_profile,
+};
+
+fn requirement(capabilities: Vec<CredentialCapability>) -> CredentialRequirement {
+    CredentialRequirement::new(
+        CredentialRequirementName::parse("orders.api").expect("valid logical requirement name"),
+        CredentialProviderKind::parse("request-signer").expect("valid provider kind"),
+        capabilities,
+        CredentialLifetime::Run,
+        CredentialRenewal::Required,
+        CredentialRevocation::Required,
+        CredentialHandleUnits::new(NonZeroU32::new(2).expect("non-zero units")),
+    )
+    .expect("valid requirement")
+}
+
+struct FixtureLease {
+    _secret: String,
+    drops: Arc<AtomicUsize>,
+}
+
+impl Drop for FixtureLease {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl CredentialLease for FixtureLease {}
+
+struct FixtureProvider {
+    kind: CredentialProviderKind,
+    capabilities: Vec<CredentialCapability>,
+    lifetimes: Vec<CredentialLifetime>,
+    renewal: bool,
+    revocation: bool,
+    capacity: CredentialHandleUnits,
+    secret: String,
+    resolve_calls: Arc<AtomicUsize>,
+    drops: Arc<AtomicUsize>,
+}
+
+impl CredentialProvider for FixtureProvider {
+    fn kind(&self) -> &CredentialProviderKind {
+        &self.kind
+    }
+
+    fn capabilities(&self) -> &[CredentialCapability] {
+        &self.capabilities
+    }
+
+    fn lifetimes(&self) -> &[CredentialLifetime] {
+        &self.lifetimes
+    }
+
+    fn supports_renewal(&self) -> bool {
+        self.renewal
+    }
+
+    fn supports_revocation(&self) -> bool {
+        self.revocation
+    }
+
+    fn handle_capacity(&self) -> CredentialHandleUnits {
+        self.capacity
+    }
+
+    fn resolve(
+        &self,
+        _requirement: &CredentialRequirement,
+    ) -> Result<Box<dyn CredentialLease>, CredentialProviderFailure> {
+        self.resolve_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Box::new(FixtureLease {
+            _secret: self.secret.clone(),
+            drops: Arc::clone(&self.drops),
+        }))
+    }
+}
+
+fn provider(
+    capabilities: Vec<CredentialCapability>,
+    lifetimes: Vec<CredentialLifetime>,
+    renewal: bool,
+    revocation: bool,
+    capacity: u32,
+) -> FixtureProvider {
+    FixtureProvider {
+        kind: CredentialProviderKind::parse("request-signer").expect("valid provider kind"),
+        capabilities,
+        lifetimes,
+        renewal,
+        revocation,
+        capacity: CredentialHandleUnits::new(
+            NonZeroU32::new(capacity).expect("fixture capacity must be non-zero"),
+        ),
+        secret: "lease-secret-must-not-escape".to_owned(),
+        resolve_calls: Arc::new(AtomicUsize::new(0)),
+        drops: Arc::new(AtomicUsize::new(0)),
+    }
+}
+
+#[test]
+fn low_level_requirement_is_deterministic_strict_and_secret_free() {
+    let requirement = requirement(vec![
+        CredentialCapability::OpenSession,
+        CredentialCapability::AuthenticateRequest,
+        CredentialCapability::OpenSession,
+    ]);
+
+    assert_eq!(
+        requirement.capabilities(),
+        &[
+            CredentialCapability::AuthenticateRequest,
+            CredentialCapability::OpenSession,
+        ]
+    );
+    let encoded = serde_json::to_value(&requirement).expect("serialize secret-free requirement");
+    assert_eq!(
+        encoded,
+        serde_json::json!({
+            "name": "orders.api",
+            "provider_kind": "request-signer",
+            "capabilities": ["authenticate-request", "open-session"],
+            "lifetime": "run",
+            "renewal": "required",
+            "revocation": "required",
+            "handle_units": 2
+        })
+    );
+    let rendered = serde_json::to_string(&encoded).expect("render requirement JSON");
+    assert!(!rendered.contains("secret"));
+    assert!(!rendered.contains("profile"));
+
+    let decoded: CredentialRequirement =
+        serde_json::from_value(encoded).expect("deserialize valid requirement");
+    assert_eq!(decoded, requirement);
+    assert!(
+        serde_json::from_value::<CredentialRequirement>(serde_json::json!({
+            "name": "orders.api",
+            "provider_kind": "request-signer",
+            "capabilities": ["authenticate-request"],
+            "lifetime": "run",
+            "renewal": "required",
+            "revocation": "required",
+            "handle_units": 1,
+            "token": "must-not-be-accepted"
+        }))
+        .is_err(),
+        "unknown credential-shaped fields must fail closed"
+    );
+
+    let rejected = CredentialRequirementName::parse("must-not-print=token")
+        .expect_err("invalid name must fail");
+    for text in [rejected.to_string(), format!("{rejected:?}")] {
+        assert!(!text.contains("must-not-print=token"));
+    }
+}
+
+#[test]
+fn low_level_explicit_profile_resolves_one_redacted_leased_handle() {
+    let provider = provider(
+        vec![
+            CredentialCapability::AuthenticateRequest,
+            CredentialCapability::OpenSession,
+        ],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let resolve_calls = Arc::clone(&provider.resolve_calls);
+    let drops = Arc::clone(&provider.drops);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+    let requirement = requirement(vec![
+        CredentialCapability::AuthenticateRequest,
+        CredentialCapability::OpenSession,
+    ]);
+
+    {
+        let handle: LeasedCredentialHandle<'_> =
+            resolve_explicit_profile(&selected, &profiles, &requirement)
+                .expect("compatible explicit profile resolves");
+        assert_eq!(handle.requirement_name(), requirement.name());
+        assert_eq!(handle.provider_kind(), requirement.provider_kind());
+        assert_eq!(handle.handle_units(), requirement.handle_units());
+        assert_eq!(
+            format!("{handle:?}"),
+            "LeasedCredentialHandle { credential: <redacted> }"
+        );
+        assert!(!format!("{handle:?}").contains("release"));
+        assert!(!format!("{handle:?}").contains("orders.api"));
+        assert!(!format!("{handle:?}").contains("lease-secret-must-not-escape"));
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+    }
+
+    assert_eq!(resolve_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn low_level_unknown_or_incompatible_selection_fails_before_provider_resolution() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Request],
+        false,
+        false,
+        1,
+    );
+    let resolve_calls = Arc::clone(&provider.resolve_calls);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let requirement = requirement(vec![CredentialCapability::OpenSession]);
+
+    let cases = [
+        (
+            resolve_explicit_profile(
+                &CredentialProfileName::parse("missing").expect("valid explicit profile"),
+                &profiles,
+                &requirement,
+            )
+            .expect_err("unknown profile must fail")
+            .kind(),
+            CredentialResolutionErrorKind::UnknownProfile,
+        ),
+        (
+            resolve_explicit_profile(
+                &CredentialProfileName::parse("empty").expect("valid explicit profile"),
+                &[CredentialProfile::new(
+                    CredentialProfileName::parse("empty").expect("valid explicit profile"),
+                    &[],
+                )],
+                &requirement,
+            )
+            .expect_err("unknown provider must fail")
+            .kind(),
+            CredentialResolutionErrorKind::UnknownProvider,
+        ),
+        (
+            resolve_explicit_profile(
+                &CredentialProfileName::parse("release").expect("valid explicit profile"),
+                &profiles,
+                &requirement,
+            )
+            .expect_err("unsupported capability must fail")
+            .kind(),
+            CredentialResolutionErrorKind::UnsupportedCapability,
+        ),
+    ];
+    for (actual, expected) in cases {
+        assert_eq!(actual, expected);
+    }
+    assert_eq!(resolve_calls.load(Ordering::SeqCst), 0);
+
+    let error = resolve_explicit_profile(
+        &CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &profiles,
+        &requirement,
+    )
+    .expect_err("incompatible selection must fail");
+    for text in [error.to_string(), format!("{error:?}")] {
+        assert!(!text.contains("release"));
+        assert!(!text.contains("orders.api"));
+        assert!(!text.contains("lease-secret-must-not-escape"));
+    }
+}
+
+#[test]
+fn low_level_lifecycle_and_capacity_requirements_fail_closed() {
+    let provider = provider(
+        vec![
+            CredentialCapability::AuthenticateRequest,
+            CredentialCapability::OpenSession,
+        ],
+        vec![CredentialLifetime::Request],
+        false,
+        false,
+        1,
+    );
+    let resolve_calls = Arc::clone(&provider.resolve_calls);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+
+    let mut requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    assert_eq!(
+        resolve_explicit_profile(&selected, &profiles, &requirement)
+            .expect_err("unsupported lifetime must fail")
+            .kind(),
+        CredentialResolutionErrorKind::UnsupportedLifetime
+    );
+
+    requirement = CredentialRequirement::new(
+        requirement.name().clone(),
+        requirement.provider_kind().clone(),
+        requirement.capabilities().to_vec(),
+        CredentialLifetime::Request,
+        CredentialRenewal::Required,
+        CredentialRevocation::NotRequired,
+        CredentialHandleUnits::new(NonZeroU32::new(1).expect("non-zero units")),
+    )
+    .expect("valid renewal requirement");
+    assert_eq!(
+        resolve_explicit_profile(&selected, &profiles, &requirement)
+            .expect_err("unsupported renewal must fail")
+            .kind(),
+        CredentialResolutionErrorKind::UnsupportedRenewal
+    );
+
+    requirement = CredentialRequirement::new(
+        requirement.name().clone(),
+        requirement.provider_kind().clone(),
+        requirement.capabilities().to_vec(),
+        CredentialLifetime::Request,
+        CredentialRenewal::NotRequired,
+        CredentialRevocation::Required,
+        CredentialHandleUnits::new(NonZeroU32::new(1).expect("non-zero units")),
+    )
+    .expect("valid revocation requirement");
+    assert_eq!(
+        resolve_explicit_profile(&selected, &profiles, &requirement)
+            .expect_err("unsupported revocation must fail")
+            .kind(),
+        CredentialResolutionErrorKind::UnsupportedRevocation
+    );
+
+    requirement = CredentialRequirement::new(
+        requirement.name().clone(),
+        requirement.provider_kind().clone(),
+        requirement.capabilities().to_vec(),
+        CredentialLifetime::Request,
+        CredentialRenewal::NotRequired,
+        CredentialRevocation::NotRequired,
+        CredentialHandleUnits::new(NonZeroU32::new(2).expect("non-zero units")),
+    )
+    .expect("valid capacity requirement");
+    assert_eq!(
+        resolve_explicit_profile(&selected, &profiles, &requirement)
+            .expect_err("insufficient capacity must fail")
+            .kind(),
+        CredentialResolutionErrorKind::InsufficientHandleCapacity
+    );
+    assert_eq!(resolve_calls.load(Ordering::SeqCst), 0);
+}

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -50,6 +50,7 @@ struct FixtureProvider {
     revocation: bool,
     capacity: CredentialHandleUnits,
     secret: String,
+    failure: Option<CredentialProviderFailure>,
     resolve_calls: Arc<AtomicUsize>,
     drops: Arc<AtomicUsize>,
 }
@@ -84,6 +85,9 @@ impl CredentialProvider for FixtureProvider {
         _requirement: &CredentialRequirement,
     ) -> Result<Box<dyn CredentialLease>, CredentialProviderFailure> {
         self.resolve_calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(failure) = self.failure {
+            return Err(failure);
+        }
         Ok(Box::new(FixtureLease {
             _secret: self.secret.clone(),
             drops: Arc::clone(&self.drops),
@@ -108,9 +112,45 @@ fn provider(
             NonZeroU32::new(capacity).expect("fixture capacity must be non-zero"),
         ),
         secret: "lease-secret-must-not-escape".to_owned(),
+        failure: None,
         resolve_calls: Arc::new(AtomicUsize::new(0)),
         drops: Arc::new(AtomicUsize::new(0)),
     }
+}
+
+fn provider_failure_kind(failure: CredentialProviderFailure) -> CredentialResolutionErrorKind {
+    let mut provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    provider.failure = Some(failure);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    resolve_explicit_profile(
+        &CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &profiles,
+        &requirement(vec![CredentialCapability::AuthenticateRequest]),
+    )
+    .expect_err("provider failure must remain typed")
+    .kind()
+}
+
+#[test]
+fn low_level_provider_failures_are_closed_and_sanitized() {
+    assert_eq!(
+        provider_failure_kind(CredentialProviderFailure::Unavailable),
+        CredentialResolutionErrorKind::ProviderUnavailable
+    );
+    assert_eq!(
+        provider_failure_kind(CredentialProviderFailure::Refused),
+        CredentialResolutionErrorKind::ProviderRefused
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- define deterministic, secret-free credential requirements in the planning vocabulary
- resolve a requirement only through an explicitly selected profile and exact provider kind
- reject missing, ambiguous, or capability-incompatible profiles before acquiring a lease
- keep provider state opaque, non-serializable, and fully redacted in diagnostics

## Validation

- `cargo test -p clinker --test credential_profiles --locked --offline low_level_` (5 passed)
- `cargo clippy -p clinker-plan -p clinker --tests --locked --offline -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This is stacked on #1092 because credential requirements consume the typed resource vocabulary introduced there.

## Scope

This PR intentionally establishes only low-level requirement and profile resolution. The CLI selection flag, bounded live-handle registry, activation admission, renewal/revocation execution, and lifecycle telemetry will follow as separate reviewable changes.

- Lineage is unaffected because no column value, route, or dataset boundary changes.
- A single caller-owned lease has constant state; growing handle tables and memory-consumer accounting are not introduced here.
