### PR TITLE
Migrate lineage fixtures to Sink syntax

### DIFF
--- a/crates/clinker-lineage/tests/composition_lineage.rs
+++ b/crates/clinker-lineage/tests/composition_lineage.rs
@@ -126,7 +126,7 @@ nodes:
     use: ../compositions/rename_id.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: comp
     config: { name: out, type: csv, path: out/rename.csv }
@@ -192,7 +192,7 @@ nodes:
     use: ../compositions/outer.comp.yaml
     inputs:
       o_in: src
-  - type: output
+  - type: sink
     name: out
     input: top
     config: { name: out, type: csv, path: out/nested.csv }
@@ -256,7 +256,7 @@ nodes:
     use: ../compositions/agg_in_body.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: comp
     config: { name: out, type: csv, path: out/agg.csv }
@@ -320,7 +320,7 @@ nodes:
     inputs:
       orders: orders_src
       products: products_src
-  - type: output
+  - type: sink
     name: out
     input: comp
     config: { name: out, type: csv, path: out/join.csv }
@@ -412,7 +412,7 @@ nodes:
     use: ../compositions/doc_read.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: comp
     config: { name: out, type: csv, path: out/doc_comp.csv }
@@ -480,7 +480,7 @@ nodes:
     use: ../compositions/own_source.comp.yaml
     inputs:
       driver: ref
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config: { name: out, type: csv, path: out/out.csv }
@@ -591,7 +591,7 @@ nodes:
     use: ../compositions/own_source.comp.yaml
     inputs:
       driver: drive
-  - type: output
+  - type: sink
     name: enrich.ref
     input: enrich
     config: { name: enrich.ref, type: csv, path: out/out.csv }
@@ -648,7 +648,7 @@ nodes:
     use: ../compositions/own_source.comp.yaml
     inputs:
       driver: drive
-  - type: output
+  - type: sink
     name: out
     input: {call_site}
     config: {{ name: out, type: csv, path: out/out.csv }}
@@ -750,7 +750,7 @@ nodes:
     use: ../compositions/own_source.comp.yaml
     inputs:
       driver: drive
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config: { name: out, type: csv, path: out/out.csv }
@@ -820,7 +820,7 @@ nodes:
     use: ../compositions/own_multi_record.comp.yaml
     inputs:
       driver: drv
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config: { name: out, type: csv, path: out/out.csv }

--- a/crates/clinker-lineage/tests/logical_identity.rs
+++ b/crates/clinker-lineage/tests/logical_identity.rs
@@ -72,7 +72,7 @@ nodes:
       type: csv
       glob: incoming/customers/*.csv
       schema: [{ name: id, type: int }]
-  - type: output
+  - type: sink
     name: output_customers
     input: source_customers
     config: { name: output_customers, type: csv, path: out/customers.csv }
@@ -193,7 +193,7 @@ nodes:
       type: csv
       path: /worker-a/incoming/customers.csv
       schema: [{ name: id, type: int }]
-  - type: output
+  - type: sink
     name: output_customers
     input: source_customers
     config: { name: output_customers, type: csv, path: /worker-a/out/customers.csv }
@@ -288,7 +288,7 @@ nodes:
       type: csv
       path: /different-worker/input.csv
       schema: [{ name: id, type: int }]
-  - type: output
+  - type: sink
     name: output_customers
     input: source_customers
     config: { name: output_customers, type: csv, path: /different-worker/output.csv }
@@ -362,7 +362,7 @@ nodes:
         emit kind = record_type
         emit batch_id = batch_id
         emit amount = amount
-  - type: output
+  - type: sink
     name: out
     input: project
     config: { name: out, type: csv, path: out/out.csv }
@@ -463,7 +463,7 @@ nodes:
     config:
       cxl: |
         emit id = id
-  - type: output
+  - type: sink
     name: récapitulatif
     input: shape
     config: { name: récapitulatif, type: csv, path: out/summary.csv }
@@ -571,7 +571,7 @@ nodes:
     config:
       cxl: |
         emit amount = amount
-  - type: output
+  - type: sink
     name: out
     input: project
     config: { name: out, type: csv, path: out/out.csv }
@@ -694,11 +694,11 @@ nodes:
       type: csv
       glob: incoming/us/*.csv
       schema: [{ name: id, type: int }]
-  - type: output
+  - type: sink
     name: daily_eu
     input: orders_eu
     config: { name: daily_eu, type: csv, path: out/eu.csv }
-  - type: output
+  - type: sink
     name: daily_us
     input: orders_us
     config: { name: daily_us, type: csv, path: out/us.csv }


### PR DESCRIPTION
## Summary

- migrate the remaining positive lineage integration fixtures from `type: output` to `type: sink`
- keep the composition and logical-identity scenarios otherwise byte-for-byte unchanged
- restore the full lineage test suite on the Sink stack

## Validation

- `cargo test -p clinker-lineage --locked --offline` (117 passed)
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This two-file corpus update is stacked on #1093, which adds the Sink telemetry and lineage behavior exercised by these fixtures.

No production behavior, dependencies, telemetry vocabulary, or memory ownership changes in this PR.
