### PR TITLE
Migrate REST fixtures to Sink syntax

### DIFF
--- a/crates/clinker-net/tests/rest_continuation_security.rs
+++ b/crates/clinker-net/tests/rest_continuation_security.rs
@@ -223,7 +223,7 @@ nodes:
 {pagination}
       schema:
         - {{ name: id, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: api
     config:

--- a/crates/clinker-net/tests/rest_executor_e2e.rs
+++ b/crates/clinker-net/tests/rest_executor_e2e.rs
@@ -118,7 +118,7 @@ nodes:
         emit label = label
         emit src_file = $source.file
         emit src_name = $source.name
-  - type: output
+  - type: sink
     name: out
     input: stamp
     config:
@@ -255,7 +255,7 @@ nodes:
       cxl: |
         emit id = id
         emit doubled = amount.to_int() * 2
-  - type: output
+  - type: sink
     name: out
     input: doubler
     config:

--- a/crates/clinker-net/tests/rest_pagination.rs
+++ b/crates/clinker-net/tests/rest_pagination.rs
@@ -165,7 +165,7 @@ nodes:
       schema:
         - {{ name: id, type: int }}
         - {{ name: amount, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: api
     config:
@@ -346,7 +346,7 @@ nodes:
       schema:
         - {{ name: id, type: int }}
         - {{ name: amount, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: api
     config:
@@ -468,7 +468,7 @@ nodes:
       schema:
         - {{ name: id, type: int }}
         - {{ name: amount, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: api
     config:

--- a/crates/clinker-net/tests/rest_retry.rs
+++ b/crates/clinker-net/tests/rest_retry.rs
@@ -126,7 +126,7 @@ nodes:
 {auth}
       schema:
         - {{ name: id, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: api
     config:


### PR DESCRIPTION
## Summary

- migrate seven positive REST integration fixtures from `type: output` to `type: sink`
- preserve continuation, execution, pagination, and retry behavior unchanged
- keep the authored terminal syntax consistent with the Sink cutover

## Validation

- feature-enabled continuation-security target
- feature-enabled REST executor target
- feature-enabled pagination target
- feature-enabled retry target
- 30 tests passed across the exact affected targets
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This focused four-file corpus update is stacked on #1095.

The full crate command was not used because the repository test guide marks the localhost socket suites as environment-sensitive; the exact affected feature-enabled targets are green. No production behavior, dependencies, telemetry vocabulary, or memory ownership changes here.
