### PR TITLE
Migrate planner fixtures to Sink syntax

### DIFF
--- a/crates/clinker-plan/src/plan/tests/ck_lattice.rs
+++ b/crates/clinker-plan/src/plan/tests/ck_lattice.rs
@@ -78,7 +78,7 @@ nodes:
       group_by: [order_id]
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: per_order
     config:
@@ -135,7 +135,7 @@ nodes:
       group_by: [department]
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: dept_totals
     config:
@@ -210,7 +210,7 @@ nodes:
       group_by: [order_id]
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: per_order
     config:
@@ -306,7 +306,7 @@ nodes:
       group_by: [bucket]
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: bucket_totals
     config:
@@ -378,7 +378,7 @@ nodes:
         emit amount = o.amount
         emit name = p.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -442,7 +442,7 @@ nodes:
         emit product_id = o.product_id
         emit name = p.name
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -512,7 +512,7 @@ nodes:
         emit name = p.name
       propagate_ck:
         named: [order_id]
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -560,7 +560,7 @@ nodes:
   - type: merge
     name: all_orders
     inputs: [east, west]
-  - type: output
+  - type: sink
     name: out
     input: all_orders
     config:
@@ -609,7 +609,7 @@ nodes:
       strategy: streaming
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: dept_totals
     config:
@@ -659,7 +659,7 @@ nodes:
       group_by: [order_id]
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: by_id
     config:
@@ -737,7 +737,7 @@ nodes:
         emit total = a.total
         emit budget = l.budget
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -829,7 +829,7 @@ nodes:
         emit total = a.total
         emit avg_priority = b.avg_priority
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -917,7 +917,7 @@ nodes:
         emit total = a.total
         emit avg_priority = b.avg_priority
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -986,7 +986,7 @@ nodes:
       group_by: [order_id]
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: per_order
     config:

--- a/crates/clinker-plan/src/plan/tests/combine_body_typed_on_node.rs
+++ b/crates/clinker-plan/src/plan/tests/combine_body_typed_on_node.rs
@@ -136,7 +136,7 @@ nodes:
     inputs:
       orders: orders_src
       products: products_src
-  - type: output
+  - type: sink
     name: out_top
     input: top_combine
     config:
@@ -144,7 +144,7 @@ nodes:
       type: csv
       path: out_top.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:

--- a/crates/clinker-plan/src/plan/tests/combine_where_scoped_key.rs
+++ b/crates/clinker-plan/src/plan/tests/combine_where_scoped_key.rs
@@ -117,7 +117,7 @@ nodes:
     inputs:
       orders: orders_src
       products: products_src
-  - type: output
+  - type: sink
     name: out_top
     input: join_x
     config:
@@ -125,7 +125,7 @@ nodes:
       type: csv
       path: out_top.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:

--- a/crates/clinker-plan/src/plan/tests/composition_binding_fatal.rs
+++ b/crates/clinker-plan/src/plan/tests/composition_binding_fatal.rs
@@ -66,7 +66,7 @@ nodes:
     use: {use_path}
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:

--- a/crates/clinker-plan/src/plan/tests/composition_source_patch.rs
+++ b/crates/clinker-plan/src/plan/tests/composition_source_patch.rs
@@ -80,7 +80,7 @@ nodes:
     use: ../compositions/with_ref.comp.yaml
     inputs:
       driver: drv
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config:
@@ -294,14 +294,14 @@ nodes:
     use: ../compositions/wrap.comp.yaml
     inputs:
       driver: drv
-  - type: output
+  - type: sink
     name: out_enrich
     input: enrich
     config:
       name: out_enrich
       type: csv
       path: out_enrich.csv
-  - type: output
+  - type: sink
     name: out_wrap
     input: wrap
     config:

--- a/crates/clinker-plan/src/plan/tests/config_fold.rs
+++ b/crates/clinker-plan/src/plan/tests/config_fold.rs
@@ -107,14 +107,14 @@ nodes:
       inp: src
     config:
       min_amount: 100.0
-  - type: output
+  - type: sink
     name: out_low
     input: gate_low
     config:
       name: out_low
       type: csv
       path: out_low.csv
-  - type: output
+  - type: sink
     name: out_high
     input: gate_high
     config:
@@ -200,7 +200,7 @@ nodes:
     use: ../compositions/gate.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: gate
     config:

--- a/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
+++ b/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
@@ -52,14 +52,14 @@ nodes:
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
         - name: drop_big
           drop_group_when: "sum(amount) > 100"
-  - type: output
+  - type: sink
     name: out
     input: cd
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: cd.removed
     config:
@@ -143,14 +143,14 @@ nodes:
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
         - name: drop_big
           drop_group_when: "sum(amount) > 100"
-  - type: output
+  - type: sink
     name: out
     input: cd
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: cd.removed
     config:
@@ -248,14 +248,14 @@ nodes:
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0  # any error in group"
         - name: drop_big
           drop_group_when: "sum(amount) > 100"
-  - type: output
+  - type: sink
     name: out
     input: cd
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: cd.removed
     config:
@@ -328,14 +328,14 @@ nodes:
           drop_group_when: "sum(nonexistent) > 0  # references a missing column"
         - name: drop_big
           drop_group_when: "sum(amount) > 100"
-  - type: output
+  - type: sink
     name: out
     input: cd
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: cd.removed
     config:
@@ -409,7 +409,7 @@ nodes:
             copy_from: trigger
             overrides:
               label: "'synthesized'"
-  - type: output
+  - type: sink
     name: out
     input: rs
     config:

--- a/crates/clinker-plan/src/plan/tests/cull_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/cull_validation.rs
@@ -69,14 +69,14 @@ nodes:
     input: src
     config:
 {cull_config}
-  - type: output
+  - type: sink
     name: out
     input: cd
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: cd.removed
     config:

--- a/crates/clinker-plan/src/plan/tests/dag.rs
+++ b/crates/clinker-plan/src/plan/tests/dag.rs
@@ -62,7 +62,7 @@ nodes:
     config:
       cxl: |
         emit done = true
-  - type: output
+  - type: sink
     name: output
     input: finalize
     config:
@@ -100,7 +100,7 @@ nodes:
     config:
       cxl: |
         emit y = amount * 2
-  - type: output
+  - type: sink
     name: output
     input: step_two
     config:
@@ -196,7 +196,7 @@ nodes:
     cxl: 'emit y = amount
 
       '
-- type: output
+- type: sink
   name: output
   input: beta
   config:
@@ -287,7 +287,7 @@ nodes:
       c: amount > 0
     default: output
     mode: exclusive
-- type: output
+- type: sink
   name: output
   input: router
   config:
@@ -352,7 +352,7 @@ nodes:
     cxl: 'emit z = amount
 
       '
-- type: output
+- type: sink
   name: output
   input: merged
   config:
@@ -410,7 +410,7 @@ nodes:
     cxl: 'emit x = amount
 
       '
-- type: output
+- type: sink
   name: output
   input: only
   config:
@@ -478,7 +478,7 @@ nodes:
     cxl: 'emit x = amount
 
       '
-- type: output
+- type: sink
   name: output
   input: step
   config:
@@ -545,7 +545,7 @@ nodes:
     analytic_window:
       group_by:
       - dept
-- type: output
+- type: sink
   name: output
   input: agg
   config:
@@ -686,7 +686,7 @@ nodes:
       bad: amount + 1
     default: fallback
     mode: exclusive
-- type: output
+- type: sink
   name: bad_out
   input: router.bad
   config:
@@ -694,7 +694,7 @@ nodes:
     path: bad.csv
     include_unmapped: true
     type: csv
-- type: output
+- type: sink
   name: fallback
   input: router.fallback
   config:
@@ -739,7 +739,7 @@ nodes:
     cxl: 'emit x = amount
 
       '
-- type: output
+- type: sink
   name: output
   input: loopy
   config:
@@ -821,7 +821,7 @@ nodes:
     cxl: 'emit done = true
 
       '
-- type: output
+- type: sink
   name: output
   input: finalize
   config:
@@ -889,7 +889,7 @@ fn test_explain_json_node_ids() {
         .collect();
     assert!(slugs.contains(&"source.primary".to_string()));
     assert!(slugs.contains(&"transform.step_one".to_string()));
-    assert!(slugs.contains(&"output.output".to_string()));
+    assert!(slugs.contains(&"sink.output".to_string()));
 }
 
 /// JSON depends_on correctly reflects graph edges.

--- a/crates/clinker-plan/src/plan/tests/dedup_node_rooted.rs
+++ b/crates/clinker-plan/src/plan/tests/dedup_node_rooted.rs
@@ -62,7 +62,7 @@ nodes:
       emit running_count = $window.sum(count)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out_total
   input: total_window
   config:
@@ -70,7 +70,7 @@ nodes:
     path: total.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: out_count
   input: count_window
   config:

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -55,7 +55,7 @@ nodes:
         prev = name;
     }
     yaml.push_str(&format!(
-        "  - type: output\n    name: out\n    input: {prev}\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+        "  - type: sink\n    name: out\n    input: {prev}\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
     ));
 
     let config = parse_config(&yaml).expect("parse doc-paths pipeline");
@@ -145,7 +145,7 @@ nodes:
       cxl: |
         emit amount = amount
         emit total = $doc.Summary.total
-  - type: output
+  - type: sink
     name: out
     input: t0
     config:
@@ -217,7 +217,7 @@ nodes:
       cxl: |
         emit amount = amount
         emit picked = $doc.Summary.total[amount]
-  - type: output
+  - type: sink
     name: out
     input: t0
     config:
@@ -285,7 +285,7 @@ nodes:
         yaml.push_str(&format!("        {line}\n"));
     }
     yaml.push_str(
-        "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+        "  - type: sink\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
     );
     let config = parse_config(&yaml).expect("parse doc-validate pipeline");
     config.compile(&CompileContext::default())
@@ -376,7 +376,7 @@ nodes:
         yaml.push_str(&format!("        {line}\n"));
     }
     yaml.push_str(
-        "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+        "  - type: sink\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
     );
     let config = parse_config(&yaml).expect("parse x12 pipeline");
     config.compile(&CompileContext::default())
@@ -538,7 +538,7 @@ nodes:
             yaml.push_str(&format!("        {line}\n"));
         }
         yaml.push_str(
-            "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+            "  - type: sink\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
         );
         let config = parse_config(&yaml).expect("parse hl7 pipeline");
         config.compile(&CompileContext::default())
@@ -593,7 +593,7 @@ nodes:
             yaml.push_str(&format!("        {line}\n"));
         }
         yaml.push_str(
-            "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+            "  - type: sink\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
         );
         let config = parse_config(&yaml).expect("parse x12 group_section pipeline");
         config.compile(&CompileContext::default())
@@ -661,7 +661,7 @@ nodes:
         yaml.push_str(&format!("        {line}\n"));
     }
     yaml.push_str(
-        "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+        "  - type: sink\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
     );
     let config = parse_config(&yaml).expect("parse rest pipeline");
     config.compile(&CompileContext::default())
@@ -734,7 +734,7 @@ nodes:
               batch_id: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -780,7 +780,7 @@ nodes:
               batch_id: string
       schema:
         - { name: amount, type: int, start: 0, width: 9 }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -843,7 +843,7 @@ nodes:
         emit kind = record_type
         emit amount = amount
         emit batch = $doc.head.batch_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -894,7 +894,7 @@ nodes:
       cxl: |
         emit kind = record_type
         emit batch = $doc.head.batch_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -950,7 +950,7 @@ nodes:
       cxl: |
         emit kind = record_type
         emit batch = $doc.head.bath_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -1007,7 +1007,7 @@ nodes:
       cxl: |
         emit kind = record_type
         emit batch = $doc.hed.batch_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -1068,7 +1068,7 @@ nodes:
         emit kind = record_type
         emit amount = amount
         emit batch = $doc.head.batch_di
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -1108,7 +1108,7 @@ nodes:
       path: ./payments.csv
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -1182,7 +1182,7 @@ nodes:
         emit id = l.id
         emit label = r.label
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -1247,14 +1247,14 @@ nodes:
       conditions:
         big: "amount > $doc.Head.cutoff"
       default: small
-  - type: output
+  - type: sink
     name: big_out
     input: split.big
     config:
       name: big_out
       type: csv
       path: big.csv
-  - type: output
+  - type: sink
     name: small_out
     input: split.small
     config:
@@ -1333,7 +1333,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [tag_alpha, tag_beta]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -1420,7 +1420,7 @@ nodes:
     use: ../compositions/doc_body.comp.yaml
     inputs:
       inp: payments
-  - type: output
+  - type: sink
     name: out
     input: body
     config:
@@ -1535,7 +1535,7 @@ nodes:
       cxl: |
         emit amount = amount
         emit tag = $doc.Shared.tag
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -1585,7 +1585,7 @@ nodes:
 {body}
       schema:
         - {{ name: amount, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -1660,7 +1660,7 @@ nodes:
               batch_id: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: docs
     config:
@@ -1704,7 +1704,7 @@ nodes:
               batch_id: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: docs
     config:
@@ -1754,7 +1754,7 @@ nodes:
             yaml.push_str(&format!("        {line}\n"));
         }
         yaml.push_str(
-            "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+            "  - type: sink\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
         );
         let config = parse_config(&yaml).expect("parse x12 name-collision pipeline");
         config.compile(&CompileContext::default())
@@ -1805,7 +1805,7 @@ nodes:
               a: string
       schema:
         - {{ name: seg_id, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-plan/src/plan/tests/dup_body_node_name.rs
+++ b/crates/clinker-plan/src/plan/tests/dup_body_node_name.rs
@@ -79,7 +79,7 @@ nodes:
     use: ../compositions/dup_body.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:

--- a/crates/clinker-plan/src/plan/tests/envelope_synthesis.rs
+++ b/crates/clinker-plan/src/plan/tests/envelope_synthesis.rs
@@ -46,7 +46,7 @@ nodes:
         yaml.push_str(&format!("      {line}\n"));
     }
     yaml.push_str(
-        "  - type: output\n    name: out\n    input: framed\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+        "  - type: sink\n    name: out\n    input: framed\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
     );
     yaml
 }


### PR DESCRIPTION
## Summary

- migrate 79 positive planner fixtures from `type: output` to `type: sink`
- update the explain-node slug expectation from the retired Output kind to the Sink kind
- preserve every planner scenario and diagnostic assertion otherwise unchanged

## Validation

- 13 exact affected planner module filters (115 passed)
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This planner corpus shard is stacked on #1096.

The full planner library command now reaches the remaining unmigrated fixture shards and is therefore not claimed green in this PR. Those shards are being kept separate so each review remains mechanical and bounded. No production behavior, dependencies, telemetry vocabulary, or memory ownership changes here.
