### PR TITLE
Migrate planner validation fixtures to Sink syntax

### DIFF
--- a/crates/clinker-exec/tests/fixtures/pipelines/nested_composition_pipeline.yaml
+++ b/crates/clinker-exec/tests/fixtures/pipelines/nested_composition_pipeline.yaml
@@ -24,7 +24,7 @@ nodes:
     config:
       strict_mode: false
 
-  - type: output
+  - type: sink
     name: final_out
     input: nested_process
     config:

--- a/crates/clinker-plan/src/plan/tests/explain_buffer_class.rs
+++ b/crates/clinker-plan/src/plan/tests/explain_buffer_class.rs
@@ -86,7 +86,7 @@ nodes:
       cxl: |
         emit doubled = amount * 2
 
-  - type: output
+  - type: sink
     name: out
     input: scale
     config:
@@ -115,7 +115,7 @@ fn buffer_class_marks_fused_source_transform_output_chain_streaming() {
 
     assert_eq!(buffer_class_for(block, "source.primary"), "streaming");
     assert_eq!(buffer_class_for(block, "transform.scale"), "streaming");
-    assert_eq!(buffer_class_for(block, "output.out"), "streaming");
+    assert_eq!(buffer_class_for(block, "sink.out"), "streaming");
 }
 
 // ── Gate 2: route fan-out forces materialization ─────────────────────
@@ -144,7 +144,7 @@ nodes:
         out_low: "amount <= 100"
       default: out_low
 
-  - type: output
+  - type: sink
     name: out_high
     input: categorize.out_high
     config:
@@ -153,7 +153,7 @@ nodes:
       path: out_high.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: out_low
     input: categorize.out_low
     config:
@@ -177,8 +177,8 @@ fn buffer_class_marks_route_materialized_and_sinks_streaming() {
 
     assert_eq!(buffer_class_for(block, "route.categorize"), "materialized");
     assert_eq!(buffer_class_for(block, "source.primary"), "materialized");
-    assert_eq!(buffer_class_for(block, "output.out_high"), "streaming");
-    assert_eq!(buffer_class_for(block, "output.out_low"), "streaming");
+    assert_eq!(buffer_class_for(block, "sink.out_high"), "streaming");
+    assert_eq!(buffer_class_for(block, "sink.out_low"), "streaming");
 }
 
 fn shared_source_interleaves_yaml() -> &'static str {
@@ -225,7 +225,7 @@ nodes:
     config:
       mode: interleave
 
-  - type: output
+  - type: sink
     name: left_out
     input: left_merge
     config:
@@ -233,7 +233,7 @@ nodes:
       type: csv
       path: left_out.csv
 
-  - type: output
+  - type: sink
     name: right_out
     input: right_merge
     config:

--- a/crates/clinker-plan/src/plan/tests/explain_polish.rs
+++ b/crates/clinker-plan/src/plan/tests/explain_polish.rs
@@ -59,7 +59,7 @@ nodes:
       group_by: [dept]
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: output
     input: by_dept
     config:
@@ -146,7 +146,7 @@ fn test_explain_aggregate_renders_as_sibling() {
         .unwrap();
     let output_idx = topology
         .lines()
-        .position(|l| l.contains("[output] output"))
+        .position(|l| l.contains("[sink] output"))
         .unwrap();
     assert!(source_idx < agg_idx && agg_idx < output_idx);
 }
@@ -176,7 +176,7 @@ nodes:
     config:
       cxl: |
         emit x = amount + 1
-  - type: output
+  - type: sink
     name: output
     input: step_one
     config:

--- a/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
@@ -32,7 +32,7 @@ nodes:
       options:
         record_path: Orders/Order
 {source_body}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -58,7 +58,7 @@ nodes:
       type: json
       path: ./in.json
 {source_body}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -406,7 +406,7 @@ nodes:
     config:
       cxl: |
         emit id = id
-  - type: output
+  - type: sink
     name: out
     input: pick
     config:
@@ -437,7 +437,7 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: pick
     config:
@@ -479,7 +479,7 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: codes, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -516,7 +516,7 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: codes, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -569,7 +569,7 @@ nodes:
         emit id = orders.id
         emit tags = events.tags
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: report
     input: enriched
     config:
@@ -613,7 +613,7 @@ nodes:
             columns:
               - { name: kind, type: string }
               - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -658,7 +658,7 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: report_sink
     input: orders_src
     config:
@@ -696,7 +696,7 @@ nodes:
       type: json
       path: ./orders.json
       schema: {}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -730,7 +730,7 @@ nodes:
       split_values:
         - tags
       schema: {}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -888,7 +888,7 @@ nodes:
       type: {source_format}
       path: ./in.dat
 {source_body}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -1055,7 +1055,7 @@ nodes:
             columns:
               - { name: kind, type: string }
               - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -1189,7 +1189,7 @@ nodes:
         record_path: Orders/Order
       schema:
         - {{ name: tags, type: string, multiple: true }}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -1434,7 +1434,7 @@ nodes:
 {split_block}
       schema:
         - {{ name: tags, type: string, multiple: true }}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -1495,7 +1495,7 @@ nodes:
         - { field: tags, delimiter: "::", escape: "\\" }
       schema:
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -1542,7 +1542,7 @@ nodes:
         - { field: tags, json: true, delimiter: "" }
       schema:
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -1597,7 +1597,7 @@ nodes:
         - { field: tags, delimiter: "", escape: "\\" }
       schema:
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/output_mapping_validation.rs
@@ -39,7 +39,7 @@ nodes:
         - {{ name: first_name, type: string }}
         - {{ name: last_name, type: string }}
         - {{ name: department, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: people
     config:
@@ -344,7 +344,7 @@ nodes:
       path: ./people.csv
       schema:
         - { name: first_name, type: string }
-  - type: output
+  - type: sink
     name: out
     input: people
     config:
@@ -378,7 +378,7 @@ nodes:
       path: ./people.csv
       schema:
         - { name: first_name, type: string }
-  - type: output
+  - type: sink
     name: out
     input: people
     config:
@@ -412,7 +412,7 @@ nodes:
       path: ./people.csv
       schema:
         - { name: first_name, type: string }
-  - type: output
+  - type: sink
     name: out
     input: people
     config:

--- a/crates/clinker-plan/src/plan/tests/overlay_compile.rs
+++ b/crates/clinker-plan/src/plan/tests/overlay_compile.rs
@@ -41,7 +41,7 @@ nodes:
     input: orders
     config:
       cxl: "emit order_id = order_id\nemit amount = amount"
-  - type: output
+  - type: sink
     name: sink
     input: normalize
     config:
@@ -401,7 +401,7 @@ nodes:
     input: orders
     config:
       cxl: "emit order_id = order_id\nemit amount = amount"
-  - type: output
+  - type: sink
     name: sink
     input: normalize
     config:
@@ -457,7 +457,7 @@ nodes:
       path: orders.csv
       schema:
         - { name: amount, type: numeric }
-  - type: output
+  - type: sink
     name: sink
     input: orders
     config:

--- a/crates/clinker-plan/src/plan/tests/plan_time_window_root.rs
+++ b/crates/clinker-plan/src/plan/tests/plan_time_window_root.rs
@@ -42,7 +42,7 @@ nodes:
       emit running_amount = $window.sum(amount)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: windowed
   config:
@@ -124,7 +124,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:

--- a/crates/clinker-plan/src/plan/tests/predicate_support.rs
+++ b/crates/clinker-plan/src/plan/tests/predicate_support.rs
@@ -67,21 +67,21 @@ nodes:
         high: "amount > 100"
         flagged: "status == 'urgent'"
       default: low
-  - type: output
+  - type: sink
     name: high_out
     input: split.high
     config:
       name: high_out
       type: csv
       path: high.csv
-  - type: output
+  - type: sink
     name: flagged_out
     input: split.flagged
     config:
       name: flagged_out
       type: csv
       path: flagged.csv
-  - type: output
+  - type: sink
     name: low_out
     input: split.low
     config:
@@ -162,7 +162,7 @@ nodes:
         emit order_id = orders.order_id
         emit pname = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: join
     config:
@@ -222,14 +222,14 @@ nodes:
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
         - name: drop_big
           drop_group_when: "sum(amount) > 100"
-  - type: output
+  - type: sink
     name: out
     input: cd
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: cd.removed
     config:
@@ -281,7 +281,7 @@ nodes:
       cxl: |
         emit id = id
         emit amount = amount
-  - type: output
+  - type: sink
     name: out
     input: passthrough
     config:

--- a/crates/clinker-plan/src/plan/tests/record_path_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/record_path_validation.rs
@@ -27,7 +27,7 @@ nodes:
       path: ./in.{format}
 {options}      schema:
         - {{ name: id, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-plan/src/plan/tests/reshape_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/reshape_validation.rs
@@ -70,7 +70,7 @@ nodes:
     input: src
     config:
 {reshape_config}
-  - type: output
+  - type: sink
     name: out
     input: rs
     config:
@@ -266,7 +266,7 @@ nodes:
       partition_by: [account]
       rules:
 {rules}
-  - type: output
+  - type: sink
     name: out
     input: rs
     config:

--- a/crates/clinker-plan/src/plan/tests/route_ports.rs
+++ b/crates/clinker-plan/src/plan/tests/route_ports.rs
@@ -78,14 +78,14 @@ fn port_form_references_tag_each_branch() {
       conditions:
         high: "amount.to_int() > 100"
       default: low
-  - type: output
+  - type: sink
     name: high_out
     input: split.high
     config:
       name: high_out
       type: csv
       path: high.csv
-  - type: output
+  - type: sink
     name: low_out
     input: split.low
     config:
@@ -98,8 +98,8 @@ fn port_form_references_tag_each_branch() {
     assert_eq!(
         route_port_targets(&yaml),
         vec![
-            (Some("high".to_string()), "output.high_out".to_string()),
-            (Some("low".to_string()), "output.low_out".to_string()),
+            (Some("high".to_string()), "sink.high_out".to_string()),
+            (Some("low".to_string()), "sink.low_out".to_string()),
         ],
     );
 }
@@ -119,14 +119,14 @@ fn bare_name_references_tag_the_matching_branch() {
       conditions:
         high: "amount.to_int() > 100"
       default: low
-  - type: output
+  - type: sink
     name: high
     input: split
     config:
       name: high
       type: csv
       path: high.csv
-  - type: output
+  - type: sink
     name: low
     input: split
     config:
@@ -139,8 +139,8 @@ fn bare_name_references_tag_the_matching_branch() {
     assert_eq!(
         route_port_targets(&yaml),
         vec![
-            (Some("high".to_string()), "output.high".to_string()),
-            (Some("low".to_string()), "output.low".to_string()),
+            (Some("high".to_string()), "sink.high".to_string()),
+            (Some("low".to_string()), "sink.low".to_string()),
         ],
     );
 }
@@ -159,21 +159,21 @@ fn one_branch_fans_to_multiple_consumers() {
       conditions:
         high: "amount.to_int() > 100"
       default: low
-  - type: output
+  - type: sink
     name: high_a
     input: split.high
     config:
       name: high_a
       type: csv
       path: high_a.csv
-  - type: output
+  - type: sink
     name: high_b
     input: split.high
     config:
       name: high_b
       type: csv
       path: high_b.csv
-  - type: output
+  - type: sink
     name: low_out
     input: split.low
     config:
@@ -186,9 +186,9 @@ fn one_branch_fans_to_multiple_consumers() {
     assert_eq!(
         route_port_targets(&yaml),
         vec![
-            (Some("high".to_string()), "output.high_a".to_string()),
-            (Some("high".to_string()), "output.high_b".to_string()),
-            (Some("low".to_string()), "output.low_out".to_string()),
+            (Some("high".to_string()), "sink.high_a".to_string()),
+            (Some("high".to_string()), "sink.high_b".to_string()),
+            (Some("low".to_string()), "sink.low_out".to_string()),
         ],
     );
 }

--- a/crates/clinker-plan/src/plan/tests/typed_scoped_key.rs
+++ b/crates/clinker-plan/src/plan/tests/typed_scoped_key.rs
@@ -85,7 +85,7 @@ nodes:
     use: ../compositions/scoped_transform.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out_top
     input: shape
     config:
@@ -93,7 +93,7 @@ nodes:
       type: csv
       path: out_top.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:

--- a/crates/clinker-plan/src/plan/tests/watermark_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/watermark_validation.rs
@@ -41,7 +41,7 @@ nodes:
     schema:
       - { name: id, type: int }
       - { name: event_time, type: date_time }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -78,7 +78,7 @@ nodes:
     schema:
       - { name: id, type: int }
       - { name: event_time, type: date_time }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -115,7 +115,7 @@ nodes:
     schema:
       - { name: id, type: int }
       - { name: day, type: date }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -154,7 +154,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: hourly_clicks
   config:
@@ -206,7 +206,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: hourly_clicks
   config:
@@ -262,7 +262,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: hourly_clicks
   config:
@@ -311,7 +311,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: by_user
   config:
@@ -340,7 +340,7 @@ nodes:
     schema:
       - { name: id, type: int }
       - { name: event_time, type: date_time }
-- type: output
+- type: sink
   name: out
   input: src
   config:

--- a/crates/clinker-plan/tests/dotted_node_names.rs
+++ b/crates/clinker-plan/tests/dotted_node_names.rs
@@ -59,7 +59,7 @@ nodes:
       path: in.csv
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: raw.orders
     config:
@@ -85,7 +85,7 @@ nodes:
       path: in.csv
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: enrich.ref
     input: src
     config:
@@ -146,7 +146,7 @@ nodes:
     use: ../compositions/passthrough.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: enrich.step
     config:
@@ -209,7 +209,7 @@ nodes:
     use: ../compositions/dotted_body.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config:
@@ -247,14 +247,14 @@ nodes:
       conditions:
         high: "amount > 100"
       default: low
-  - type: output
+  - type: sink
     name: high_out
     input: split.high
     config:
       name: high_out
       type: csv
       path: high.csv
-  - type: output
+  - type: sink
     name: low_out
     input: split.low
     config:


### PR DESCRIPTION
## Summary

- migrate 68 positive planner validation fixtures from `type: output` to `type: sink`
- update assertions that intentionally encode the renamed Sink node kind
- migrate the nested-composition YAML fixture directly consumed by the overlay tests

## Validation

- 12 exact affected planner module filters (138 passed)
- `dotted_node_names` integration target (5 passed)
- 143 focused tests passed in total
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This planner corpus shard is stacked on #1097.

The full planner suite is not claimed green yet because later fixture shards still contain the retired positive syntax. No production behavior, dependencies, telemetry vocabulary, or memory ownership changes here.
