### PR TITLE
Bound credential leases under run memory

### DIFF
--- a/crates/clinker/src/credential_profile.rs
+++ b/crates/clinker/src/credential_profile.rs
@@ -721,32 +721,47 @@ impl MemoryConsumer for CredentialRegistryConsumer {
     }
 
     fn try_spill(&self, target_bytes: u64) -> Result<u64, ConsumerSpillError> {
+        // The arbitrator holds only shared access, while revocation and
+        // ordered teardown belong to the registry's run thread. Deliver the
+        // request without claiming that this callback released live state.
         self.handle.request_spill();
-        let bytes = self.handle.bytes();
-        if bytes >= target_bytes {
-            Ok(bytes)
-        } else {
-            Err(ConsumerSpillError::BelowTarget {
-                target: target_bytes,
-                freed: bytes,
-            })
-        }
+        Err(ConsumerSpillError::BelowTarget {
+            target: target_bytes,
+            freed: 0,
+        })
     }
 
     fn can_back_pressure(&self) -> bool {
-        true
+        false
     }
+}
 
-    fn pause(&self) {
-        self.handle.pause();
-    }
+#[cfg(test)]
+mod memory_consumer_contract_tests {
+    use super::*;
 
-    fn resume(&self) {
-        self.handle.resume();
-    }
+    #[test]
+    fn registered_consumer_reports_only_bytes_freed_synchronously() {
+        let handle = ConsumerHandle::new();
+        handle.set_bytes(4_096);
+        let consumer = Arc::new(CredentialRegistryConsumer::new(Arc::clone(&handle)));
+        let arbitrator =
+            MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, MemoryArbitrator::default_policy());
+        let consumer_id = arbitrator.register_consumer(consumer.clone());
 
-    fn is_paused(&self) -> bool {
-        self.handle.is_paused()
+        let result = consumer.try_spill(2_048);
+
+        assert!(matches!(
+            result,
+            Err(ConsumerSpillError::BelowTarget {
+                target: 2_048,
+                freed: 0,
+            })
+        ));
+        assert!(!consumer.can_back_pressure());
+        assert_eq!(consumer.current_usage(), 4_096);
+        assert!(handle.take_spill_request());
+        assert!(arbitrator.unregister_consumer(consumer_id).is_some());
     }
 }
 
@@ -755,8 +770,9 @@ impl MemoryConsumer for CredentialRegistryConsumer {
 /// The registry preallocates a fixed handle table, registers exactly one
 /// [`MemoryConsumer`], and charges each provider-declared lease plus its
 /// secret-free handle metadata before the provider may allocate it. Credential
-/// state is never written to spill: a spill request revokes and releases the
-/// complete preflight set before another acquisition is attempted.
+/// state is never written to spill. The consumer reports zero bytes freed when
+/// the arbitrator requests a spill, then the registry revokes and releases the
+/// complete preflight set at its next owned memory-signal checkpoint.
 pub struct CredentialHandleRegistry<'catalog, 'run>
 where
     'run: 'catalog,
@@ -764,6 +780,7 @@ where
     arbitrator: &'catalog MemoryArbitrator,
     catalog: &'catalog CredentialProfileCatalog<'run>,
     memory_handle: Arc<ConsumerHandle>,
+    consumer: Arc<CredentialRegistryConsumer>,
     consumer_id: Option<ConsumerId>,
     handles: Vec<LeasedCredentialHandle<'run>>,
     retained_bytes: u64,
@@ -803,13 +820,13 @@ where
             })?;
         let memory_handle = ConsumerHandle::new();
         memory_handle.set_bytes(table_bytes);
-        let consumer_id = arbitrator.register_consumer(Arc::new(CredentialRegistryConsumer::new(
-            Arc::clone(&memory_handle),
-        )));
+        let consumer = Arc::new(CredentialRegistryConsumer::new(Arc::clone(&memory_handle)));
+        let consumer_id = arbitrator.register_consumer(consumer.clone());
         Ok(Self {
             arbitrator,
             catalog,
             memory_handle,
+            consumer,
             consumer_id: Some(consumer_id),
             handles,
             retained_bytes: table_bytes,
@@ -833,19 +850,7 @@ where
         selected: &CredentialProfileName,
         requirement: &CredentialRequirement,
     ) -> Result<&LeasedCredentialHandle<'run>, CredentialRegistryError> {
-        if self.consumer_id.is_none() {
-            return Err(CredentialRegistryError::new(
-                CredentialRegistryErrorKind::Closed,
-            ));
-        }
-
-        if self.memory_handle.take_spill_request() {
-            return Err(self.fail_and_close(CredentialRegistryErrorKind::SpillRequested));
-        }
-        self.memory_handle.wait_while_paused();
-        if self.memory_handle.take_spill_request() {
-            return Err(self.fail_and_close(CredentialRegistryErrorKind::SpillRequested));
-        }
+        self.honor_memory_signals()?;
         if self.handles.len() >= self.catalog.limits.max_live_handles {
             return Err(self.fail_and_close(CredentialRegistryErrorKind::HandleLimitExceeded));
         }
@@ -916,7 +921,37 @@ where
 
     /// Bytes currently reported through the registry's consumer handle.
     pub fn retained_bytes(&self) -> u64 {
-        self.memory_handle.bytes()
+        self.consumer.current_usage()
+    }
+
+    /// Honor delivered pause or spill signals at a registry-owned boundary.
+    ///
+    /// The registered consumer has no inbound producer and therefore does not
+    /// advertise arbitrator backpressure. An explicit run coordinator may
+    /// still pause the shared handle before entering this checkpoint. A spill
+    /// request always fails closed: every live lease is revoked in reverse
+    /// acquisition order and the consumer is unregistered before returning.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CredentialRegistryErrorKind::SpillRequested`] after cleanup
+    /// when the arbitrator delivered a spill request, or
+    /// [`CredentialRegistryErrorKind::Closed`] after prior teardown.
+    pub fn honor_memory_signals(&mut self) -> Result<(), CredentialRegistryError> {
+        if self.consumer_id.is_none() {
+            return Err(CredentialRegistryError::new(
+                CredentialRegistryErrorKind::Closed,
+            ));
+        }
+
+        if self.memory_handle.take_spill_request() {
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::SpillRequested));
+        }
+        self.memory_handle.wait_while_paused();
+        if self.memory_handle.take_spill_request() {
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::SpillRequested));
+        }
+        Ok(())
     }
 
     /// Revoke and release every handle, then unregister the memory consumer.
@@ -943,8 +978,10 @@ where
 
     /// Borrow the non-secret memory coordination handle for run control.
     ///
-    /// Callers may use this only to observe accounting or deliver the same
-    /// pause/spill signals as the registered consumer; it exposes no lease.
+    /// Callers may use this only to observe accounting or deliver explicit
+    /// run-coordination pause/spill signals; it exposes no lease. The
+    /// registered arbitrator consumer does not advertise backpressure because
+    /// the registry has no inbound producer to pause.
     pub fn memory_handle(&self) -> &Arc<ConsumerHandle> {
         &self.memory_handle
     }

--- a/crates/clinker/src/credential_profile.rs
+++ b/crates/clinker/src/credential_profile.rs
@@ -6,7 +6,11 @@
 
 use std::fmt;
 use std::marker::PhantomData;
+use std::sync::Arc;
 
+use clinker_exec::pipeline::memory::{
+    ConsumerHandle, ConsumerId, ConsumerSpillError, MemoryArbitrator, MemoryConsumer,
+};
 use clinker_plan::credentials::{
     CredentialCapability, CredentialHandleUnits, CredentialLifetime, CredentialProviderKind,
     CredentialRenewal, CredentialRequirement, CredentialRequirementName, CredentialRevocation,
@@ -56,11 +60,98 @@ impl fmt::Display for CredentialProfileNameError {
 
 impl std::error::Error for CredentialProfileNameError {}
 
+/// Default maximum number of named profiles admitted for one run.
+pub const DEFAULT_MAX_CREDENTIAL_PROFILES: usize = 64;
+/// Default maximum provider registrations across every admitted profile.
+pub const DEFAULT_MAX_CREDENTIAL_PROVIDERS: usize = 256;
+/// Default maximum decoded bytes across profile and provider definitions.
+pub const DEFAULT_MAX_CREDENTIAL_DEFINITION_BYTES: usize = 1_048_576;
+/// Default maximum number of simultaneously live credential handles.
+pub const DEFAULT_MAX_LIVE_CREDENTIAL_HANDLES: usize = 256;
+
+/// Fixed admission limits for profile definitions and live handles.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CredentialProfileLimits {
+    max_profiles: usize,
+    max_providers: usize,
+    max_decoded_bytes: usize,
+    max_live_handles: usize,
+}
+
+impl CredentialProfileLimits {
+    /// Construct explicit fixed limits for one run.
+    pub const fn new(
+        max_profiles: usize,
+        max_providers: usize,
+        max_decoded_bytes: usize,
+        max_live_handles: usize,
+    ) -> Self {
+        Self {
+            max_profiles,
+            max_providers,
+            max_decoded_bytes,
+            max_live_handles,
+        }
+    }
+
+    /// Maximum admitted profile definitions.
+    pub const fn max_profiles(self) -> usize {
+        self.max_profiles
+    }
+
+    /// Maximum provider registrations across all profiles.
+    pub const fn max_providers(self) -> usize {
+        self.max_providers
+    }
+
+    /// Maximum decoded definition bytes.
+    pub const fn max_decoded_bytes(self) -> usize {
+        self.max_decoded_bytes
+    }
+
+    /// Maximum simultaneously live handles retained by the registry.
+    pub const fn max_live_handles(self) -> usize {
+        self.max_live_handles
+    }
+}
+
+impl Default for CredentialProfileLimits {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_MAX_CREDENTIAL_PROFILES,
+            DEFAULT_MAX_CREDENTIAL_PROVIDERS,
+            DEFAULT_MAX_CREDENTIAL_DEFINITION_BYTES,
+            DEFAULT_MAX_LIVE_CREDENTIAL_HANDLES,
+        )
+    }
+}
+
 /// Opaque provider-owned state that remains live for a resolved credential.
 ///
 /// The marker deliberately exposes no secret accessor. Dropping the enclosing
 /// [`LeasedCredentialHandle`] closes the lease on every ordinary exit path.
-pub trait CredentialLease: Send + Sync {}
+pub trait CredentialLease: Send + Sync {
+    /// True retained bytes owned by this lease, including its boxed payload.
+    fn retained_bytes(&self) -> u64;
+
+    /// Revoke provider-side authority before releasing the local lease.
+    fn revoke(&mut self) -> Result<(), CredentialLeaseFailure>;
+}
+
+/// A closed, sanitized lease-revocation failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CredentialLeaseFailure {
+    /// The provider could not confirm revocation at cleanup time.
+    Unavailable,
+}
+
+impl fmt::Display for CredentialLeaseFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("credential lease revocation could not be confirmed")
+    }
+}
+
+impl std::error::Error for CredentialLeaseFailure {}
 
 /// A closed, sanitized failure returned by a credential provider.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -84,7 +175,7 @@ impl std::error::Error for CredentialProviderFailure {}
 /// Compatibility metadata is inspected before `resolve` is called. Provider
 /// implementations return only an opaque owned lease and a closed failure;
 /// arbitrary secret-store errors cannot cross this boundary.
-pub trait CredentialProvider {
+pub trait CredentialProvider: Send + Sync {
     /// Stable implementation kind supplied by this provider.
     fn kind(&self) -> &CredentialProviderKind;
 
@@ -103,6 +194,22 @@ pub trait CredentialProvider {
     /// Maximum handle-capacity units admitted for one lease.
     fn handle_capacity(&self) -> CredentialHandleUnits;
 
+    /// Decoded bytes retained by this provider's profile definition.
+    ///
+    /// The count includes secret-bearing decoded configuration without
+    /// exposing it. [`CredentialProfileCatalog::admit`] checks the aggregate
+    /// before any definition becomes eligible for resolution.
+    fn decoded_definition_bytes(&self) -> usize;
+
+    /// Exact bytes the next resolved lease will retain.
+    ///
+    /// The registry charges this value before `resolve` may allocate the
+    /// lease, then verifies it against [`CredentialLease::retained_bytes`].
+    fn lease_retained_bytes(
+        &self,
+        requirement: &CredentialRequirement,
+    ) -> Result<u64, CredentialProviderFailure>;
+
     /// Resolve one validated logical requirement to an opaque owned lease.
     fn resolve(
         &self,
@@ -118,6 +225,189 @@ pub struct CredentialProfile<'run> {
     name: CredentialProfileName,
     providers: &'run [&'run dyn CredentialProvider],
 }
+
+/// A bounded, validated view over supplied credential profile definitions.
+///
+/// Admission borrows the definitions rather than copying secret-bearing
+/// provider state. Counts, decoded bytes, and duplicate names are checked in a
+/// complete pass before the catalog can be used for resolution.
+pub struct CredentialProfileCatalog<'run> {
+    profiles: &'run [CredentialProfile<'run>],
+    limits: CredentialProfileLimits,
+    provider_count: usize,
+    decoded_bytes: usize,
+}
+
+impl<'run> CredentialProfileCatalog<'run> {
+    /// Admit supplied definitions under fixed count and decoded-byte limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized error before producing a catalog when any count or
+    /// byte ceiling is exceeded, arithmetic overflows, or a profile/provider
+    /// kind is duplicated.
+    pub fn admit(
+        profiles: &'run [CredentialProfile<'run>],
+        limits: CredentialProfileLimits,
+    ) -> Result<Self, CredentialProfileAdmissionError> {
+        if profiles.len() > limits.max_profiles {
+            return Err(CredentialProfileAdmissionError::new(
+                CredentialProfileAdmissionErrorKind::TooManyProfiles,
+            ));
+        }
+
+        let mut provider_count = 0usize;
+        let mut decoded_bytes = 0usize;
+        for profile in profiles {
+            provider_count = provider_count
+                .checked_add(profile.providers.len())
+                .ok_or_else(|| {
+                    CredentialProfileAdmissionError::new(
+                        CredentialProfileAdmissionErrorKind::DefinitionSizeOverflow,
+                    )
+                })?;
+            if provider_count > limits.max_providers {
+                return Err(CredentialProfileAdmissionError::new(
+                    CredentialProfileAdmissionErrorKind::TooManyProviders,
+                ));
+            }
+
+            decoded_bytes = decoded_bytes
+                .checked_add(profile.name.as_str().len())
+                .ok_or_else(|| {
+                    CredentialProfileAdmissionError::new(
+                        CredentialProfileAdmissionErrorKind::DefinitionSizeOverflow,
+                    )
+                })?;
+            for &provider in profile.providers {
+                decoded_bytes = decoded_bytes
+                    .checked_add(provider.kind().as_str().len())
+                    .and_then(|bytes| bytes.checked_add(provider.decoded_definition_bytes()))
+                    .ok_or_else(|| {
+                        CredentialProfileAdmissionError::new(
+                            CredentialProfileAdmissionErrorKind::DefinitionSizeOverflow,
+                        )
+                    })?;
+                if decoded_bytes > limits.max_decoded_bytes {
+                    return Err(CredentialProfileAdmissionError::new(
+                        CredentialProfileAdmissionErrorKind::DecodedBytesExceeded,
+                    ));
+                }
+            }
+        }
+
+        for (index, profile) in profiles.iter().enumerate() {
+            if profiles[..index]
+                .iter()
+                .any(|earlier| earlier.name == profile.name)
+            {
+                return Err(CredentialProfileAdmissionError::new(
+                    CredentialProfileAdmissionErrorKind::DuplicateProfile,
+                ));
+            }
+            for (provider_index, provider) in profile.providers.iter().copied().enumerate() {
+                if profile.providers[..provider_index]
+                    .iter()
+                    .copied()
+                    .any(|earlier| earlier.kind() == provider.kind())
+                {
+                    return Err(CredentialProfileAdmissionError::new(
+                        CredentialProfileAdmissionErrorKind::DuplicateProvider,
+                    ));
+                }
+            }
+        }
+
+        Ok(Self {
+            profiles,
+            limits,
+            provider_count,
+            decoded_bytes,
+        })
+    }
+
+    /// Fixed limits used to admit this catalog.
+    pub const fn limits(&self) -> CredentialProfileLimits {
+        self.limits
+    }
+
+    /// Number of admitted profiles.
+    pub fn profile_count(&self) -> usize {
+        self.profiles.len()
+    }
+
+    /// Number of admitted provider registrations.
+    pub const fn provider_count(&self) -> usize {
+        self.provider_count
+    }
+
+    /// Total decoded definition bytes admitted.
+    pub const fn decoded_bytes(&self) -> usize {
+        self.decoded_bytes
+    }
+}
+
+/// Stable category for a profile-catalog admission failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CredentialProfileAdmissionErrorKind {
+    /// The profile count exceeded its fixed ceiling.
+    TooManyProfiles,
+    /// The provider-registration count exceeded its fixed ceiling.
+    TooManyProviders,
+    /// Decoded definition bytes exceeded their fixed ceiling.
+    DecodedBytesExceeded,
+    /// Definition byte or count arithmetic overflowed.
+    DefinitionSizeOverflow,
+    /// A profile name was supplied more than once.
+    DuplicateProfile,
+    /// One profile supplied the same provider kind more than once.
+    DuplicateProvider,
+}
+
+/// A sanitized profile-catalog admission failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CredentialProfileAdmissionError {
+    kind: CredentialProfileAdmissionErrorKind,
+}
+
+impl CredentialProfileAdmissionError {
+    const fn new(kind: CredentialProfileAdmissionErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Stable failure category.
+    pub const fn kind(self) -> CredentialProfileAdmissionErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for CredentialProfileAdmissionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self.kind {
+            CredentialProfileAdmissionErrorKind::TooManyProfiles => {
+                "credential profile count exceeds the fixed admission limit"
+            }
+            CredentialProfileAdmissionErrorKind::TooManyProviders => {
+                "credential provider count exceeds the fixed admission limit"
+            }
+            CredentialProfileAdmissionErrorKind::DecodedBytesExceeded => {
+                "credential profile decoded bytes exceed the fixed admission limit"
+            }
+            CredentialProfileAdmissionErrorKind::DefinitionSizeOverflow => {
+                "credential profile definition size overflowed"
+            }
+            CredentialProfileAdmissionErrorKind::DuplicateProfile => {
+                "credential profile name is configured more than once"
+            }
+            CredentialProfileAdmissionErrorKind::DuplicateProvider => {
+                "credential provider kind is configured more than once in one profile"
+            }
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for CredentialProfileAdmissionError {}
 
 impl<'run> CredentialProfile<'run> {
     /// Construct a named profile from a borrowed provider slice.
@@ -163,7 +453,9 @@ pub struct LeasedCredentialHandle<'run> {
     requirement_name: CredentialRequirementName,
     provider_kind: CredentialProviderKind,
     handle_units: CredentialHandleUnits,
-    _lease: Box<dyn CredentialLease>,
+    retained_bytes: u64,
+    lease: Box<dyn CredentialLease>,
+    revoked: bool,
     _run: PhantomData<&'run CredentialProfile<'run>>,
 }
 
@@ -182,11 +474,30 @@ impl LeasedCredentialHandle<'_> {
     pub const fn handle_units(&self) -> CredentialHandleUnits {
         self.handle_units
     }
+
+    fn retained_bytes(&self) -> u64 {
+        self.retained_bytes
+    }
+
+    fn revoke(&mut self) -> Result<(), CredentialLeaseFailure> {
+        if self.revoked {
+            return Ok(());
+        }
+        let result = self.lease.revoke();
+        self.revoked = true;
+        result
+    }
 }
 
 impl fmt::Debug for LeasedCredentialHandle<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("LeasedCredentialHandle { credential: <redacted> }")
+    }
+}
+
+impl Drop for LeasedCredentialHandle<'_> {
+    fn drop(&mut self) {
+        let _ = self.revoke();
     }
 }
 
@@ -215,6 +526,8 @@ pub enum CredentialResolutionErrorKind {
     ProviderUnavailable,
     /// The provider refused the logical requirement.
     ProviderRefused,
+    /// The resolved lease did not match its pre-allocation byte declaration.
+    RetainedBytesMismatch,
 }
 
 /// A sanitized explicit profile-resolution failure.
@@ -273,6 +586,9 @@ impl fmt::Display for CredentialResolutionError {
             CredentialResolutionErrorKind::ProviderRefused => {
                 "credential provider refused the logical requirement before the run began"
             }
+            CredentialResolutionErrorKind::RetainedBytesMismatch => {
+                "credential provider returned a lease with inconsistent retained-byte accounting"
+            }
         };
         formatter.write_str(message)
     }
@@ -287,10 +603,45 @@ impl std::error::Error for CredentialResolutionError {}
 /// inspect a plan or infer a profile from any other run option.
 pub fn resolve_explicit_profile<'run>(
     selected: &CredentialProfileName,
-    profiles: &'run [CredentialProfile<'run>],
+    catalog: &CredentialProfileCatalog<'run>,
     requirement: &CredentialRequirement,
 ) -> Result<LeasedCredentialHandle<'run>, CredentialResolutionError> {
-    let mut matches = profiles.iter().filter(|profile| profile.name() == selected);
+    let provider = compatible_provider(selected, catalog, requirement)?;
+    let declared_lease_bytes = provider
+        .lease_retained_bytes(requirement)
+        .map_err(resolution_provider_error)?;
+    let mut lease = provider
+        .resolve(requirement)
+        .map_err(resolution_provider_error)?;
+    if lease.retained_bytes() != declared_lease_bytes {
+        let _ = lease.revoke();
+        return Err(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::RetainedBytesMismatch,
+        ));
+    }
+    let retained_bytes = handle_dynamic_bytes(requirement, declared_lease_bytes).ok_or(
+        CredentialResolutionError::new(CredentialResolutionErrorKind::RetainedBytesMismatch),
+    )?;
+    Ok(LeasedCredentialHandle {
+        requirement_name: requirement.name().clone(),
+        provider_kind: requirement.provider_kind().clone(),
+        handle_units: requirement.handle_units(),
+        retained_bytes,
+        lease,
+        revoked: false,
+        _run: PhantomData,
+    })
+}
+
+fn compatible_provider<'run>(
+    selected: &CredentialProfileName,
+    catalog: &CredentialProfileCatalog<'run>,
+    requirement: &CredentialRequirement,
+) -> Result<&'run dyn CredentialProvider, CredentialResolutionError> {
+    let mut matches = catalog
+        .profiles
+        .iter()
+        .filter(|profile| profile.name() == selected);
     let profile = matches.next().ok_or(CredentialResolutionError::new(
         CredentialResolutionErrorKind::UnknownProfile,
     ))?;
@@ -332,22 +683,382 @@ pub fn resolve_explicit_profile<'run>(
         ));
     }
 
-    let lease = provider.resolve(requirement).map_err(|failure| {
-        CredentialResolutionError::new(match failure {
-            CredentialProviderFailure::Unavailable => {
-                CredentialResolutionErrorKind::ProviderUnavailable
-            }
-            CredentialProviderFailure::Refused => CredentialResolutionErrorKind::ProviderRefused,
-        })
-    })?;
-    Ok(LeasedCredentialHandle {
-        requirement_name: requirement.name().clone(),
-        provider_kind: requirement.provider_kind().clone(),
-        handle_units: requirement.handle_units(),
-        _lease: lease,
-        _run: PhantomData,
+    Ok(provider)
+}
+
+fn resolution_provider_error(failure: CredentialProviderFailure) -> CredentialResolutionError {
+    CredentialResolutionError::new(match failure {
+        CredentialProviderFailure::Unavailable => {
+            CredentialResolutionErrorKind::ProviderUnavailable
+        }
+        CredentialProviderFailure::Refused => CredentialResolutionErrorKind::ProviderRefused,
     })
 }
+
+fn handle_dynamic_bytes(requirement: &CredentialRequirement, lease_bytes: u64) -> Option<u64> {
+    let name_bytes = u64::try_from(requirement.name().as_str().len()).ok()?;
+    let kind_bytes = u64::try_from(requirement.provider_kind().as_str().len()).ok()?;
+    lease_bytes.checked_add(name_bytes)?.checked_add(kind_bytes)
+}
+
+struct CredentialRegistryConsumer {
+    handle: Arc<ConsumerHandle>,
+}
+
+impl CredentialRegistryConsumer {
+    fn new(handle: Arc<ConsumerHandle>) -> Self {
+        Self { handle }
+    }
+}
+
+impl MemoryConsumer for CredentialRegistryConsumer {
+    fn current_usage(&self) -> u64 {
+        self.handle.bytes()
+    }
+
+    fn spill_priority(&self) -> i32 {
+        i32::MAX - 1
+    }
+
+    fn try_spill(&self, target_bytes: u64) -> Result<u64, ConsumerSpillError> {
+        self.handle.request_spill();
+        let bytes = self.handle.bytes();
+        if bytes >= target_bytes {
+            Ok(bytes)
+        } else {
+            Err(ConsumerSpillError::BelowTarget {
+                target: target_bytes,
+                freed: bytes,
+            })
+        }
+    }
+
+    fn can_back_pressure(&self) -> bool {
+        true
+    }
+
+    fn pause(&self) {
+        self.handle.pause();
+    }
+
+    fn resume(&self) {
+        self.handle.resume();
+    }
+
+    fn is_paused(&self) -> bool {
+        self.handle.is_paused()
+    }
+}
+
+/// Run-local owner for every credential lease acquired during preflight.
+///
+/// The registry preallocates a fixed handle table, registers exactly one
+/// [`MemoryConsumer`], and charges each provider-declared lease plus its
+/// secret-free handle metadata before the provider may allocate it. Credential
+/// state is never written to spill: a spill request revokes and releases the
+/// complete preflight set before another acquisition is attempted.
+pub struct CredentialHandleRegistry<'catalog, 'run>
+where
+    'run: 'catalog,
+{
+    arbitrator: &'catalog MemoryArbitrator,
+    catalog: &'catalog CredentialProfileCatalog<'run>,
+    memory_handle: Arc<ConsumerHandle>,
+    consumer_id: Option<ConsumerId>,
+    handles: Vec<LeasedCredentialHandle<'run>>,
+    retained_bytes: u64,
+}
+
+impl<'catalog, 'run> CredentialHandleRegistry<'catalog, 'run>
+where
+    'run: 'catalog,
+{
+    /// Create an empty registry and register its single memory consumer.
+    ///
+    /// The fixed handle-slot table is allocated before registration and holds
+    /// no credential state. Its actual capacity bytes are charged immediately;
+    /// every subsequent lease allocation is precharged before provider work.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CredentialRegistryErrorKind::AllocationFailed`] when the
+    /// fixed handle table cannot be reserved or its byte size cannot be
+    /// represented by the memory consumer.
+    pub fn new(
+        arbitrator: &'catalog MemoryArbitrator,
+        catalog: &'catalog CredentialProfileCatalog<'run>,
+    ) -> Result<Self, CredentialRegistryError> {
+        let mut handles = Vec::new();
+        handles
+            .try_reserve_exact(catalog.limits.max_live_handles)
+            .map_err(|_| {
+                CredentialRegistryError::new(CredentialRegistryErrorKind::AllocationFailed)
+            })?;
+        let table_bytes = handles
+            .capacity()
+            .checked_mul(std::mem::size_of::<LeasedCredentialHandle<'run>>())
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .ok_or_else(|| {
+                CredentialRegistryError::new(CredentialRegistryErrorKind::AllocationFailed)
+            })?;
+        let memory_handle = ConsumerHandle::new();
+        memory_handle.set_bytes(table_bytes);
+        let consumer_id = arbitrator.register_consumer(Arc::new(CredentialRegistryConsumer::new(
+            Arc::clone(&memory_handle),
+        )));
+        Ok(Self {
+            arbitrator,
+            catalog,
+            memory_handle,
+            consumer_id: Some(consumer_id),
+            handles,
+            retained_bytes: table_bytes,
+        })
+    }
+
+    /// Acquire and retain one requirement through the explicit profile.
+    ///
+    /// Pause and spill requests are honored before every growth boundary. A
+    /// failed acquisition revokes all earlier handles and unregisters the
+    /// registry, so callers cannot accidentally continue from partial
+    /// preflight state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sanitized resolution, capacity, memory, accounting, or
+    /// provider error. Every error leaves zero live handles and no registered
+    /// consumer.
+    pub fn acquire(
+        &mut self,
+        selected: &CredentialProfileName,
+        requirement: &CredentialRequirement,
+    ) -> Result<&LeasedCredentialHandle<'run>, CredentialRegistryError> {
+        if self.consumer_id.is_none() {
+            return Err(CredentialRegistryError::new(
+                CredentialRegistryErrorKind::Closed,
+            ));
+        }
+
+        if self.memory_handle.take_spill_request() {
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::SpillRequested));
+        }
+        self.memory_handle.wait_while_paused();
+        if self.memory_handle.take_spill_request() {
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::SpillRequested));
+        }
+        if self.handles.len() >= self.catalog.limits.max_live_handles {
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::HandleLimitExceeded));
+        }
+
+        let provider = match compatible_provider(selected, self.catalog, requirement) {
+            Ok(provider) => provider,
+            Err(error) => {
+                return Err(
+                    self.fail_and_close(CredentialRegistryErrorKind::Resolution(error.kind()))
+                );
+            }
+        };
+        let lease_bytes = match provider.lease_retained_bytes(requirement) {
+            Ok(bytes) => bytes,
+            Err(failure) => {
+                return Err(self.fail_and_close(CredentialRegistryErrorKind::Resolution(
+                    resolution_provider_error(failure).kind(),
+                )));
+            }
+        };
+        let Some(dynamic_bytes) = handle_dynamic_bytes(requirement, lease_bytes) else {
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::RetainedBytesOverflow));
+        };
+        let Some(prospective_bytes) = self.retained_bytes.checked_add(dynamic_bytes) else {
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::RetainedBytesOverflow));
+        };
+
+        self.memory_handle.set_bytes(prospective_bytes);
+        if self.arbitrator.should_abort_local(prospective_bytes) {
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::MemoryLimitExceeded));
+        }
+
+        let mut lease = match provider.resolve(requirement) {
+            Ok(lease) => lease,
+            Err(failure) => {
+                self.memory_handle.set_bytes(self.retained_bytes);
+                return Err(self.fail_and_close(CredentialRegistryErrorKind::Resolution(
+                    resolution_provider_error(failure).kind(),
+                )));
+            }
+        };
+        if lease.retained_bytes() != lease_bytes {
+            let _ = lease.revoke();
+            self.memory_handle.set_bytes(self.retained_bytes);
+            return Err(self.fail_and_close(CredentialRegistryErrorKind::RetainedBytesMismatch));
+        }
+
+        self.handles.push(LeasedCredentialHandle {
+            requirement_name: requirement.name().clone(),
+            provider_kind: requirement.provider_kind().clone(),
+            handle_units: requirement.handle_units(),
+            retained_bytes: dynamic_bytes,
+            lease,
+            revoked: false,
+            _run: PhantomData,
+        });
+        self.retained_bytes = prospective_bytes;
+        Ok(self
+            .handles
+            .last()
+            .expect("a just-pushed credential handle must exist"))
+    }
+
+    /// Number of live leases currently owned by the registry.
+    pub fn live_handle_count(&self) -> usize {
+        self.handles.len()
+    }
+
+    /// Bytes currently reported through the registry's consumer handle.
+    pub fn retained_bytes(&self) -> u64 {
+        self.memory_handle.bytes()
+    }
+
+    /// Revoke and release every handle, then unregister the memory consumer.
+    ///
+    /// Cleanup continues after a revocation failure so no later lease or
+    /// registration survives the error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CredentialRegistryErrorKind::CleanupFailed`] when at least
+    /// one provider could not confirm revocation. All local handles are still
+    /// released and the consumer is still unregistered.
+    pub fn close(mut self) -> Result<(), CredentialRegistryError> {
+        let cleanup_failed = self.release_all();
+        self.unregister();
+        if cleanup_failed {
+            Err(CredentialRegistryError::new(
+                CredentialRegistryErrorKind::CleanupFailed,
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Borrow the non-secret memory coordination handle for run control.
+    ///
+    /// Callers may use this only to observe accounting or deliver the same
+    /// pause/spill signals as the registered consumer; it exposes no lease.
+    pub fn memory_handle(&self) -> &Arc<ConsumerHandle> {
+        &self.memory_handle
+    }
+
+    fn fail_and_close(&mut self, kind: CredentialRegistryErrorKind) -> CredentialRegistryError {
+        let _ = self.release_all();
+        self.unregister();
+        CredentialRegistryError::new(kind)
+    }
+
+    fn release_all(&mut self) -> bool {
+        let mut cleanup_failed = false;
+        while let Some(mut handle) = self.handles.pop() {
+            let bytes = handle.retained_bytes();
+            if handle.revoke().is_err() {
+                cleanup_failed = true;
+            }
+            drop(handle);
+            self.retained_bytes = self.retained_bytes.saturating_sub(bytes);
+            self.memory_handle.set_bytes(self.retained_bytes);
+        }
+        cleanup_failed
+    }
+
+    fn unregister(&mut self) {
+        self.memory_handle.set_bytes(0);
+        self.retained_bytes = 0;
+        if let Some(consumer_id) = self.consumer_id.take() {
+            let _ = self.arbitrator.unregister_consumer(consumer_id);
+        }
+    }
+}
+
+impl Drop for CredentialHandleRegistry<'_, '_> {
+    fn drop(&mut self) {
+        let _ = self.release_all();
+        self.unregister();
+    }
+}
+
+/// Stable category for registry construction, acquisition, or cleanup failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CredentialRegistryErrorKind {
+    /// Profile/provider compatibility or provider acquisition failed.
+    Resolution(CredentialResolutionErrorKind),
+    /// The fixed handle-entry ceiling was reached.
+    HandleLimitExceeded,
+    /// Prospective retained bytes exceeded the run memory budget.
+    MemoryLimitExceeded,
+    /// The arbitrator requested release before another acquisition.
+    SpillRequested,
+    /// Retained-byte arithmetic overflowed.
+    RetainedBytesOverflow,
+    /// A provider's declared and actual retained bytes differed.
+    RetainedBytesMismatch,
+    /// At least one lease could not confirm revocation.
+    CleanupFailed,
+    /// The fixed handle table could not be allocated or represented.
+    AllocationFailed,
+    /// An acquisition was attempted after the registry closed.
+    Closed,
+}
+
+/// A sanitized credential-registry failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CredentialRegistryError {
+    kind: CredentialRegistryErrorKind,
+}
+
+impl CredentialRegistryError {
+    const fn new(kind: CredentialRegistryErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Stable failure category.
+    pub const fn kind(self) -> CredentialRegistryErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for CredentialRegistryError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self.kind {
+            CredentialRegistryErrorKind::Resolution(_) => {
+                "credential requirement could not be resolved through the selected profile"
+            }
+            CredentialRegistryErrorKind::HandleLimitExceeded => {
+                "credential live-handle count exceeds the fixed admission limit"
+            }
+            CredentialRegistryErrorKind::MemoryLimitExceeded => {
+                "credential handle bytes exceed the run memory budget"
+            }
+            CredentialRegistryErrorKind::SpillRequested => {
+                "credential acquisition stopped under memory pressure"
+            }
+            CredentialRegistryErrorKind::RetainedBytesOverflow => {
+                "credential retained-byte accounting overflowed"
+            }
+            CredentialRegistryErrorKind::RetainedBytesMismatch => {
+                "credential provider returned inconsistent retained-byte accounting"
+            }
+            CredentialRegistryErrorKind::CleanupFailed => {
+                "credential cleanup released all local handles but revocation was not confirmed"
+            }
+            CredentialRegistryErrorKind::AllocationFailed => {
+                "credential handle registry could not allocate its fixed table"
+            }
+            CredentialRegistryErrorKind::Closed => "credential handle registry is already closed",
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for CredentialRegistryError {}
 
 fn is_profile_name(value: &str) -> bool {
     !value.is_empty()

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -841,7 +841,7 @@ fn cleanup_provider_failure_releases_prior_handles_and_unregisters() {
 }
 
 #[test]
-fn cleanup_spill_request_releases_before_another_acquisition() {
+fn cleanup_registered_spill_request_releases_at_next_checkpoint() {
     let provider = provider(
         vec![CredentialCapability::AuthenticateRequest],
         vec![CredentialLifetime::Run],
@@ -868,11 +868,15 @@ fn cleanup_spill_request_releases_before_another_acquisition() {
     registry
         .acquire(&selected, &requirement)
         .expect("second handle");
-    registry.memory_handle().request_spill();
+    let retained_before = registry.retained_bytes();
+    arbitrator.spill_reclaimable(retained_before);
+    assert_eq!(registry.retained_bytes(), retained_before);
+    assert_eq!(registry.live_handle_count(), 2);
+    assert_eq!(arbitrator.consumer_count(), 1);
 
     let error = registry
-        .acquire(&selected, &requirement)
-        .expect_err("spill request must stop further acquisition");
+        .honor_memory_signals()
+        .expect_err("spill checkpoint must close the registry");
 
     assert_eq!(error.kind(), CredentialRegistryErrorKind::SpillRequested);
     assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 2);

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -1,7 +1,10 @@
 use std::num::NonZeroU32;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::Duration;
 
+use clinker_exec::pipeline::memory::MemoryArbitrator;
 use clinker_plan::credentials::{
     CredentialCapability, CredentialHandleUnits, CredentialLifetime, CredentialProviderKind,
     CredentialRenewal, CredentialRequirement, CredentialRequirementName, CredentialRevocation,
@@ -11,8 +14,10 @@ use clinker_plan::credentials::{
 mod credential_profile;
 
 use credential_profile::{
-    CredentialLease, CredentialProfile, CredentialProfileName, CredentialProvider,
-    CredentialProviderFailure, CredentialResolutionErrorKind, LeasedCredentialHandle,
+    CredentialHandleRegistry, CredentialLease, CredentialLeaseFailure, CredentialProfile,
+    CredentialProfileAdmissionErrorKind, CredentialProfileCatalog, CredentialProfileLimits,
+    CredentialProfileName, CredentialProvider, CredentialProviderFailure,
+    CredentialRegistryErrorKind, CredentialResolutionErrorKind, LeasedCredentialHandle,
     resolve_explicit_profile,
 };
 
@@ -30,17 +35,41 @@ fn requirement(capabilities: Vec<CredentialCapability>) -> CredentialRequirement
 }
 
 struct FixtureLease {
-    _secret: String,
+    _secret: Box<str>,
+    id: usize,
+    retained_bytes: u64,
+    revoke_fails: bool,
     drops: Arc<AtomicUsize>,
+    events: Arc<Mutex<Vec<String>>>,
 }
 
 impl Drop for FixtureLease {
     fn drop(&mut self) {
+        self.events
+            .lock()
+            .expect("fixture event mutex")
+            .push(format!("drop-{}", self.id));
         self.drops.fetch_add(1, Ordering::SeqCst);
     }
 }
 
-impl CredentialLease for FixtureLease {}
+impl CredentialLease for FixtureLease {
+    fn retained_bytes(&self) -> u64 {
+        self.retained_bytes
+    }
+
+    fn revoke(&mut self) -> Result<(), CredentialLeaseFailure> {
+        self.events
+            .lock()
+            .expect("fixture event mutex")
+            .push(format!("revoke-{}", self.id));
+        if self.revoke_fails {
+            Err(CredentialLeaseFailure::Unavailable)
+        } else {
+            Ok(())
+        }
+    }
+}
 
 struct FixtureProvider {
     kind: CredentialProviderKind,
@@ -50,9 +79,14 @@ struct FixtureProvider {
     revocation: bool,
     capacity: CredentialHandleUnits,
     secret: String,
+    definition_bytes: usize,
+    declared_lease_bytes: AtomicU64,
     failure: Option<CredentialProviderFailure>,
+    fail_after: Option<usize>,
+    revoke_failure_at: Option<usize>,
     resolve_calls: Arc<AtomicUsize>,
     drops: Arc<AtomicUsize>,
+    events: Arc<Mutex<Vec<String>>>,
 }
 
 impl CredentialProvider for FixtureProvider {
@@ -80,17 +114,38 @@ impl CredentialProvider for FixtureProvider {
         self.capacity
     }
 
+    fn decoded_definition_bytes(&self) -> usize {
+        self.definition_bytes
+    }
+
+    fn lease_retained_bytes(
+        &self,
+        _requirement: &CredentialRequirement,
+    ) -> Result<u64, CredentialProviderFailure> {
+        Ok(self.declared_lease_bytes.load(Ordering::SeqCst))
+    }
+
     fn resolve(
         &self,
         _requirement: &CredentialRequirement,
     ) -> Result<Box<dyn CredentialLease>, CredentialProviderFailure> {
-        self.resolve_calls.fetch_add(1, Ordering::SeqCst);
+        let id = self.resolve_calls.fetch_add(1, Ordering::SeqCst) + 1;
         if let Some(failure) = self.failure {
             return Err(failure);
         }
+        if self.fail_after.is_some_and(|successful| id > successful) {
+            return Err(CredentialProviderFailure::Unavailable);
+        }
+        let secret: Box<str> = self.secret.clone().into_boxed_str();
+        let retained_bytes = u64::try_from(std::mem::size_of::<FixtureLease>() + secret.len())
+            .expect("fixture retained bytes fit u64");
         Ok(Box::new(FixtureLease {
-            _secret: self.secret.clone(),
+            _secret: secret,
+            id,
+            retained_bytes,
+            revoke_fails: self.revoke_failure_at == Some(id),
             drops: Arc::clone(&self.drops),
+            events: Arc::clone(&self.events),
         }))
     }
 }
@@ -102,6 +157,9 @@ fn provider(
     revocation: bool,
     capacity: u32,
 ) -> FixtureProvider {
+    let secret = "lease-secret-must-not-escape".to_owned();
+    let lease_bytes = u64::try_from(std::mem::size_of::<FixtureLease>() + secret.len())
+        .expect("fixture retained bytes fit u64");
     FixtureProvider {
         kind: CredentialProviderKind::parse("request-signer").expect("valid provider kind"),
         capabilities,
@@ -111,11 +169,41 @@ fn provider(
         capacity: CredentialHandleUnits::new(
             NonZeroU32::new(capacity).expect("fixture capacity must be non-zero"),
         ),
-        secret: "lease-secret-must-not-escape".to_owned(),
+        secret,
+        definition_bytes: 64,
+        declared_lease_bytes: AtomicU64::new(lease_bytes),
         failure: None,
+        fail_after: None,
+        revoke_failure_at: None,
         resolve_calls: Arc::new(AtomicUsize::new(0)),
         drops: Arc::new(AtomicUsize::new(0)),
+        events: Arc::new(Mutex::new(Vec::new())),
     }
+}
+
+fn admitted_profiles<'run>(
+    profiles: &'run [CredentialProfile<'run>],
+) -> CredentialProfileCatalog<'run> {
+    CredentialProfileCatalog::admit(profiles, CredentialProfileLimits::default())
+        .expect("fixture profiles are within default bounds")
+}
+
+fn profile_limits(
+    max_profiles: usize,
+    max_providers: usize,
+    max_decoded_bytes: usize,
+    max_live_handles: usize,
+) -> CredentialProfileLimits {
+    CredentialProfileLimits::new(
+        max_profiles,
+        max_providers,
+        max_decoded_bytes,
+        max_live_handles,
+    )
+}
+
+fn memory_arbitrator(limit: u64) -> MemoryArbitrator {
+    MemoryArbitrator::with_policy(limit, 0.80, 0.70, MemoryArbitrator::default_policy())
 }
 
 fn provider_failure_kind(failure: CredentialProviderFailure) -> CredentialResolutionErrorKind {
@@ -132,9 +220,10 @@ fn provider_failure_kind(failure: CredentialProviderFailure) -> CredentialResolu
         CredentialProfileName::parse("release").expect("valid explicit profile"),
         &providers,
     )];
+    let catalog = admitted_profiles(&profiles);
     resolve_explicit_profile(
         &CredentialProfileName::parse("release").expect("valid explicit profile"),
-        &profiles,
+        &catalog,
         &requirement(vec![CredentialCapability::AuthenticateRequest]),
     )
     .expect_err("provider failure must remain typed")
@@ -229,6 +318,7 @@ fn low_level_explicit_profile_resolves_one_redacted_leased_handle() {
         CredentialProfileName::parse("release").expect("valid explicit profile"),
         &providers,
     )];
+    let catalog = admitted_profiles(&profiles);
     let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
     let requirement = requirement(vec![
         CredentialCapability::AuthenticateRequest,
@@ -237,7 +327,7 @@ fn low_level_explicit_profile_resolves_one_redacted_leased_handle() {
 
     {
         let handle: LeasedCredentialHandle<'_> =
-            resolve_explicit_profile(&selected, &profiles, &requirement)
+            resolve_explicit_profile(&selected, &catalog, &requirement)
                 .expect("compatible explicit profile resolves");
         assert_eq!(handle.requirement_name(), requirement.name());
         assert_eq!(handle.provider_kind(), requirement.provider_kind());
@@ -271,13 +361,19 @@ fn low_level_unknown_or_incompatible_selection_fails_before_provider_resolution(
         CredentialProfileName::parse("release").expect("valid explicit profile"),
         &providers,
     )];
+    let catalog = admitted_profiles(&profiles);
+    let empty_profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("empty").expect("valid explicit profile"),
+        &[],
+    )];
+    let empty_catalog = admitted_profiles(&empty_profiles);
     let requirement = requirement(vec![CredentialCapability::OpenSession]);
 
     let cases = [
         (
             resolve_explicit_profile(
                 &CredentialProfileName::parse("missing").expect("valid explicit profile"),
-                &profiles,
+                &catalog,
                 &requirement,
             )
             .expect_err("unknown profile must fail")
@@ -287,10 +383,7 @@ fn low_level_unknown_or_incompatible_selection_fails_before_provider_resolution(
         (
             resolve_explicit_profile(
                 &CredentialProfileName::parse("empty").expect("valid explicit profile"),
-                &[CredentialProfile::new(
-                    CredentialProfileName::parse("empty").expect("valid explicit profile"),
-                    &[],
-                )],
+                &empty_catalog,
                 &requirement,
             )
             .expect_err("unknown provider must fail")
@@ -300,7 +393,7 @@ fn low_level_unknown_or_incompatible_selection_fails_before_provider_resolution(
         (
             resolve_explicit_profile(
                 &CredentialProfileName::parse("release").expect("valid explicit profile"),
-                &profiles,
+                &catalog,
                 &requirement,
             )
             .expect_err("unsupported capability must fail")
@@ -315,7 +408,7 @@ fn low_level_unknown_or_incompatible_selection_fails_before_provider_resolution(
 
     let error = resolve_explicit_profile(
         &CredentialProfileName::parse("release").expect("valid explicit profile"),
-        &profiles,
+        &catalog,
         &requirement,
     )
     .expect_err("incompatible selection must fail");
@@ -344,11 +437,12 @@ fn low_level_lifecycle_and_capacity_requirements_fail_closed() {
         CredentialProfileName::parse("release").expect("valid explicit profile"),
         &providers,
     )];
+    let catalog = admitted_profiles(&profiles);
     let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
 
     let mut requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
     assert_eq!(
-        resolve_explicit_profile(&selected, &profiles, &requirement)
+        resolve_explicit_profile(&selected, &catalog, &requirement)
             .expect_err("unsupported lifetime must fail")
             .kind(),
         CredentialResolutionErrorKind::UnsupportedLifetime
@@ -365,7 +459,7 @@ fn low_level_lifecycle_and_capacity_requirements_fail_closed() {
     )
     .expect("valid renewal requirement");
     assert_eq!(
-        resolve_explicit_profile(&selected, &profiles, &requirement)
+        resolve_explicit_profile(&selected, &catalog, &requirement)
             .expect_err("unsupported renewal must fail")
             .kind(),
         CredentialResolutionErrorKind::UnsupportedRenewal
@@ -382,7 +476,7 @@ fn low_level_lifecycle_and_capacity_requirements_fail_closed() {
     )
     .expect("valid revocation requirement");
     assert_eq!(
-        resolve_explicit_profile(&selected, &profiles, &requirement)
+        resolve_explicit_profile(&selected, &catalog, &requirement)
             .expect_err("unsupported revocation must fail")
             .kind(),
         CredentialResolutionErrorKind::UnsupportedRevocation
@@ -399,10 +493,395 @@ fn low_level_lifecycle_and_capacity_requirements_fail_closed() {
     )
     .expect("valid capacity requirement");
     assert_eq!(
-        resolve_explicit_profile(&selected, &profiles, &requirement)
+        resolve_explicit_profile(&selected, &catalog, &requirement)
             .expect_err("insufficient capacity must fail")
             .kind(),
         CredentialResolutionErrorKind::InsufficientHandleCapacity
     );
     assert_eq!(resolve_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn bounds_profile_and_provider_counts_fail_before_catalog_admission() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [
+        CredentialProfile::new(
+            CredentialProfileName::parse("first").expect("valid explicit profile"),
+            &providers,
+        ),
+        CredentialProfile::new(
+            CredentialProfileName::parse("second").expect("valid explicit profile"),
+            &providers,
+        ),
+    ];
+    let profile_error =
+        match CredentialProfileCatalog::admit(&profiles, profile_limits(1, 2, usize::MAX, 2)) {
+            Ok(_) => panic!("profile cap + 1 must fail"),
+            Err(error) => error,
+        };
+    assert_eq!(
+        profile_error.kind(),
+        CredentialProfileAdmissionErrorKind::TooManyProfiles
+    );
+
+    let duplicate_providers: [&dyn CredentialProvider; 2] = [&provider, &provider];
+    let one_profile = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &duplicate_providers,
+    )];
+    let provider_error =
+        match CredentialProfileCatalog::admit(&one_profile, profile_limits(1, 1, usize::MAX, 2)) {
+            Ok(_) => panic!("provider cap + 1 must fail"),
+            Err(error) => error,
+        };
+    assert_eq!(
+        provider_error.kind(),
+        CredentialProfileAdmissionErrorKind::TooManyProviders
+    );
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn bounds_decoded_definition_bytes_fail_before_catalog_admission() {
+    let mut provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    provider.definition_bytes = 1_024;
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let error = match CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, 1_023, 2)) {
+        Ok(_) => panic!("decoded definition bytes over the cap must fail"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error.kind(),
+        CredentialProfileAdmissionErrorKind::DecodedBytesExceeded
+    );
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn bounds_handle_cap_plus_one_releases_all_and_unregisters() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let events = Arc::clone(&provider.events);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 2))
+        .expect("bounded profile catalog");
+    let arbitrator = memory_arbitrator(u64::MAX);
+    let mut registry =
+        CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+
+    registry
+        .acquire(&selected, &requirement)
+        .expect("first handle");
+    registry
+        .acquire(&selected, &requirement)
+        .expect("second handle");
+    let error = registry
+        .acquire(&selected, &requirement)
+        .expect_err("cap + 1 must fail closed");
+
+    assert_eq!(
+        error.kind(),
+        CredentialRegistryErrorKind::HandleLimitExceeded
+    );
+    assert_eq!(registry.live_handle_count(), 0);
+    assert_eq!(registry.retained_bytes(), 0);
+    assert_eq!(arbitrator.consumer_count(), 0);
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        *events.lock().expect("fixture event mutex"),
+        ["revoke-2", "drop-2", "revoke-1", "drop-1"]
+    );
+}
+
+#[test]
+fn bounds_memory_overshoot_is_rejected_before_provider_allocation() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    provider
+        .declared_lease_bytes
+        .store(128 * 1024 * 1024, Ordering::SeqCst);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 2))
+        .expect("bounded profile catalog");
+    let arbitrator = memory_arbitrator(64 * 1024 * 1024);
+    let mut registry =
+        CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
+
+    let error = registry
+        .acquire(
+            &CredentialProfileName::parse("release").expect("valid explicit profile"),
+            &requirement(vec![CredentialCapability::AuthenticateRequest]),
+        )
+        .expect_err("prospective retained bytes exceed the run budget");
+
+    assert_eq!(
+        error.kind(),
+        CredentialRegistryErrorKind::MemoryLimitExceeded
+    );
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(registry.live_handle_count(), 0);
+    assert_eq!(registry.retained_bytes(), 0);
+    assert_eq!(arbitrator.consumer_count(), 0);
+}
+
+#[test]
+fn cleanup_drop_revokes_and_releases_in_reverse_acquisition_order() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let events = Arc::clone(&provider.events);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 3))
+        .expect("bounded profile catalog");
+    let arbitrator = memory_arbitrator(u64::MAX);
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+
+    {
+        let mut registry =
+            CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
+        for _ in 0..3 {
+            registry
+                .acquire(&selected, &requirement)
+                .expect("bounded handle acquisition");
+        }
+        assert_eq!(registry.live_handle_count(), 3);
+        assert_eq!(arbitrator.consumer_count(), 1);
+    }
+
+    assert_eq!(arbitrator.consumer_count(), 0);
+    assert_eq!(
+        *events.lock().expect("fixture event mutex"),
+        [
+            "revoke-3", "drop-3", "revoke-2", "drop-2", "revoke-1", "drop-1",
+        ]
+    );
+}
+
+#[test]
+fn cleanup_provider_failure_releases_prior_handles_and_unregisters() {
+    let mut provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    provider.fail_after = Some(2);
+    let events = Arc::clone(&provider.events);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 3))
+        .expect("bounded profile catalog");
+    let arbitrator = memory_arbitrator(u64::MAX);
+    let mut registry =
+        CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    registry
+        .acquire(&selected, &requirement)
+        .expect("first handle");
+    registry
+        .acquire(&selected, &requirement)
+        .expect("second handle");
+
+    let error = registry
+        .acquire(&selected, &requirement)
+        .expect_err("provider failure must close the registry");
+
+    assert_eq!(
+        error.kind(),
+        CredentialRegistryErrorKind::Resolution(CredentialResolutionErrorKind::ProviderUnavailable)
+    );
+    assert_eq!(registry.live_handle_count(), 0);
+    assert_eq!(arbitrator.consumer_count(), 0);
+    assert_eq!(
+        *events.lock().expect("fixture event mutex"),
+        ["revoke-2", "drop-2", "revoke-1", "drop-1"]
+    );
+}
+
+#[test]
+fn cleanup_spill_request_releases_before_another_acquisition() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let events = Arc::clone(&provider.events);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 3))
+        .expect("bounded profile catalog");
+    let arbitrator = memory_arbitrator(u64::MAX);
+    let mut registry =
+        CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    registry
+        .acquire(&selected, &requirement)
+        .expect("first handle");
+    registry
+        .acquire(&selected, &requirement)
+        .expect("second handle");
+    registry.memory_handle_for_test().request_spill();
+
+    let error = registry
+        .acquire(&selected, &requirement)
+        .expect_err("spill request must stop further acquisition");
+
+    assert_eq!(error.kind(), CredentialRegistryErrorKind::SpillRequested);
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(registry.live_handle_count(), 0);
+    assert_eq!(arbitrator.consumer_count(), 0);
+    assert_eq!(
+        *events.lock().expect("fixture event mutex"),
+        ["revoke-2", "drop-2", "revoke-1", "drop-1"]
+    );
+}
+
+#[test]
+fn cleanup_pause_blocks_acquisition_until_resume() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let resolve_calls = Arc::clone(&provider.resolve_calls);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 1))
+        .expect("bounded profile catalog");
+    let arbitrator = memory_arbitrator(u64::MAX);
+    let mut registry =
+        CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
+    let memory_handle = Arc::clone(registry.memory_handle_for_test());
+    memory_handle.pause();
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+
+    std::thread::scope(|scope| {
+        scope.spawn(move || {
+            started_tx.send(()).expect("signal acquisition start");
+            let acquired = registry.acquire(&selected, &requirement).is_ok();
+            done_tx.send(acquired).expect("signal acquisition result");
+        });
+        started_rx.recv().expect("acquisition thread started");
+        assert!(matches!(
+            done_rx.recv_timeout(Duration::from_millis(50)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        assert_eq!(resolve_calls.load(Ordering::SeqCst), 0);
+        memory_handle.resume();
+        assert!(
+            done_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("acquisition resumes")
+        );
+    });
+
+    assert_eq!(resolve_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(arbitrator.consumer_count(), 0);
+}
+
+#[test]
+fn cleanup_revoke_failure_still_releases_every_handle_and_unregisters() {
+    let mut provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    provider.revoke_failure_at = Some(2);
+    let events = Arc::clone(&provider.events);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 3))
+        .expect("bounded profile catalog");
+    let arbitrator = memory_arbitrator(u64::MAX);
+    let mut registry =
+        CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    for _ in 0..3 {
+        registry
+            .acquire(&selected, &requirement)
+            .expect("bounded handle acquisition");
+    }
+
+    let error = registry.close().expect_err("revoke failure remains typed");
+
+    assert_eq!(error.kind(), CredentialRegistryErrorKind::CleanupFailed);
+    assert_eq!(arbitrator.consumer_count(), 0);
+    assert_eq!(provider.drops.load(Ordering::SeqCst), 3);
+    assert_eq!(
+        *events.lock().expect("fixture event mutex"),
+        [
+            "revoke-3", "drop-3", "revoke-2", "drop-2", "revoke-1", "drop-1",
+        ]
+    );
 }

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -84,6 +84,8 @@ struct FixtureProvider {
     failure: Option<CredentialProviderFailure>,
     fail_after: Option<usize>,
     revoke_failure_at: Option<usize>,
+    memory_probe: Option<Arc<MemoryArbitrator>>,
+    observed_bytes_at_resolve: Arc<AtomicU64>,
     resolve_calls: Arc<AtomicUsize>,
     drops: Arc<AtomicUsize>,
     events: Arc<Mutex<Vec<String>>>,
@@ -130,6 +132,10 @@ impl CredentialProvider for FixtureProvider {
         _requirement: &CredentialRequirement,
     ) -> Result<Box<dyn CredentialLease>, CredentialProviderFailure> {
         let id = self.resolve_calls.fetch_add(1, Ordering::SeqCst) + 1;
+        if let Some(arbitrator) = &self.memory_probe {
+            self.observed_bytes_at_resolve
+                .store(arbitrator.sum_consumer_usage(), Ordering::SeqCst);
+        }
         if let Some(failure) = self.failure {
             return Err(failure);
         }
@@ -175,6 +181,8 @@ fn provider(
         failure: None,
         fail_after: None,
         revoke_failure_at: None,
+        memory_probe: None,
+        observed_bytes_at_resolve: Arc::new(AtomicU64::new(0)),
         resolve_calls: Arc::new(AtomicUsize::new(0)),
         drops: Arc::new(AtomicUsize::new(0)),
         events: Arc::new(Mutex::new(Vec::new())),
@@ -549,6 +557,39 @@ fn bounds_profile_and_provider_counts_fail_before_catalog_admission() {
 }
 
 #[test]
+fn bounds_catalog_reports_the_exact_admitted_definition_totals() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [
+        CredentialProfile::new(
+            CredentialProfileName::parse("first").expect("valid explicit profile"),
+            &providers,
+        ),
+        CredentialProfile::new(
+            CredentialProfileName::parse("second").expect("valid explicit profile"),
+            &providers,
+        ),
+    ];
+    let limits = profile_limits(2, 2, 1_024, 3);
+    let catalog = CredentialProfileCatalog::admit(&profiles, limits).expect("bounded catalog");
+
+    assert_eq!(catalog.profile_count(), 2);
+    assert_eq!(catalog.provider_count(), 2);
+    assert_eq!(catalog.decoded_bytes(), 167);
+    assert_eq!(catalog.limits(), limits);
+    assert_eq!(limits.max_profiles(), 2);
+    assert_eq!(limits.max_providers(), 2);
+    assert_eq!(limits.max_decoded_bytes(), 1_024);
+    assert_eq!(limits.max_live_handles(), 3);
+}
+
+#[test]
 fn bounds_decoded_definition_bytes_fail_before_catalog_admission() {
     let mut provider = provider(
         vec![CredentialCapability::AuthenticateRequest],
@@ -630,9 +671,7 @@ fn bounds_memory_overshoot_is_rejected_before_provider_allocation() {
         true,
         2,
     );
-    provider
-        .declared_lease_bytes
-        .store(128 * 1024 * 1024, Ordering::SeqCst);
+    let events = Arc::clone(&provider.events);
     let providers: [&dyn CredentialProvider; 1] = [&provider];
     let profiles = [CredentialProfile::new(
         CredentialProfileName::parse("release").expect("valid explicit profile"),
@@ -640,24 +679,76 @@ fn bounds_memory_overshoot_is_rejected_before_provider_allocation() {
     )];
     let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 2))
         .expect("bounded profile catalog");
-    let arbitrator = memory_arbitrator(64 * 1024 * 1024);
+    let arbitrator = memory_arbitrator(u64::MAX);
     let mut registry =
         CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
+    let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    registry
+        .acquire(&selected, &requirement)
+        .expect("first handle fits the run budget");
+    provider
+        .declared_lease_bytes
+        .store(128 * 1024 * 1024, Ordering::SeqCst);
+    arbitrator.set_limit(64 * 1024 * 1024);
 
     let error = registry
-        .acquire(
-            &CredentialProfileName::parse("release").expect("valid explicit profile"),
-            &requirement(vec![CredentialCapability::AuthenticateRequest]),
-        )
+        .acquire(&selected, &requirement)
         .expect_err("prospective retained bytes exceed the run budget");
 
     assert_eq!(
         error.kind(),
         CredentialRegistryErrorKind::MemoryLimitExceeded
     );
-    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 1);
     assert_eq!(registry.live_handle_count(), 0);
     assert_eq!(registry.retained_bytes(), 0);
+    assert_eq!(arbitrator.consumer_count(), 0);
+    assert_eq!(
+        *events.lock().expect("fixture event mutex"),
+        ["revoke-1", "drop-1"]
+    );
+}
+
+#[test]
+fn bounds_successful_lease_bytes_are_reported_before_provider_allocation() {
+    let arbitrator = Arc::new(memory_arbitrator(u64::MAX));
+    let mut provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    provider.memory_probe = Some(Arc::clone(&arbitrator));
+    let observed_bytes = Arc::clone(&provider.observed_bytes_at_resolve);
+    let declared_lease_bytes = provider.declared_lease_bytes.load(Ordering::SeqCst);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("release").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 1))
+        .expect("bounded profile catalog");
+    let mut registry = CredentialHandleRegistry::new(arbitrator.as_ref(), &catalog)
+        .expect("register handle owner");
+    let table_bytes = registry.retained_bytes();
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    let expected = table_bytes
+        + declared_lease_bytes
+        + u64::try_from(requirement.name().as_str().len()).expect("name length fits")
+        + u64::try_from(requirement.provider_kind().as_str().len()).expect("kind length fits");
+
+    registry
+        .acquire(
+            &CredentialProfileName::parse("release").expect("valid explicit profile"),
+            &requirement,
+        )
+        .expect("bounded handle acquisition");
+
+    assert_eq!(observed_bytes.load(Ordering::SeqCst), expected);
+    assert_eq!(registry.retained_bytes(), expected);
+    registry.close().expect("clean registry close");
     assert_eq!(arbitrator.consumer_count(), 0);
 }
 
@@ -777,7 +868,7 @@ fn cleanup_spill_request_releases_before_another_acquisition() {
     registry
         .acquire(&selected, &requirement)
         .expect("second handle");
-    registry.memory_handle_for_test().request_spill();
+    registry.memory_handle().request_spill();
 
     let error = registry
         .acquire(&selected, &requirement)
@@ -813,7 +904,7 @@ fn cleanup_pause_blocks_acquisition_until_resume() {
     let arbitrator = memory_arbitrator(u64::MAX);
     let mut registry =
         CredentialHandleRegistry::new(&arbitrator, &catalog).expect("register handle owner");
-    let memory_handle = Arc::clone(registry.memory_handle_for_test());
+    let memory_handle = Arc::clone(registry.memory_handle());
     memory_handle.pause();
     let selected = CredentialProfileName::parse("release").expect("valid explicit profile");
     let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -63,9 +63,12 @@ registrations across those profiles, 1 MiB of decoded profile/provider
 definition state, and 256 simultaneously retained handles. Admission checks
 all definition counts and bytes before a profile can resolve a requirement.
 Each live lease reports its exact retained bytes to the run memory arbitrator
-before provider allocation; cap, memory, provider, pause, or spill failures
-revoke and release the partial set in reverse acquisition order and unregister
-the registry.
+before provider allocation. The registry has no inbound producer and is not a
+backpressure target. An arbitrator spill callback queues a request and reports
+zero bytes freed synchronously; the next registry-owned checkpoint revokes and
+releases the partial set in reverse acquisition order and unregisters the
+registry. Cap, memory, and provider failures follow the same fail-closed
+cleanup path; an explicit run coordinator may pause acquisition until resume.
 
 These are foundation limits, not newly available command-line behavior. A
 later complete preflight surface must add the one explicit profile selector,

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -48,6 +48,30 @@ recommended contracts. Decision D-45 requires every visible option to be
 wired and behavior-tested, or replaced by a nonzero tombstone with a
 paste-ready alternative under AUTH-05.
 
+### Credential profile foundation
+
+The current binary does **not** yet accept a credential-profile option or a
+credential-profile configuration table. Referenced credentials therefore do
+not activate a source, destination, or observability exporter through this
+surface. Do not pass an environment, channel, or group as a substitute: those
+selectors never choose credentials, and there is no default or sentinel
+profile.
+
+The run-local foundation that later preflight wiring will call is already
+bounded. Its default ceilings are 64 named profiles, 256 provider
+registrations across those profiles, 1 MiB of decoded profile/provider
+definition state, and 256 simultaneously retained handles. Admission checks
+all definition counts and bytes before a profile can resolve a requirement.
+Each live lease reports its exact retained bytes to the run memory arbitrator
+before provider allocation; cap, memory, provider, pause, or spill failures
+revoke and release the partial set in reverse acquisition order and unregister
+the registry.
+
+These are foundation limits, not newly available command-line behavior. A
+later complete preflight surface must add the one explicit profile selector,
+credential-required omission checks, and consumer activation together before
+the option can appear in the options table above.
+
 ### Examples
 
 ```bash


### PR DESCRIPTION
## Summary

- admit credential profile definitions under fixed count and decoded-byte ceilings
- preallocate a bounded run-local handle table and charge exact retained bytes before provider allocation
- revoke leases in reverse acquisition order and unregister the memory consumer on every cleanup path
- handle memory pressure truthfully: spill callbacks report zero synchronous relief, and the registry checkpoint performs fail-closed teardown

## Validation

- `cargo test -p clinker --test credential_profiles --locked --offline` (17 passed)
- `cargo clippy -p clinker --all-targets --locked --offline -- -D warnings`
- `cargo fmt --all --check`
- `mdbook build docs/user`
- `git diff --check`

## Stack

This is stacked on #1094, which introduces explicit secret-free credential profile resolution.

## Scope

This PR adds bounded definition and live-lease ownership but does not expose the CLI selection flag or activate credentialed resources. Lifecycle telemetry and complete preflight admission remain separate changes that must land before activation.

- Lineage is unaffected because no column value, route, or dataset boundary changes.
- The registered consumer reports true retained bytes and never claims a spill occurred before revocation actually releases the leases.
