### PR TITLE
Migrate planner core fixtures and normalize Sink identity

### DIFF
--- a/crates/clinker-plan/src/config/canonical.rs
+++ b/crates/clinker-plan/src/config/canonical.rs
@@ -718,7 +718,7 @@ nodes:
     fn join_values_bare_expands() {
         let raw = "\
 nodes:
-  - type: output
+  - type: sink
     name: o
     input: s
     config:
@@ -885,7 +885,7 @@ nodes:
       path: in.csv
       schema:
         - { name: order_id, type: string }
-  - type: output
+  - type: sink
     name: o
     input: s
     config:
@@ -1019,7 +1019,7 @@ nodes:
           delimiter: \"|\"
       schema:
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: o
     input: s
     config:

--- a/crates/clinker-plan/src/config/patch.rs
+++ b/crates/clinker-plan/src/config/patch.rs
@@ -1772,7 +1772,7 @@ nodes:
         - { name: amount, type: int }
         - { name: cust_id, type: string }
         - { name: order_notes, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -2097,7 +2097,7 @@ nodes:
         discriminator: { start: 0, width: 1 }
         records:
           - { id: detail, tag: D, columns: [ { name: amount, type: int, start: 1, width: 9 } ] }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -2143,7 +2143,7 @@ nodes:
       path: /tmp/in.csv
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: node_ident
     config:
@@ -2201,7 +2201,7 @@ nodes:
     name: comp
     input: src
     use: ./thing.comp.yaml
-  - type: output
+  - type: sink
     name: out
     input: comp
     config:
@@ -2245,7 +2245,7 @@ nodes:
     use: ./thing.comp.yaml
     inputs:
       driver: src
-  - type: output
+  - type: sink
     name: out
     input: comp
     config:
@@ -2346,7 +2346,7 @@ nodes:
       schema:
         - { name: id, type: int }
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -2707,7 +2707,7 @@ nodes:
             e06: string
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -2919,7 +2919,7 @@ nodes:
           - { field: f03, components: 5 }
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -3094,7 +3094,7 @@ nodes:
         records:
           - { id: detail, tag: D, columns: [ { name: amount, type: int, start: 1, width: 9 } ] }
           - { id: trailer, tag: T, columns: [ { name: count, type: int, start: 1, width: 9 } ] }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -3122,7 +3122,7 @@ nodes:
         records:
           - { id: detail, tag: D, columns: [ { name: rec_type, type: string }, { name: amount, type: float } ] }
           - { id: trailer, tag: T, columns: [ { name: rec_type, type: string }, { name: count, type: int } ] }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-plan/src/overlay_ops.rs
+++ b/crates/clinker-plan/src/overlay_ops.rs
@@ -2661,7 +2661,7 @@ schema:
         let err = apply_overlay_ops(base, one(op)).expect_err("not a source");
         assert!(
             matches!(err, OverlayOpError::NotSource { ref target, actual, .. }
-                if target == "sink" && actual == "output")
+                if target == "sink" && actual == "sink")
         );
     }
 

--- a/crates/clinker-plan/src/plan/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/deferred_region.rs
@@ -1380,7 +1380,7 @@ nodes:
       emit order_id = order_id
       emit department = department
       emit total = sum(amount)
-- type: output
+- type: sink
   name: out
   input: order_totals
   config:

--- a/crates/clinker-plan/src/plan/execution/consumer_registry.rs
+++ b/crates/clinker-plan/src/plan/execution/consumer_registry.rs
@@ -205,14 +205,14 @@ nodes:
       type: csv
       path: other.csv
       schema: [{ name: id, type: string }]
-  - type: output
+  - type: sink
     name: direct
     input: shared
     config: { name: direct, type: csv, path: direct.csv }
   - type: merge
     name: joined
     inputs: [shared, other]
-  - type: output
+  - type: sink
     name: merged
     input: joined
     config: { name: merged, type: csv, path: merged.csv }
@@ -259,11 +259,11 @@ nodes:
       mode: exclusive
       conditions: { left: "side == 'left'" }
       default: right
-  - type: output
+  - type: sink
     name: left
     input: split.left
     config: { name: left, type: csv, path: left.csv }
-  - type: output
+  - type: sink
     name: right
     input: split.right
     config: { name: right, type: csv, path: right.csv }

--- a/crates/clinker-plan/src/plan/execution/streaming_class.rs
+++ b/crates/clinker-plan/src/plan/execution/streaming_class.rs
@@ -764,7 +764,7 @@ nodes:
       emit order_id = orders.order_id
       emit band_id = bands.band_id
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: banded
   config:
@@ -812,14 +812,14 @@ nodes:
       emit order_id = orders.order_id
       emit band_id = bands.band_id
     propagate_ck: driver
-- type: output
+- type: sink
   name: out_a
   input: banded
   config:
     name: out_a
     type: csv
     path: out_a.csv
-- type: output
+- type: sink
   name: out_b
   input: banded
   config:
@@ -869,7 +869,7 @@ nodes:
       emit amount = orders.amount
       emit lo = bands.lo
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: banded
   config:
@@ -903,7 +903,7 @@ nodes:
   inputs: [src_a, src_b]
   config:
     mode: interleave
-- type: output
+- type: sink
   name: out
   input: merged
   config:
@@ -937,14 +937,14 @@ nodes:
   inputs: [shared, exclusive]
   config:
     mode: interleave
-- type: output
+- type: sink
   name: merged_out
   input: merged
   config:
     name: merged_out
     type: csv
     path: merged.csv
-- type: output
+- type: sink
   name: sibling_out
   input: shared
   config:
@@ -991,14 +991,14 @@ nodes:
   inputs: [shared, right_only]
   config:
     mode: interleave
-- type: output
+- type: sink
   name: left_out
   input: left_merge
   config:
     name: left_out
     type: csv
     path: left.csv
-- type: output
+- type: sink
   name: right_out
   input: right_merge
   config:

--- a/crates/clinker-plan/src/plan/semantic_identity.rs
+++ b/crates/clinker-plan/src/plan/semantic_identity.rs
@@ -245,13 +245,22 @@ fn semantic_node(
     let Some(object) = value.as_object_mut() else {
         return Ok(value);
     };
-    if object.get("type").and_then(serde_json::Value::as_str) == Some("source")
-        && let Some(config) = object
-            .get_mut("config")
-            .and_then(serde_json::Value::as_object_mut)
+    if let Some(config) = object
+        .get_mut("config")
+        .and_then(serde_json::Value::as_object_mut)
     {
-        // The resolved schema is represented once in `bound_schemas`.
-        config.remove("schema");
+        // Match the typed variant so a renamed serialized discriminator cannot
+        // silently retain deployment-only fields in semantic identity.
+        match node {
+            crate::config::PipelineNode::Source { .. } => {
+                // The resolved schema is represented once in `bound_schemas`.
+                config.remove("schema");
+            }
+            crate::config::PipelineNode::Sink { .. } => {
+                config.remove("path");
+            }
+            _ => {}
+        }
     }
     Ok(value)
 }
@@ -348,7 +357,7 @@ nodes:
     input: src
     config:
       cxl: "emit value = id + $vars.threshold"
-  - type: output
+  - type: sink
     name: out
     input: map
     config:
@@ -481,7 +490,7 @@ nodes:
     input: drv
     use: ../compositions/enrich.comp.yaml
     inputs: { driver: drv }
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config: { name: out, path: out.csv, type: csv }
@@ -590,7 +599,7 @@ nodes:
     input: src
     use: compositions/gate.comp.yaml
     inputs: { inp: src }
-  - type: output
+  - type: sink
     name: out
     input: gate_call
     config: { name: out, path: output.csv, type: csv }
@@ -629,7 +638,7 @@ nodes:
   - config: { type: csv, path: output.csv, name: out }
     input: map
     name: out
-    type: output
+    type: sink
 "#;
         assert_eq!(fingerprint(BASE), fingerprint(reordered));
     }
@@ -796,7 +805,7 @@ nodes:
     input: src
     use: compositions/increment.comp.yaml
     inputs: { inp: src }
-  - type: output
+  - type: sink
     name: out
     input: increment_call
     config: { name: out, path: output.csv, type: csv }
@@ -959,7 +968,7 @@ nodes:
     input: src
     use: ../compositions/gate.comp.yaml
     inputs: { inp: src }
-  - type: output
+  - type: sink
     name: out
     input: gate_call
     config: { name: out, path: output.csv, type: csv }

--- a/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
@@ -80,7 +80,7 @@ nodes:
     use: ../compositions/framed_body.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:
@@ -223,7 +223,7 @@ fn body_output_bad_csv_delimiter_rejected_at_compile() {
       cxl: |
         emit id = id
         emit val = val
-  - type: output
+  - type: sink
     name: body_sink
     input: shape
     config:
@@ -274,7 +274,7 @@ fn body_output_valid_csv_delimiter_compiles() {
       cxl: |
         emit id = id
         emit val = val
-  - type: output
+  - type: sink
     name: body_sink
     input: shape
     config:
@@ -355,7 +355,7 @@ nodes:
     use: ../compositions/src_body.comp.yaml
     inputs:
       driver: drv
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config:
@@ -433,7 +433,7 @@ nodes:
     use: ../compositions/mv_body.comp.yaml
     inputs:
       driver: drv
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config:
@@ -600,7 +600,7 @@ nodes:
       cxl: |
         emit id = id
         emit amount = amount
-  - type: output
+  - type: sink
     name: body_sink
     input: shape
     config:
@@ -634,7 +634,7 @@ nodes:
     use: ../compositions/decimal_body.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:
@@ -746,7 +746,7 @@ nodes:
     use: ../compositions/src_ref_body.comp.yaml
     inputs:
       driver: drv
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config:
@@ -848,7 +848,7 @@ nodes:
     use: ../compositions/logging_body.comp.yaml
     inputs:
       inp: seen
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:

--- a/crates/clinker-plan/src/plan/tests/bound_schemas.rs
+++ b/crates/clinker-plan/src/plan/tests/bound_schemas.rs
@@ -20,7 +20,7 @@ nodes:
     schema:
       - { name: order_id, type: string }
       - { name: amount, type: int }
-- type: output
+- type: sink
   name: out
   input: orders
   config:

--- a/crates/clinker-plan/src/plan/tests/ck_aligned_partition.rs
+++ b/crates/clinker-plan/src/plan/tests/ck_aligned_partition.rs
@@ -49,7 +49,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [department, '$ck.aggregate.dept_totals']
-- type: output
+- type: sink
   name: out
   input: ck_aligned_window
   config:
@@ -133,7 +133,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: dept_window
   config:
@@ -200,7 +200,7 @@ nodes:
       emit order_id = order_id
       emit department = department
       emit total = sum(amount)
-- type: output
+- type: sink
   name: out
   input: order_totals
   config:


### PR DESCRIPTION
## Summary

- migrate 46 positive planner-core fixtures from `type: output` to `type: sink`
- preserve the intentional E376 rejection for the retired author syntax
- normalize Sink identity through the typed node projection so physical destination paths do not change the semantic fingerprint
- update the planner's expected node-kind value to `sink`

## Validation

- exact affected planner filters (165 passed)
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This planner-core shard is stacked on #1098.

The full planner library run reached 946 passes and three remaining corpus failures: two extraction tests share one external YAML fixture, and one aggregate test reads retired positive syntax from six diagnostic pages. Those owners are intentionally left to the next focused PR.

No dependencies, telemetry vocabulary, or runtime memory ownership change here. The semantic-identity correction removes deployment-only Sink path data; it does not remove logical format, schema, mapping, or ordering behavior from the fingerprint.
