### PR TITLE
Migrate planner explain fixtures to Sink syntax

### DIFF
--- a/crates/clinker-exec/tests/fixtures/pipelines/composition_pipeline.yaml
+++ b/crates/clinker-exec/tests/fixtures/pipelines/composition_pipeline.yaml
@@ -44,7 +44,7 @@ nodes:
     config:
       strict_mode: true
 
-  - type: output
+  - type: sink
     name: enriched_out
     input: enrich1
     config:

--- a/docs/explain/E010.md
+++ b/docs/explain/E010.md
@@ -34,7 +34,7 @@ nodes:
       path: orders.csv
       schema:
         - { name: id, type: string }
-  - type: output
+  - type: sink
     name: write_orders
     input: raw.orders
     config:

--- a/docs/explain/E359.md
+++ b/docs/explain/E359.md
@@ -56,7 +56,7 @@ nodes:
         - { name: order_id, type: string }
         - { name: tags,     type: string, multiple: true }
 
-  - type: output
+  - type: sink
     name: report
     input: orders
     config:
@@ -70,7 +70,7 @@ nodes:
 ```yaml
 # Corrected (write CSV): the field joins into one delimited cell, defaulting to
 # `;` with `on_conflict: error`. See `join_values` in the CSV format reference.
-  - type: output
+  - type: sink
     name: report
     input: orders
     config:
@@ -81,7 +81,7 @@ nodes:
 
 ```yaml
 # Corrected (write JSON): the array is the format's native shape.
-  - type: output
+  - type: sink
     name: report
     input: orders
     config:
@@ -93,7 +93,7 @@ nodes:
 ```yaml
 # Corrected (write XML): the values emit as repeated child elements, one per
 # value. See `join_values` in the XML format reference to rename them.
-  - type: output
+  - type: sink
     name: report
     input: orders
     config:
@@ -105,7 +105,7 @@ nodes:
 ```yaml
 # Also rejected: the declaration on the output's own schema, where no writer
 # honors it.
-  - type: output
+  - type: sink
     name: report
     input: orders
     config:

--- a/docs/explain/E364.md
+++ b/docs/explain/E364.md
@@ -51,7 +51,7 @@ nodes:
         - { name: order_id, type: string }
         - { name: customer_id, type: string }
         - { name: sku, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -77,7 +77,7 @@ nodes:
       schema:
         - { name: order_id, type: string }
         - { name: sku, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -103,7 +103,7 @@ nodes:
       schema:
         - { name: order_id, type: string }
         - { name: customer_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -129,7 +129,7 @@ nodes:
       path: ./orders.csv
       schema:
         - { name: order_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -155,7 +155,7 @@ nodes:
         - { name: order_id, type: string }
         - { name: customer_id, type: string }
         - { name: sold_to, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -183,7 +183,7 @@ nodes:
         - { name: order_id, type: string }
         - { name: customer_id, type: string }
         - { name: sku, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:

--- a/docs/explain/E365.md
+++ b/docs/explain/E365.md
@@ -37,7 +37,7 @@ nodes:
       schema:
         - { name: first_name, type: string }
         - { name: last_name, type: string }
-  - type: output
+  - type: sink
     name: out
     input: people
     config:
@@ -63,7 +63,7 @@ nodes:
       schema:
         - { name: first_name, type: string }
         - { name: last_name, type: string }
-  - type: output
+  - type: sink
     name: out
     input: people
     config:

--- a/docs/explain/W365.md
+++ b/docs/explain/W365.md
@@ -38,7 +38,7 @@ nodes:
       path: ./people.csv
       schema:
         - { name: first_name, type: string }
-  - type: output
+  - type: sink
     name: out
     input: people
     config:

--- a/docs/explain/W366.md
+++ b/docs/explain/W366.md
@@ -40,7 +40,7 @@ nodes:
       schema:
         - { name: order_id, type: string }
         - { name: customer_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:


### PR DESCRIPTION
## Summary

- migrate 17 executable planner and diagnostic examples from `type: output` to `type: sink`
- restore the composition-extraction tests that consume the shared pipeline fixture
- restore aggregate validation of the affected diagnostic examples

## Validation

- extraction tests (2 passed)
- explain-document aggregate test (passed)
- `cargo test -p clinker-plan --lib --locked --offline` (949 passed)
- user and engine mdBook builds
- rendered-link validation
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This seven-file corpus update is stacked on #1100 and closes the remaining planner-library fixture failures on that stack.

No production behavior, dependencies, telemetry vocabulary, or memory ownership changes here.
