### PR TITLE
Add bounded numeric schema guess preview

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -93,6 +93,7 @@ fn build_format_reader(
                 schema,
                 MultiRecordKind::Csv(opts.as_ref()),
                 open_one_shot(&source)?,
+                numeric_observer,
             ),
             _ => {
                 let mut config = build_csv_reader_config(opts.as_ref())?;
@@ -132,6 +133,7 @@ fn build_format_reader(
                 schema,
                 MultiRecordKind::FixedWidth(opts.as_ref()),
                 open_one_shot(&source)?,
+                numeric_observer,
             ),
             SourceSchema::Columns(cols) => {
                 let mut config = build_fw_reader_config(opts.as_ref());
@@ -188,9 +190,10 @@ fn build_format_reader(
 /// This is the shared construction seam for runtime ingest and authoring tools:
 /// format options, multi-value behavior, schema projection, and coercion all
 /// pass through the same builders. When `numeric_observer` is present, native
-/// JSON/XML scalars are observed before record-value conversion and decoded
-/// text formats are observed at the canonical schema-coercion boundary. The
-/// callback is synchronous and must retain only bounded evidence.
+/// JSON/XML scalars and positional multi-record fields are observed before
+/// record-value conversion; decoded text formats are observed at the canonical
+/// schema-coercion boundary. The callback is synchronous and must retain only
+/// bounded evidence.
 ///
 /// The function performs no pipeline execution and does not retain the input.
 /// File-backed callers should pass [`ReopenableSource::path`] so JSON and XML
@@ -202,10 +205,11 @@ pub fn build_source_format_reader(
     source: ReopenableSource,
     numeric_observer: Option<NumericObserver>,
 ) -> Result<Box<dyn FormatReader>, PipelineError> {
-    let format_observer = if matches!(
-        &input.format,
-        clinker_plan::config::InputFormat::Json(_) | clinker_plan::config::InputFormat::Xml(_)
-    ) {
+    let format_observer = if matches!(schema, SourceSchema::MultiRecord { .. })
+        || matches!(
+            &input.format,
+            clinker_plan::config::InputFormat::Json(_) | clinker_plan::config::InputFormat::Xml(_)
+        ) {
         numeric_observer.clone()
     } else {
         None
@@ -1346,6 +1350,7 @@ fn build_multi_record_reader(
     schema: &SourceSchema,
     kind: MultiRecordKind,
     reader: Box<dyn Read + Send>,
+    numeric_observer: Option<NumericObserver>,
 ) -> Result<Box<dyn FormatReader>, PipelineError> {
     let SourceSchema::MultiRecord {
         discriminator,
@@ -1380,14 +1385,16 @@ fn build_multi_record_reader(
     let built: Box<dyn FormatReader> = match kind {
         MultiRecordKind::FixedWidth(opts) => {
             let cfg = build_fw_reader_config(opts);
-            Box::new(
-                clinker_format::multi_record::MultiRecordReader::new_fixed_width(
-                    reader,
-                    spec,
-                    cfg.line_separator,
-                )
-                .map_err(to_pipeline_err)?,
+            let reader = clinker_format::multi_record::MultiRecordReader::new_fixed_width(
+                reader,
+                spec,
+                cfg.line_separator,
             )
+            .map_err(to_pipeline_err)?;
+            Box::new(match numeric_observer {
+                Some(observer) => reader.with_numeric_observer(observer),
+                None => reader,
+            })
         }
         MultiRecordKind::Csv(opts) => {
             let cfg = build_csv_reader_config(opts)?;
@@ -1405,22 +1412,24 @@ fn build_multi_record_reader(
                     )),
                 ));
             }
-            Box::new(
-                clinker_format::multi_record::MultiRecordReader::new_csv(
-                    reader,
-                    spec,
-                    clinker_format::multi_record::CsvDialect {
-                        delimiter: cfg.delimiter,
-                        quote_char: cfg.quote_char,
-                        // A multi-record CSV exported with a column-header line
-                        // (the default `has_header: true`) skips that first
-                        // physical row, so a textual header is not mistaken for
-                        // an unknown discriminator value.
-                        has_header: cfg.has_header,
-                    },
-                )
-                .map_err(to_pipeline_err)?,
+            let reader = clinker_format::multi_record::MultiRecordReader::new_csv(
+                reader,
+                spec,
+                clinker_format::multi_record::CsvDialect {
+                    delimiter: cfg.delimiter,
+                    quote_char: cfg.quote_char,
+                    // A multi-record CSV exported with a column-header line
+                    // (the default `has_header: true`) skips that first
+                    // physical row, so a textual header is not mistaken for
+                    // an unknown discriminator value.
+                    has_header: cfg.has_header,
+                },
             )
+            .map_err(to_pipeline_err)?;
+            Box::new(match numeric_observer {
+                Some(observer) => reader.with_numeric_observer(observer),
+                None => reader,
+            })
         }
     };
     Ok(built)

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -16,7 +16,7 @@ use clinker_format::swift::reader::{SwiftReader, SwiftReaderConfig};
 use clinker_format::traits::FormatReader;
 use clinker_format::x12::reader::{X12Reader, X12ReaderConfig};
 use clinker_format::xml::reader::{NamespaceMode, XmlReader, XmlReaderConfig};
-use clinker_format::{Column, SourceSchema};
+use clinker_format::{Column, NumericObserver, SourceSchema};
 use clinker_plan::config::PipelineConfig;
 use clinker_plan::error::PipelineError;
 
@@ -66,6 +66,7 @@ fn build_format_reader(
     input: &clinker_plan::config::SourceConfig,
     schema: &SourceSchema,
     source: ReopenableSource,
+    numeric_observer: Option<NumericObserver>,
 ) -> Result<Box<dyn FormatReader>, PipelineError> {
     // External `.schema.yaml` (`SourceSchema::File`) references are resolved to
     // their inline form once at compile time (config load + `compile`), so the
@@ -107,11 +108,21 @@ fn build_format_reader(
         },
         clinker_plan::config::InputFormat::Json(opts) => {
             let config = build_json_reader_config(opts.as_ref(), input, schema);
-            Ok(Box::new(JsonReader::from_source(source, config)?))
+            match numeric_observer {
+                Some(observer) => Ok(Box::new(JsonReader::from_source_observing(
+                    source, config, observer,
+                )?)),
+                None => Ok(Box::new(JsonReader::from_source(source, config)?)),
+            }
         }
         clinker_plan::config::InputFormat::Xml(opts) => {
             let config = build_xml_reader_config(opts.as_ref(), input, schema);
-            Ok(Box::new(XmlReader::from_source(source, config)?))
+            match numeric_observer {
+                Some(observer) => Ok(Box::new(XmlReader::from_source_observing(
+                    source, config, observer,
+                )?)),
+                None => Ok(Box::new(XmlReader::from_source(source, config)?)),
+            }
         }
         clinker_plan::config::InputFormat::FixedWidth(opts) => match schema {
             // A multi-record `schema:` is a header/trailer/body byte-range flat
@@ -171,6 +182,43 @@ fn build_format_reader(
     }
 }
 
+/// Build one read-only source reader from an already-resolved effective source
+/// configuration and byte source.
+///
+/// This is the shared construction seam for runtime ingest and authoring tools:
+/// format options, multi-value behavior, schema projection, and coercion all
+/// pass through the same builders. When `numeric_observer` is present, native
+/// JSON/XML scalars are observed before record-value conversion and decoded
+/// text formats are observed at the canonical schema-coercion boundary. The
+/// callback is synchronous and must retain only bounded evidence.
+///
+/// The function performs no pipeline execution and does not retain the input.
+/// File-backed callers should pass [`ReopenableSource::path`] so JSON and XML
+/// remain streaming rather than buffering a complete document.
+pub fn build_source_format_reader(
+    input: &clinker_plan::config::SourceConfig,
+    schema: &SourceSchema,
+    policy: clinker_plan::config::pipeline_node::OnUnmapped,
+    source: ReopenableSource,
+    numeric_observer: Option<NumericObserver>,
+) -> Result<Box<dyn FormatReader>, PipelineError> {
+    let format_observer = if matches!(
+        &input.format,
+        clinker_plan::config::InputFormat::Json(_) | clinker_plan::config::InputFormat::Xml(_)
+    ) {
+        numeric_observer.clone()
+    } else {
+        None
+    };
+    let coercion_observer = if format_observer.is_some() {
+        None
+    } else {
+        numeric_observer
+    };
+    let reader = build_format_reader(input, schema, source, format_observer)?;
+    wrap_reader_with_schema_coercion(reader, input, schema, policy, coercion_observer)
+}
+
 /// Open a single `Read` from a re-openable source for a one-pass format reader,
 /// mapping an open failure to a pipeline config-validation error.
 fn open_one_shot(source: &ReopenableSource) -> Result<Box<dyn Read + Send>, PipelineError> {
@@ -203,7 +251,7 @@ fn build_multi_file_reader(
     let factory: Box<FactoryFn> = Box::new(
         move |source: ReopenableSource|
               -> Result<Box<dyn FormatReader>, clinker_format::FormatError> {
-            build_format_reader(&owned_config, &owned_schema, source).map_err(|e| {
+            build_format_reader(&owned_config, &owned_schema, source, None).map_err(|e| {
                 clinker_format::FormatError::SchemaInference(format!(
                     "format reader construction failed: {e}"
                 ))
@@ -233,36 +281,16 @@ fn build_multi_file_reader(
 
 /// Wrap a format reader with schema-based type coercion if the source
 /// declares typed columns in its `schema:` block.
-fn wrap_with_schema_coercion(
+fn wrap_reader_with_schema_coercion(
     reader: Box<dyn FormatReader>,
-    config: &PipelineConfig,
-    source_name: &str,
+    input: &clinker_plan::config::SourceConfig,
+    schema: &SourceSchema,
+    policy: clinker_plan::config::pipeline_node::OnUnmapped,
+    numeric_observer: Option<NumericObserver>,
 ) -> Result<Box<dyn FormatReader>, PipelineError> {
-    use clinker_plan::config::PipelineNode;
     use clinker_plan::config::pipeline_node::OnUnmapped;
-
-    // Find the source node's schema + on_unmapped policy + format. Format is
-    // needed for the auto_widen-on-fixed-width structural-inertness diagnostic
-    // below.
-    let body_data = config.nodes.iter().find_map(|s| {
-        if let PipelineNode::Source {
-            header,
-            config: body,
-        } = &s.value
-            && header.name == source_name
-        {
-            return Some((
-                &body.schema,
-                body.on_unmapped.clone(),
-                body.source.format.clone(),
-            ));
-        }
-        None
-    });
-
-    let Some((schema, policy, format)) = body_data else {
-        return Ok(reader);
-    };
+    let source_name = input.name.as_str();
+    let format = &input.format;
 
     // The unified `schema:` is resolved to its effective column list (single-
     // record columns, or the multi-record superset). Its `File` form was
@@ -314,13 +342,25 @@ fn wrap_with_schema_coercion(
                         source_name,
                     )
                 }
-                _ => crate::pipeline::schema_coerce::CoercingReader::new(
-                    reader,
-                    &columns,
-                    policy,
-                    source_name,
-                    pretyped,
-                ),
+                _ => match numeric_observer {
+                    Some(observer) => {
+                        crate::pipeline::schema_coerce::CoercingReader::new_observing(
+                            reader,
+                            &columns,
+                            policy,
+                            source_name,
+                            pretyped,
+                            observer,
+                        )
+                    }
+                    None => crate::pipeline::schema_coerce::CoercingReader::new(
+                        reader,
+                        &columns,
+                        policy,
+                        source_name,
+                        pretyped,
+                    ),
+                },
             }
             .map_err(|e| PipelineError::Compilation {
                 transform_name: source_name.to_string(),
@@ -359,16 +399,19 @@ fn coercible_columns(
     }
 }
 
-/// Borrow a source node's unified `schema:` ([`SourceSchema`]) from the compiled
-/// plan, keyed by node identity (`header.name`) — the same key every other
-/// source lookup on the ingest path uses.
-fn source_schema<'a>(config: &'a PipelineConfig, source_name: &str) -> Option<&'a SourceSchema> {
+/// Borrow a source node body from the compiled plan, keyed by node identity
+/// (`header.name`) — the same key every other source lookup on the ingest path
+/// uses.
+fn source_body<'a>(
+    config: &'a PipelineConfig,
+    source_name: &str,
+) -> Option<&'a clinker_plan::config::pipeline_node::SourceBody> {
     use clinker_plan::config::PipelineNode;
     config.nodes.iter().find_map(|s| match &s.value {
         PipelineNode::Source {
             header,
             config: body,
-        } if header.name == source_name => Some(&body.schema),
+        } if header.name == source_name => Some(body),
         _ => None,
     })
 }
@@ -454,14 +497,21 @@ pub(super) fn ingest_source(
                     )),
                 ));
             }
-            let schema = source_schema(&config, &src_cfg.name).ok_or_else(|| {
+            let body = source_body(&config, &src_cfg.name).ok_or_else(|| {
                 PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
                     "source '{}' not found in the compiled plan while building its reader",
                     src_cfg.name
                 )))
             })?;
-            let raw_reader = build_multi_file_reader(&src_cfg, schema, files, progress.clone())?;
-            let src_reader = wrap_with_schema_coercion(raw_reader, &config, &src_cfg.name)?;
+            let raw_reader =
+                build_multi_file_reader(&src_cfg, &body.schema, files, progress.clone())?;
+            let src_reader = wrap_reader_with_schema_coercion(
+                raw_reader,
+                &src_cfg,
+                &body.schema,
+                body.on_unmapped.clone(),
+                None,
+            )?;
             // The file arm reaches the shared driver through the blanket
             // `RecordSource for Box<dyn FormatReader>` impl.
             drive_record_source(src_cfg, Box::new(src_reader), stream, shutdown_token)
@@ -1702,7 +1752,7 @@ nodes:
             clinker_format::Column::bare("name", cxl::typecheck::Type::String),
         ]);
 
-        let mut reader = build_format_reader(&input, &schema, source).expect("build reader");
+        let mut reader = build_format_reader(&input, &schema, source, None).expect("build reader");
         while reader.next_record().expect("read record").is_some() {}
 
         assert_eq!(

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -49,6 +49,7 @@ use context::build_stable_eval_context;
 pub use dispatch::DispatchFaultGuard;
 pub use dlq::DlqEntry;
 pub(crate) use dlq::TypeErrorEvent;
+pub use ingest::build_source_format_reader;
 use ingest::{IngestTaskOutcome, ingest_source};
 use params::sum_cpu_io_totals;
 pub use params::{ExecutionReport, PipelineRunParams};

--- a/crates/clinker-exec/tests/numeric_guess_parity.rs
+++ b/crates/clinker-exec/tests/numeric_guess_parity.rs
@@ -1,4 +1,6 @@
+use clinker_exec::executor::build_source_format_reader;
 use clinker_exec::pipeline::schema_coerce::{CoercingReader, coerce_numeric_with_observation};
+use clinker_format::ReopenableSource;
 use clinker_format::edifact::{EdifactReader, EdifactReaderConfig};
 use clinker_format::fixed_width::field::{
     coerce_scalar_with_constraints, coerce_scalar_with_constraints_observed,
@@ -572,4 +574,114 @@ fn coercing_reader_emits_schema_observation_before_accepting_csv_text() {
     assert_eq!(field, "n");
     assert_eq!(observation.boundary(), NumericBoundary::SchemaCoerce);
     assert_eq!(record.get("n"), observation.parsed_value().as_ref());
+}
+
+fn source_body<'a>(
+    config: &'a clinker_plan::config::PipelineConfig,
+    name: &str,
+) -> &'a clinker_plan::config::SourceBody {
+    config
+        .source_bodies()
+        .find(|body| body.source.name == name)
+        .unwrap_or_else(|| panic!("source {name} exists"))
+}
+
+fn observe_with_shared_source_reader(
+    body: &clinker_plan::config::SourceBody,
+    input: &str,
+) -> (Value, NumericObservation) {
+    let (observer, observations) = observation_collector();
+    let source = ReopenableSource::buffer(Cursor::new(input.as_bytes().to_vec()))
+        .expect("buffer source bytes");
+    let mut reader = build_source_format_reader(
+        &body.source,
+        &body.schema,
+        body.on_unmapped.clone(),
+        source,
+        Some(observer),
+    )
+    .expect("shared source reader builds");
+    let record = reader
+        .next_record()
+        .expect("source record parses")
+        .expect("one source record");
+    assert!(reader.next_record().expect("source reaches EOF").is_none());
+    let observations = observations.lock().expect("observation collector lock");
+    let [(field, observation)] = observations.as_slice() else {
+        panic!("expected one numeric observation, got {observations:?}");
+    };
+    assert_eq!(field, "n");
+    (
+        record.get("n").expect("n field").clone(),
+        observation.clone(),
+    )
+}
+
+#[test]
+fn shared_guess_reader_matches_runtime_csv_json_and_xml_construction() {
+    let config = clinker_plan::config::load_config_from_str(
+        r#"
+pipeline:
+  name: shared_reader_parity
+nodes:
+  - type: source
+    name: csv_source
+    config:
+      name: csv_source
+      type: csv
+      path: unused.csv
+      options:
+        delimiter: ";"
+      schema:
+        - { name: n, type: numeric }
+  - type: source
+    name: json_source
+    config:
+      name: json_source
+      type: json
+      path: unused.json
+      options:
+        format: array
+      schema:
+        - { name: n, type: numeric }
+  - type: source
+    name: xml_source
+    config:
+      name: xml_source
+      type: xml
+      path: unused.xml
+      options:
+        record_path: root/row
+      schema:
+        - { name: n, type: numeric }
+"#,
+    )
+    .expect("parse reader parity config");
+
+    let (csv_value, csv_observation) = observe_with_shared_source_reader(
+        source_body(&config, "csv_source"),
+        "n;ignored\n42.5;x\n",
+    );
+    assert_eq!(csv_value, Value::Float(42.5));
+    assert_eq!(csv_observation.boundary(), NumericBoundary::SchemaCoerce);
+    assert_eq!(csv_observation.vote(), NumericVote::Float);
+
+    let (json_value, json_observation) = observe_with_shared_source_reader(
+        source_body(&config, "json_source"),
+        r#"[{"n":0.10000000000000001}]"#,
+    );
+    assert_eq!(json_value, Value::Float(0.1));
+    assert_eq!(json_observation.boundary(), NumericBoundary::Json);
+    assert_eq!(
+        json_observation.vote(),
+        NumericVote::Unresolved(NumericIssue::PrecisionLoss)
+    );
+
+    let (xml_value, xml_observation) = observe_with_shared_source_reader(
+        source_body(&config, "xml_source"),
+        "<root><row><n>42</n></row></root>",
+    );
+    assert_eq!(xml_value, Value::Integer(42));
+    assert_eq!(xml_observation.boundary(), NumericBoundary::Xml);
+    assert_eq!(xml_observation.vote(), NumericVote::Int);
 }

--- a/crates/clinker-exec/tests/numeric_guess_parity.rs
+++ b/crates/clinker-exec/tests/numeric_guess_parity.rs
@@ -685,3 +685,100 @@ nodes:
     assert_eq!(xml_observation.boundary(), NumericBoundary::Xml);
     assert_eq!(xml_observation.vote(), NumericVote::Int);
 }
+
+#[test]
+fn shared_guess_reader_observes_only_literal_numeric_multi_record_owners() {
+    let config = clinker_plan::config::load_config_from_str(
+        r#"
+pipeline:
+  name: multi_record_reader_parity
+nodes:
+  - type: source
+    name: csv_source
+    config:
+      name: csv_source
+      type: csv
+      path: unused.csv
+      options:
+        has_header: false
+      schema:
+        discriminator: { field: kind }
+        records:
+          - id: detail
+            tag: D
+            columns:
+              - { name: kind, type: string }
+              - { name: amount, type: numeric }
+          - id: adjustment
+            tag: A
+            columns:
+              - { name: kind, type: string }
+              - { name: amount, type: { nullable: numeric } }
+          - id: summary
+            tag: S
+            columns:
+              - { name: kind, type: string }
+              - { name: amount, type: int }
+"#,
+    )
+    .expect("parse multi-record reader parity config");
+    let body = source_body(&config, "csv_source");
+    let observations = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&observations);
+    let observer = NumericObserver::new_scoped(move |scope, observation| {
+        sink.lock()
+            .expect("scoped observation collector lock")
+            .push((
+                scope.record().map(str::to_owned),
+                scope.field().to_owned(),
+                observation,
+            ));
+    });
+    let source = ReopenableSource::buffer(Cursor::new(b"D,10\nA,20.5\nS,30\n".to_vec()))
+        .expect("buffer multi-record bytes");
+    let mut reader = build_source_format_reader(
+        &body.source,
+        &body.schema,
+        body.on_unmapped.clone(),
+        source,
+        Some(observer),
+    )
+    .expect("shared multi-record reader builds");
+    let mut records = Vec::new();
+    while let Some(record) = reader.next_record().expect("multi-record row parses") {
+        records.push(record);
+    }
+    assert_eq!(records.len(), 3);
+    assert_eq!(records[2].get("amount"), Some(&Value::Integer(30)));
+
+    let observations = observations.lock().expect("observation collector lock");
+    assert_eq!(observations.len(), 2, "concrete int owner must not vote");
+    assert_eq!(
+        observations
+            .iter()
+            .map(|(record, field, observation)| (
+                record.as_deref(),
+                field.as_str(),
+                observation.boundary(),
+                observation.lexeme().complete(),
+                observation.vote(),
+            ))
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                Some("detail"),
+                "amount",
+                NumericBoundary::Positional,
+                Some("10"),
+                NumericVote::Int,
+            ),
+            (
+                Some("adjustment"),
+                "amount",
+                NumericBoundary::Positional,
+                Some("20.5"),
+                NumericVote::Float,
+            ),
+        ]
+    );
+}

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -37,8 +37,9 @@ pub use multi_value::{
 };
 pub use numeric_observation::{
     NumericAcceptance, NumericBoundary, NumericIssue, NumericLexeme, NumericObservation,
-    NumericObserver, NumericParserOutcome, NumericVote, observe_json_number, observe_json_value,
-    observe_positional_numeric, observe_schema_numeric, observe_xml_scalar,
+    NumericObservationScope, NumericObserver, NumericParserOutcome, NumericVote,
+    observe_json_number, observe_json_value, observe_positional_numeric, observe_schema_numeric,
+    observe_xml_scalar,
 };
 pub use record_path::{RecordPath, RecordPathError, RecordPathSyntax};
 pub use schema::{

--- a/crates/clinker-format/src/multi_record.rs
+++ b/crates/clinker-format/src/multi_record.rs
@@ -36,6 +36,7 @@ use crate::bom::SkipBom;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
 use crate::fixed_width::field::{self, ResolvedField};
+use crate::numeric_observation::NumericObserver;
 use crate::schema::{Column, Discriminator, RecordType, StructureConstraint};
 use crate::traits::FormatReader;
 
@@ -182,6 +183,9 @@ pub struct MultiRecordReader<R: Read> {
     /// `true` once the trailer of a constrained type has streamed; a body row
     /// after it is a structural error (content past the document's trailer).
     trailer_seen: bool,
+    /// Optional authoring-only sink for numeric observations produced by the
+    /// canonical positional coercion of each active record-type field.
+    numeric_observer: Option<NumericObserver>,
     done: bool,
 }
 
@@ -345,8 +349,17 @@ impl<R: Read> MultiRecordReader<R> {
             pending_line: None,
             last_trailer: None,
             trailer_seen: false,
+            numeric_observer: None,
             done: false,
         })
+    }
+
+    /// Stream parser-owned numeric observations while preserving ordinary
+    /// reader output and error behavior.
+    #[must_use]
+    pub fn with_numeric_observer(mut self, observer: NumericObserver) -> Self {
+        self.numeric_observer = Some(observer);
+        self
     }
 
     /// Read one non-blank physical line from the scanner, or `None` at end of
@@ -438,7 +451,13 @@ impl<R: Read> MultiRecordReader<R> {
         let mut values: Vec<Value> = vec![Value::Null; self.schema.column_count()];
         values[0] = Value::String(rt.id.as_ref().into());
         for tf in &rt.fields {
-            values[tf.column] = extract_field_value(tf, line, self.physical_row)?;
+            values[tf.column] = extract_field_value(
+                rt.id.as_ref(),
+                tf,
+                line,
+                self.physical_row,
+                self.numeric_observer.as_ref(),
+            )?;
         }
         Ok(Record::new(Arc::clone(&self.schema), values))
     }
@@ -474,6 +493,7 @@ impl<R: Read> MultiRecordReader<R> {
                 .by_tag
                 .get(&tag)
                 .expect("header tag resolved to a record type at construction");
+            observe_numeric_fields(rt, &line, self.physical_row, self.numeric_observer.as_ref())?;
             let pairs = collect_named_pairs(rt, &line, self.physical_row)?;
             self.captured_headers.insert(tag, pairs);
         }
@@ -502,11 +522,23 @@ impl<R: Read> MultiRecordReader<R> {
             };
             let id = Arc::clone(&rt.id);
             if self.header_ids.iter().any(|h| Arc::ptr_eq(h, &id)) {
+                observe_numeric_fields(
+                    rt,
+                    &line,
+                    self.physical_row,
+                    self.numeric_observer.as_ref(),
+                )?;
                 // A header type's row outside the contiguous head region: the
                 // pre-scan already captured the first occurrence.
                 continue;
             }
             if self.trailer_ids.iter().any(|t| Arc::ptr_eq(t, &id)) {
+                observe_numeric_fields(
+                    rt,
+                    &line,
+                    self.physical_row,
+                    self.numeric_observer.as_ref(),
+                )?;
                 let raw = collect_named_pairs(rt, &line, self.physical_row)?;
                 self.last_trailer = Some((id, raw.into_iter().collect()));
                 self.trailer_seen = true;
@@ -891,7 +923,13 @@ fn require_tag(tag: &str, id: &str) -> Result<String, String> {
 
 /// Extract one field's typed value from a scanned line: pull the raw text
 /// (shared with pair collection), then coerce to the declared type.
-fn extract_field_value(tf: &TypeField, line: &ScannedLine, row: u64) -> Result<Value, FormatError> {
+fn extract_field_value(
+    record: &str,
+    tf: &TypeField,
+    line: &ScannedLine,
+    row: u64,
+    numeric_observer: Option<&NumericObserver>,
+) -> Result<Value, FormatError> {
     let raw = field_raw_text(tf, line, row)?;
     if raw.is_empty() {
         if tf.ty.is_nullable() || matches!(tf.ty.unwrap_nullable(), Type::Null) {
@@ -902,17 +940,59 @@ fn extract_field_value(tf: &TypeField, line: &ScannedLine, row: u64) -> Result<V
             message: format!("field '{}': null is not a valid {}", tf.name, tf.ty),
         });
     }
-    field::coerce_scalar_with_constraints(
+    let observed = field::coerce_scalar_with_constraints_observed(
         &tf.ty,
         tf.format.as_deref(),
         tf.precision,
         tf.scale,
         &raw,
-    )
-    .map_err(|m| FormatError::InvalidRecord {
-        row,
-        message: format!("field '{}': {m}", tf.name),
-    })
+    );
+    if let Some(observation) = observed.numeric_observation()
+        && let Some(observer) = numeric_observer
+    {
+        observer.observe_record_field(record, &tf.name, observation.clone());
+    }
+    observed
+        .into_result()
+        .map_err(|m| FormatError::InvalidRecord {
+            row,
+            message: format!("field '{}': {m}", tf.name),
+        })
+}
+
+/// Observe numeric fields on a header/trailer row that is structurally
+/// consumed rather than emitted as a body record. The ordinary reader does not
+/// coerce those fields into record values, so parser rejection remains report
+/// evidence and does not change runtime success/failure behavior.
+fn observe_numeric_fields(
+    rt: &ResolvedType,
+    line: &ScannedLine,
+    row: u64,
+    numeric_observer: Option<&NumericObserver>,
+) -> Result<(), FormatError> {
+    let Some(observer) = numeric_observer else {
+        return Ok(());
+    };
+    for tf in &rt.fields {
+        if !matches!(tf.ty.unwrap_nullable(), Type::Numeric) {
+            continue;
+        }
+        let raw = field_raw_text(tf, line, row)?;
+        if raw.is_empty() {
+            continue;
+        }
+        let observed = field::coerce_scalar_with_constraints_observed(
+            &tf.ty,
+            tf.format.as_deref(),
+            tf.precision,
+            tf.scale,
+            &raw,
+        );
+        if let Some(observation) = observed.numeric_observation() {
+            observer.observe_record_field(rt.id.as_ref(), &tf.name, observation.clone());
+        }
+    }
+    Ok(())
 }
 
 /// A field's raw (un-coerced) text from a scanned line, stripped of padding

--- a/crates/clinker-format/src/numeric_observation.rs
+++ b/crates/clinker-format/src/numeric_observation.rs
@@ -184,9 +184,30 @@ impl NumericObservation {
     }
 }
 
+/// Authored field identity at the parser boundary that produced an
+/// observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NumericObservationScope<'a> {
+    field: &'a str,
+    record: Option<&'a str>,
+}
+
+impl<'a> NumericObservationScope<'a> {
+    pub fn field(self) -> &'a str {
+        self.field
+    }
+
+    /// Record-type id for a multi-record field, or `None` for an ordinary
+    /// source column.
+    pub fn record(self) -> Option<&'a str> {
+        self.record
+    }
+}
+
 /// Cloneable callback used by streaming readers to publish one observation at
 /// a time without retaining document-sized evidence.
-type NumericObservationCallback = dyn Fn(&str, NumericObservation) + Send + Sync;
+type NumericObservationCallback =
+    dyn for<'a> Fn(NumericObservationScope<'a>, NumericObservation) + Send + Sync;
 
 #[derive(Clone)]
 pub struct NumericObserver {
@@ -199,12 +220,39 @@ impl NumericObserver {
         F: Fn(&str, NumericObservation) + Send + Sync + 'static,
     {
         Self {
+            callback: Arc::new(move |scope, observation| callback(scope.field(), observation)),
+        }
+    }
+
+    /// Build an observer that retains the record-type identity emitted by a
+    /// multi-record parser boundary.
+    pub fn new_scoped<F>(callback: F) -> Self
+    where
+        F: for<'a> Fn(NumericObservationScope<'a>, NumericObservation) + Send + Sync + 'static,
+    {
+        Self {
             callback: Arc::new(callback),
         }
     }
 
     pub fn observe(&self, field: &str, observation: NumericObservation) {
-        (self.callback)(field, observation);
+        (self.callback)(
+            NumericObservationScope {
+                field,
+                record: None,
+            },
+            observation,
+        );
+    }
+
+    pub fn observe_record_field(&self, record: &str, field: &str, observation: NumericObservation) {
+        (self.callback)(
+            NumericObservationScope {
+                field,
+                record: Some(record),
+            },
+            observation,
+        );
     }
 }
 

--- a/crates/clinker-plan/src/config/composition/mod.rs
+++ b/crates/clinker-plan/src/config/composition/mod.rs
@@ -85,6 +85,7 @@ pub use provenance::{
     LayerKind, ProvenanceDb, ProvenanceField, ProvenanceKey, ProvenanceLayer,
     ProvenanceLookupError, ProvenanceMatch, ProvenanceQuery, ProvenanceQueryParseError,
     ResolvedValue, ScopedNodeAddress, ScopedNodeAddressParseError, ScopedSchemaAddress,
+    ScopedSchemaLeafAddress,
 };
 pub use resource::Resource;
 pub use schema_provenance::{

--- a/crates/clinker-plan/src/config/composition/provenance.rs
+++ b/crates/clinker-plan/src/config/composition/provenance.rs
@@ -299,6 +299,22 @@ pub struct ScopedSchemaAddress {
     attribute: String,
 }
 
+/// Exact owner address for one authored source-schema leaf.
+///
+/// A single-record column uses the existing [`ScopedSchemaAddress`] shape. A
+/// discriminator-driven schema adds the authored `records:` id before the
+/// column, keeping two same-named columns in distinct record types distinct.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ScopedSchemaLeafAddress {
+    Column(ScopedSchemaAddress),
+    RecordColumn {
+        source: String,
+        record: String,
+        column: String,
+        attribute: String,
+    },
+}
+
 impl ScopedSchemaAddress {
     pub fn new(
         source: impl Into<String>,
@@ -357,6 +373,113 @@ impl ScopedSchemaAddress {
 
     pub fn attribute(&self) -> &str {
         &self.attribute
+    }
+}
+
+impl ScopedSchemaLeafAddress {
+    pub fn column(
+        source: impl Into<String>,
+        column: impl Into<String>,
+        attribute: impl Into<String>,
+    ) -> Self {
+        Self::Column(ScopedSchemaAddress::new(source, column, attribute))
+    }
+
+    pub fn record_column(
+        source: impl Into<String>,
+        record: impl Into<String>,
+        column: impl Into<String>,
+        attribute: impl Into<String>,
+    ) -> Self {
+        Self::RecordColumn {
+            source: source.into(),
+            record: record.into(),
+            column: column.into(),
+            attribute: attribute.into(),
+        }
+    }
+
+    pub fn parse(input: &str) -> Result<Self, ScopedNodeAddressParseError> {
+        if let Ok(address) = ScopedSchemaAddress::parse(input) {
+            return Ok(Self::Column(address));
+        }
+        let raw_segments: Vec<&str> = input
+            .strip_prefix('/')
+            .ok_or_else(|| ScopedNodeAddressParseError::Malformed(input.to_owned()))?
+            .split('/')
+            .collect();
+        let segments: Vec<String> = raw_segments
+            .into_iter()
+            .map(decode_pointer_segment)
+            .collect::<Result<_, _>>()?;
+        if segments.len() != 10
+            || segments[0] != "v1"
+            || segments[1] != "schema"
+            || segments[2] != "sources"
+            || segments[4] != "records"
+            || segments[6] != "columns"
+            || segments[8] != "attributes"
+        {
+            return Err(ScopedNodeAddressParseError::Malformed(input.to_owned()));
+        }
+        Ok(Self::record_column(
+            segments[3].clone(),
+            segments[5].clone(),
+            segments[7].clone(),
+            segments[9].clone(),
+        ))
+    }
+
+    pub fn render(&self) -> String {
+        match self {
+            Self::Column(address) => address.render(),
+            Self::RecordColumn {
+                source,
+                record,
+                column,
+                attribute,
+            } => format!(
+                "/v1/schema/sources/{}/records/{}/columns/{}/attributes/{}",
+                encode_pointer_segment(source),
+                encode_pointer_segment(record),
+                encode_pointer_segment(column),
+                encode_pointer_segment(attribute),
+            ),
+        }
+    }
+
+    pub fn source(&self) -> &str {
+        match self {
+            Self::Column(address) => address.source(),
+            Self::RecordColumn { source, .. } => source,
+        }
+    }
+
+    pub fn record(&self) -> Option<&str> {
+        match self {
+            Self::Column(_) => None,
+            Self::RecordColumn { record, .. } => Some(record),
+        }
+    }
+
+    pub fn column_name(&self) -> &str {
+        match self {
+            Self::Column(address) => address.column(),
+            Self::RecordColumn { column, .. } => column,
+        }
+    }
+
+    pub fn attribute(&self) -> &str {
+        match self {
+            Self::Column(address) => address.attribute(),
+            Self::RecordColumn { attribute, .. } => attribute,
+        }
+    }
+}
+
+impl From<ScopedSchemaAddress> for ScopedSchemaLeafAddress {
+    fn from(address: ScopedSchemaAddress) -> Self {
+        Self::Column(address)
     }
 }
 
@@ -1155,6 +1278,28 @@ mod tests {
         assert_ne!(left.render(), right.render());
         assert_eq!(ScopedNodeAddress::parse(&left.render()).unwrap(), left);
         assert_eq!(ScopedNodeAddress::parse(&right.render()).unwrap(), right);
+    }
+
+    #[test]
+    fn schema_leaf_addresses_round_trip_flat_and_record_column_owners() {
+        let flat = ScopedSchemaLeafAddress::column("orders/~", "amount/paid", "type");
+        assert_eq!(
+            ScopedSchemaLeafAddress::parse(&flat.render()).unwrap(),
+            flat
+        );
+
+        let record = ScopedSchemaLeafAddress::record_column(
+            "orders/~",
+            "detail/foreign~",
+            "amount/paid",
+            "type",
+        );
+        let rendered = record.render();
+        assert_eq!(
+            rendered,
+            "/v1/schema/sources/orders~1~0/records/detail~1foreign~0/columns/amount~1paid/attributes/type"
+        );
+        assert_eq!(ScopedSchemaLeafAddress::parse(&rendered).unwrap(), record);
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/discovery.rs
+++ b/crates/clinker-plan/src/config/discovery.rs
@@ -18,6 +18,7 @@
 //!   falls back to `modified()` otherwise — mirrors `find -newer` and
 //!   Spark's `latestFirst` semantics.
 
+use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -115,6 +116,46 @@ impl DiscoveryOutcome {
     }
 }
 
+/// Bounded discovery result for read-only sampling tools.
+///
+/// `files()` retains at most the caller's requested limit while
+/// `discovered_file_count()` reports the complete post-filter, post-take file
+/// count. Candidate enumeration streams through the matcher and never retains
+/// a collection proportional to the number of matching filesystem entries.
+#[derive(Debug)]
+pub enum BoundedDiscoveryOutcome {
+    /// One or more files survived discovery.
+    Found {
+        files: Vec<DiscoveredFile>,
+        discovered_files: usize,
+    },
+    /// Zero files survived, and the policy is `Warn`.
+    EmptyWarn { matcher: String },
+    /// Zero files survived, and the policy is `Skip`.
+    EmptySkip,
+}
+
+impl BoundedDiscoveryOutcome {
+    /// Borrow the fixed-size deterministic sample.
+    pub fn files(&self) -> &[DiscoveredFile] {
+        match self {
+            Self::Found { files, .. } => files,
+            Self::EmptyWarn { .. } | Self::EmptySkip => &[],
+        }
+    }
+
+    /// Number of files in the complete discovered set after configured
+    /// `take_first` / `take_last` selection.
+    pub fn discovered_file_count(&self) -> usize {
+        match self {
+            Self::Found {
+                discovered_files, ..
+            } => *discovered_files,
+            Self::EmptyWarn { .. } | Self::EmptySkip => 0,
+        }
+    }
+}
+
 /// Run the full discovery pipeline against `source` rooted at `base_dir`.
 ///
 /// `base_dir` is the workspace root (typically the directory containing
@@ -134,50 +175,12 @@ pub fn discover(
         return Err(DiscoveryError::TakeBothSpecified);
     }
 
-    // 3. Enumerate primary candidates.
+    // 3-5. Stream primary candidates through filters and metadata loading.
     let recursive = effective_recursive(source, &matcher);
-    let mut candidates = enumerate(&matcher, base_dir, recursive)?;
-
-    // 4. Drop entries matching any `exclude` pattern.
-    if let Some(excludes) = source.exclude.as_deref() {
-        let compiled = compile_globs(excludes)?;
-        candidates.retain(|p| !matches_any(p, &compiled));
-    }
-
-    // 5. Stat each survivor. Drop those that fail size / mtime filters.
-    let now = SystemTime::now();
-    let mut discovered: Vec<DiscoveredFile> = Vec::with_capacity(candidates.len());
-    for path in candidates {
-        let meta = match std::fs::metadata(&path) {
-            Ok(m) => m,
-            Err(e) => return Err(DiscoveryError::Io(e)),
-        };
-        if !meta.is_file() {
-            continue;
-        }
-        let size = meta.len();
-        if let Some(min) = source.min_size
-            && size < min.0
-        {
-            continue;
-        }
-        if let Some(max) = source.max_size
-            && size > max.0
-        {
-            continue;
-        }
-        let modified = meta.modified().unwrap_or(now);
-        let created = meta.created().unwrap_or(modified);
-        if !time_bound_pass(modified, source.modified_after, source.modified_before) {
-            continue;
-        }
-        discovered.push(DiscoveredFile {
-            path,
-            modified,
-            created,
-            size,
-        });
-    }
+    let mut discovered = Vec::new();
+    visit_discovered_files(source, &matcher, base_dir, recursive, |file| {
+        discovered.push(file);
+    })?;
 
     // 6. Sort by configured key + direction (defaults: name ascending).
     let (sort_key, sort_dir) = sort_spec(source);
@@ -218,19 +221,87 @@ pub fn discover(
     Ok(DiscoveryOutcome::Found(discovered))
 }
 
+/// Discover a deterministic, fixed-size sample without materializing the
+/// complete candidate or discovered-file set.
+///
+/// The sample follows the configured file ordering. For `take_first` (or no
+/// take control), it retains the first `limit` files. For `take_last`, it
+/// retains the last `limit` files; these are a deterministic subset of the
+/// selected tail even when the authored take count is larger than `limit`.
+/// The complete selected count is still reported.
+pub fn discover_bounded(
+    source: &SourceConfig,
+    base_dir: &Path,
+    limit: usize,
+) -> Result<BoundedDiscoveryOutcome, DiscoveryError> {
+    let matcher = pick_matcher(source)?;
+    if let Some(controls) = source.files.as_ref()
+        && controls.take_first.is_some()
+        && controls.take_last.is_some()
+    {
+        return Err(DiscoveryError::TakeBothSpecified);
+    }
+
+    let controls = source.files.as_ref();
+    let take_limit = controls.and_then(|controls| controls.take_first.or(controls.take_last));
+    let retain_limit = limit.min(take_limit.unwrap_or(usize::MAX));
+    let retain_tail = controls.is_some_and(|controls| controls.take_last.is_some());
+    let (sort_key, sort_dir) = sort_spec(source);
+    let recursive = effective_recursive(source, &matcher);
+    let mut matched_files = 0usize;
+    let mut files = Vec::with_capacity(retain_limit);
+    visit_discovered_files(source, &matcher, base_dir, recursive, |file| {
+        let ordinal = matched_files;
+        matched_files = matched_files.saturating_add(1);
+        retain_ordered_sample(
+            &mut files,
+            OrderedDiscoveredFile { file, ordinal },
+            retain_limit,
+            sort_key,
+            sort_dir,
+            retain_tail,
+        );
+    })?;
+
+    let discovered_files = take_limit
+        .map(|take| matched_files.min(take))
+        .unwrap_or(matched_files);
+    if discovered_files == 0 {
+        let policy = controls
+            .and_then(|controls| controls.on_no_match)
+            .unwrap_or_default();
+        return Ok(match policy {
+            NoMatchPolicy::Error => {
+                return Err(DiscoveryError::NoMatch {
+                    matcher: matcher_display(&matcher),
+                });
+            }
+            NoMatchPolicy::Warn => BoundedDiscoveryOutcome::EmptyWarn {
+                matcher: matcher_display(&matcher),
+            },
+            NoMatchPolicy::Skip => BoundedDiscoveryOutcome::EmptySkip,
+        });
+    }
+
+    Ok(BoundedDiscoveryOutcome::Found {
+        files: files.into_iter().map(|selected| selected.file).collect(),
+        discovered_files,
+    })
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // internals
 // ──────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone)]
-enum Matcher {
-    Path(String),
-    Glob(String),
-    Regex(String),
-    Paths(Vec<String>),
+#[derive(Debug, Clone, Copy)]
+enum Matcher<'a> {
+    Path(&'a str),
+    Glob(&'a str),
+    Regex(&'a str),
+    Paths(&'a [String]),
 }
 
-fn pick_matcher(source: &SourceConfig) -> Result<Matcher, DiscoveryError> {
+fn pick_matcher(source: &SourceConfig) -> Result<Matcher<'_>, DiscoveryError> {
     let mut which: Vec<&'static str> = Vec::new();
     if source.path.is_some() {
         which.push("path");
@@ -247,10 +318,10 @@ fn pick_matcher(source: &SourceConfig) -> Result<Matcher, DiscoveryError> {
     match which.as_slice() {
         [] => Err(DiscoveryError::NoMatcher),
         [one] => Ok(match *one {
-            "path" => Matcher::Path(source.path.clone().unwrap()),
-            "glob" => Matcher::Glob(source.glob.clone().unwrap()),
-            "regex" => Matcher::Regex(source.regex.clone().unwrap()),
-            "paths" => Matcher::Paths(source.paths.clone().unwrap()),
+            "path" => Matcher::Path(source.path.as_deref().unwrap()),
+            "glob" => Matcher::Glob(source.glob.as_deref().unwrap()),
+            "regex" => Matcher::Regex(source.regex.as_deref().unwrap()),
+            "paths" => Matcher::Paths(source.paths.as_deref().unwrap()),
             _ => unreachable!(),
         }),
         _ => Err(DiscoveryError::MultipleMatchers {
@@ -259,7 +330,7 @@ fn pick_matcher(source: &SourceConfig) -> Result<Matcher, DiscoveryError> {
     }
 }
 
-fn matcher_display(m: &Matcher) -> String {
+fn matcher_display(m: &Matcher<'_>) -> String {
     match m {
         Matcher::Path(p) => format!("path: {p}"),
         Matcher::Glob(g) => format!("glob: {g}"),
@@ -271,7 +342,7 @@ fn matcher_display(m: &Matcher) -> String {
 /// Decide whether to walk subdirectories. Explicit `files.recursive`
 /// wins. Otherwise: glob with `**` walks recursively, everything else
 /// stays at the configured directory level.
-fn effective_recursive(source: &SourceConfig, matcher: &Matcher) -> bool {
+fn effective_recursive(source: &SourceConfig, matcher: &Matcher<'_>) -> bool {
     if let Some(ctrl) = source.files.as_ref()
         && let Some(r) = ctrl.recursive
     {
@@ -280,22 +351,29 @@ fn effective_recursive(source: &SourceConfig, matcher: &Matcher) -> bool {
     matches!(matcher, Matcher::Glob(g) if g.contains("**")) || matches!(matcher, Matcher::Regex(_))
 }
 
-/// Resolve the matcher to an absolute candidate path list. Symlinks are
-/// not followed (mirrors composition-walk security policy).
-fn enumerate(
-    matcher: &Matcher,
+/// Visit absolute candidate paths without retaining the complete match set.
+/// Symlinks are not followed (mirrors composition-walk security policy).
+fn visit_candidates<F>(
+    matcher: &Matcher<'_>,
     base_dir: &Path,
     recursive: bool,
-) -> Result<Vec<PathBuf>, DiscoveryError> {
+    mut visit: F,
+) -> Result<(), DiscoveryError>
+where
+    F: FnMut(PathBuf) -> Result<(), DiscoveryError>,
+{
     match matcher {
         Matcher::Path(p) => {
-            let resolved = resolve(p, base_dir);
-            Ok(vec![resolved])
+            visit(resolve(p, base_dir))?;
         }
-        Matcher::Paths(ps) => Ok(ps.iter().map(|p| resolve(p, base_dir)).collect()),
+        Matcher::Paths(paths) => {
+            for path in *paths {
+                visit(resolve(path, base_dir))?;
+            }
+        }
         Matcher::Glob(pattern) => {
             let abs_pattern = if Path::new(pattern).is_absolute() {
-                pattern.clone()
+                (*pattern).to_owned()
             } else {
                 base_dir.join(pattern).to_string_lossy().into_owned()
             };
@@ -306,13 +384,12 @@ fn enumerate(
             };
             let entries =
                 glob::glob_with(&abs_pattern, opts).map_err(|e| DiscoveryError::InvalidGlob {
-                    pattern: pattern.clone(),
+                    pattern: (*pattern).to_owned(),
                     message: e.to_string(),
                 })?;
-            let mut out = Vec::new();
             for entry in entries {
                 match entry {
-                    Ok(p) => out.push(p),
+                    Ok(path) => visit(path)?,
                     Err(glob_err) => {
                         return Err(DiscoveryError::Io(std::io::Error::other(
                             glob_err.to_string(),
@@ -320,14 +397,12 @@ fn enumerate(
                     }
                 }
             }
-            Ok(out)
         }
         Matcher::Regex(pattern) => {
             let re = regex::Regex::new(pattern).map_err(|e| DiscoveryError::InvalidRegex {
-                pattern: pattern.clone(),
+                pattern: (*pattern).to_owned(),
                 message: e.to_string(),
             })?;
-            let mut out = Vec::new();
             let walker = walkdir::WalkDir::new(base_dir)
                 .follow_links(false)
                 .max_depth(if recursive { usize::MAX } else { 1 })
@@ -344,12 +419,58 @@ fn enumerate(
                 let path = entry.path();
                 let candidate = path.to_string_lossy().replace('\\', "/");
                 if re.is_match(&candidate) {
-                    out.push(path.to_path_buf());
+                    visit(path.to_path_buf())?;
                 }
             }
-            Ok(out)
         }
     }
+    Ok(())
+}
+
+/// Stream candidate paths through exclusions, metadata, and file filters.
+fn visit_discovered_files<F>(
+    source: &SourceConfig,
+    matcher: &Matcher<'_>,
+    base_dir: &Path,
+    recursive: bool,
+    mut visit: F,
+) -> Result<(), DiscoveryError>
+where
+    F: FnMut(DiscoveredFile),
+{
+    let excludes = source
+        .exclude
+        .as_deref()
+        .map(compile_globs)
+        .transpose()?
+        .unwrap_or_default();
+    let now = SystemTime::now();
+    visit_candidates(matcher, base_dir, recursive, |path| {
+        if !excludes.is_empty() && matches_any(&path, &excludes) {
+            return Ok(());
+        }
+        let metadata = std::fs::metadata(&path).map_err(DiscoveryError::Io)?;
+        if !metadata.is_file() {
+            return Ok(());
+        }
+        let size = metadata.len();
+        if source.min_size.is_some_and(|min| size < min.0)
+            || source.max_size.is_some_and(|max| size > max.0)
+        {
+            return Ok(());
+        }
+        let modified = metadata.modified().unwrap_or(now);
+        if !time_bound_pass(modified, source.modified_after, source.modified_before) {
+            return Ok(());
+        }
+        visit(DiscoveredFile {
+            path,
+            modified,
+            created: metadata.created().unwrap_or(modified),
+            size,
+        });
+        Ok(())
+    })
 }
 
 fn resolve(p: &str, base_dir: &Path) -> PathBuf {
@@ -419,13 +540,83 @@ fn sort_spec(source: &SourceConfig) -> (FileSortKey, SortDir) {
 
 fn sort_files(files: &mut [DiscoveredFile], key: FileSortKey, dir: SortDir) {
     match key {
-        FileSortKey::Name => files.sort_by(|a, b| a.path.cmp(&b.path)),
-        FileSortKey::Created => files.sort_by(|a, b| a.created.cmp(&b.created)),
-        FileSortKey::Modified => files.sort_by(|a, b| a.modified.cmp(&b.modified)),
+        FileSortKey::Name => files.sort_by(|left, right| left.path.cmp(&right.path)),
+        FileSortKey::Created => files.sort_by(|left, right| left.created.cmp(&right.created)),
+        FileSortKey::Modified => files.sort_by(|left, right| left.modified.cmp(&right.modified)),
     }
     if matches!(dir, SortDir::Desc) {
         files.reverse();
     }
+}
+
+struct OrderedDiscoveredFile {
+    file: DiscoveredFile,
+    ordinal: usize,
+}
+
+/// Compare sampled files exactly as the stable full sort plus optional reverse
+/// orders them, using streaming enumeration order as the stability key.
+fn compare_sample_files(
+    left: &OrderedDiscoveredFile,
+    right: &OrderedDiscoveredFile,
+    key: FileSortKey,
+    dir: SortDir,
+) -> Ordering {
+    let order = match key {
+        FileSortKey::Name => left
+            .file
+            .path
+            .cmp(&right.file.path)
+            .then_with(|| left.ordinal.cmp(&right.ordinal)),
+        FileSortKey::Created => left
+            .file
+            .created
+            .cmp(&right.file.created)
+            .then_with(|| left.ordinal.cmp(&right.ordinal)),
+        FileSortKey::Modified => left
+            .file
+            .modified
+            .cmp(&right.file.modified)
+            .then_with(|| left.ordinal.cmp(&right.ordinal)),
+    };
+    match dir {
+        SortDir::Asc => order,
+        SortDir::Desc => order.reverse(),
+    }
+}
+
+fn retain_ordered_sample(
+    files: &mut Vec<OrderedDiscoveredFile>,
+    file: OrderedDiscoveredFile,
+    limit: usize,
+    key: FileSortKey,
+    dir: SortDir,
+    retain_tail: bool,
+) {
+    if limit == 0 {
+        return;
+    }
+    if files.len() == limit {
+        let boundary = if retain_tail {
+            &files[0]
+        } else {
+            files.last().expect("a full sample is non-empty")
+        };
+        let order = compare_sample_files(&file, boundary, key, dir);
+        if (retain_tail && order != Ordering::Greater) || (!retain_tail && order != Ordering::Less)
+        {
+            return;
+        }
+        if retain_tail {
+            files.remove(0);
+        } else {
+            files.pop();
+        }
+    }
+    let index = files.partition_point(|existing| {
+        compare_sample_files(existing, &file, key, dir) != Ordering::Greater
+    });
+    files.insert(index, file);
 }
 
 #[cfg(test)]
@@ -497,6 +688,64 @@ mod tests {
         s.glob = Some("orders_*.csv".into());
         let out = discover(&s, tmp.path()).unwrap();
         assert_eq!(out.files().len(), 2);
+    }
+
+    #[test]
+    fn bounded_discovery_retains_only_the_limit_and_reports_the_full_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        for index in (0..12).rev() {
+            write(tmp.path(), &format!("orders_{index:02}.csv"), "");
+        }
+        let mut source = cfg();
+        source.glob = Some("orders_*.csv".into());
+
+        let outcome = discover_bounded(&source, tmp.path(), 4).unwrap();
+        assert_eq!(outcome.discovered_file_count(), 12);
+        assert_eq!(outcome.files().len(), 4);
+        assert_eq!(
+            outcome
+                .files()
+                .iter()
+                .map(|file| file.path.file_name().unwrap().to_string_lossy())
+                .collect::<Vec<_>>(),
+            [
+                "orders_00.csv",
+                "orders_01.csv",
+                "orders_02.csv",
+                "orders_03.csv",
+            ]
+        );
+    }
+
+    #[test]
+    fn bounded_discovery_take_last_retains_a_fixed_selected_tail() {
+        let tmp = tempfile::tempdir().unwrap();
+        for index in 0..12 {
+            write(tmp.path(), &format!("orders_{index:02}.csv"), "");
+        }
+        let mut source = cfg();
+        source.glob = Some("orders_*.csv".into());
+        source.files = Some(FileListingControls {
+            take_last: Some(7),
+            ..Default::default()
+        });
+
+        let outcome = discover_bounded(&source, tmp.path(), 4).unwrap();
+        assert_eq!(outcome.discovered_file_count(), 7);
+        assert_eq!(outcome.files().len(), 4);
+        assert_eq!(
+            outcome
+                .files()
+                .iter()
+                .map(|file| file.path.file_name().unwrap().to_string_lossy())
+                .collect::<Vec<_>>(),
+            [
+                "orders_08.csv",
+                "orders_09.csv",
+                "orders_10.csv",
+                "orders_11.csv",
+            ]
+        );
     }
 
     #[test]

--- a/crates/clinker-plan/src/yaml.rs
+++ b/crates/clinker-plan/src/yaml.rs
@@ -35,6 +35,9 @@ pub use serde_saphyr::{Location, Span, Spanned};
 /// pathological inputs never reach the deserializer at all.
 pub const MAX_INPUT_BYTES: usize = 32 * 1024 * 1024;
 
+/// Maximum number of YAML nodes admitted by one canonical parse.
+pub const MAX_NODES: usize = 100_000;
+
 /// Wrapper around [`serde_saphyr::Error`] so callers do not have to
 /// import the underlying crate. Implements `Display` / `Error` and
 /// `From<serde_saphyr::Error>`.
@@ -74,7 +77,7 @@ fn budget_options() -> serde_saphyr::Options {
             max_inclusion_depth: 0,
             // 100 000 nodes — covers the largest plausible fixture with a
             // ~10x margin.
-            max_nodes: 100_000,
+            max_nodes: MAX_NODES,
             // Reject exponential alias expansion (the canonical
             // billion-laughs defense).
             enforce_alias_anchor_ratio: true,

--- a/crates/clinker/src/guess.rs
+++ b/crates/clinker/src/guess.rs
@@ -1,0 +1,780 @@
+//! Read-only schema concretization preview for inference-only `numeric` leaves.
+
+use std::collections::{BTreeSet, HashMap};
+use std::fmt;
+use std::io::Write;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use clinker_format::numeric_observation::{
+    NumericAcceptance, NumericBoundary, NumericIssue, NumericObservation, NumericParserOutcome,
+    NumericVote,
+};
+use clinker_format::{ByteTally, NumericObserver, ReopenableSource};
+use clinker_plan::config::composition::ScopedSchemaAddress;
+use clinker_plan::config::{PipelineNode, SourceTransport};
+use clinker_plan::error::PipelineError;
+use cxl::typecheck::Type;
+use indexmap::IndexSet;
+use serde::Serialize;
+
+use crate::GuessArgs;
+
+const MAX_FILES_PER_SOURCE: usize = 4;
+const MAX_RECORDS_PER_FILE: u64 = 1_024;
+const MAX_INPUT_BYTES_PER_FILE: u64 = 8 * 1_024 * 1_024;
+const MAX_EVIDENCE_PER_FIELD: usize = 8;
+
+/// A classified `guess` failure. Selection/configuration errors are command
+/// misuse (exit 1); source I/O and reader failures are infrastructure (exit 4).
+#[derive(Debug)]
+pub(crate) struct GuessError {
+    kind: GuessErrorKind,
+    message: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum GuessErrorKind {
+    Configuration,
+    Infrastructure,
+}
+
+impl GuessError {
+    fn configuration(message: impl Into<String>) -> Self {
+        Self {
+            kind: GuessErrorKind::Configuration,
+            message: message.into(),
+        }
+    }
+
+    fn infrastructure(message: impl Into<String>) -> Self {
+        Self {
+            kind: GuessErrorKind::Infrastructure,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn exit_code(&self) -> u8 {
+        match self.kind {
+            GuessErrorKind::Configuration => 1,
+            GuessErrorKind::Infrastructure => 4,
+        }
+    }
+}
+
+impl fmt::Display for GuessError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for GuessError {}
+
+#[derive(Debug, Clone)]
+struct Candidate {
+    source: String,
+    column: String,
+    physical_column: String,
+    address: String,
+    declared_type: Type,
+}
+
+impl Candidate {
+    fn selector(&self) -> String {
+        format!("{}.{}", self.source, self.column)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct FieldAccumulator {
+    observed: u64,
+    int_votes: u64,
+    float_votes: u64,
+    no_value_votes: u64,
+    unresolved_votes: u64,
+    all_ints_float_safe: bool,
+    unresolved: BTreeSet<&'static str>,
+    evidence: Vec<EvidenceReport>,
+}
+
+impl FieldAccumulator {
+    fn new() -> Self {
+        Self {
+            all_ints_float_safe: true,
+            ..Self::default()
+        }
+    }
+
+    fn observe(&mut self, observation: &NumericObservation) {
+        self.observed = self.observed.saturating_add(1);
+        match observation.vote() {
+            NumericVote::NoValue => self.no_value_votes = self.no_value_votes.saturating_add(1),
+            NumericVote::Int => {
+                self.int_votes = self.int_votes.saturating_add(1);
+                if !matches!(
+                    observation.float_acceptance(),
+                    NumericAcceptance::Accepted(_)
+                ) {
+                    self.all_ints_float_safe = false;
+                }
+            }
+            NumericVote::Float => {
+                self.float_votes = self.float_votes.saturating_add(1);
+            }
+            NumericVote::Unresolved(issue) => {
+                self.unresolved_votes = self.unresolved_votes.saturating_add(1);
+                self.unresolved.insert(issue_label(issue));
+            }
+        }
+        if self.evidence.len() < MAX_EVIDENCE_PER_FIELD {
+            self.evidence.push(EvidenceReport::from(observation));
+        }
+    }
+
+    fn resolution(&self) -> (Option<&'static str>, Vec<&'static str>) {
+        let mut reasons = self.unresolved.iter().copied().collect::<Vec<_>>();
+        if !reasons.is_empty() {
+            return (None, reasons);
+        }
+        if self.float_votes > 0 && self.int_votes > 0 && !self.all_ints_float_safe {
+            reasons.push("unsafe_integer_widening");
+            return (None, reasons);
+        }
+        if self.float_votes > 0 {
+            return (Some("float"), reasons);
+        }
+        if self.int_votes > 0 {
+            return (Some("int"), reasons);
+        }
+        reasons.push("no_value_evidence");
+        (None, reasons)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct GuessReport {
+    schema: &'static str,
+    version: u8,
+    target: String,
+    selection: SelectionReport,
+    limits: LimitsReport,
+    coverage: Vec<SourceCoverage>,
+    fields: Vec<FieldReport>,
+    patch: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SelectionReport {
+    kind: &'static str,
+    name: Option<String>,
+    applied_groups: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct LimitsReport {
+    max_files_per_source: usize,
+    max_records_per_file: u64,
+    max_input_bytes_per_file: u64,
+    max_evidence_per_field: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct SourceCoverage {
+    source: String,
+    format: &'static str,
+    discovered_files: usize,
+    files: Vec<FileCoverage>,
+}
+
+#[derive(Debug, Serialize)]
+struct FileCoverage {
+    path: String,
+    status: &'static str,
+    input_bytes: Option<u64>,
+    bytes_read: u64,
+    records_sampled: u64,
+    truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct EvidenceReport {
+    boundary: &'static str,
+    lexeme: String,
+    original_bytes: usize,
+    truncated: bool,
+    parser_outcome: &'static str,
+    vote: &'static str,
+    reason: Option<&'static str>,
+}
+
+impl From<&NumericObservation> for EvidenceReport {
+    fn from(observation: &NumericObservation) -> Self {
+        let lexeme = observation.lexeme();
+        let rendered = match lexeme.complete() {
+            Some(complete) => complete.to_owned(),
+            None => format!("{}…{}", lexeme.head(), lexeme.tail()),
+        };
+        let (vote, reason) = match observation.vote() {
+            NumericVote::NoValue => ("no_value", None),
+            NumericVote::Int => ("int", None),
+            NumericVote::Float => ("float", None),
+            NumericVote::Unresolved(issue) => ("unresolved", Some(issue_label(issue))),
+        };
+        Self {
+            boundary: boundary_label(observation.boundary()),
+            lexeme: rendered,
+            original_bytes: lexeme.original_bytes(),
+            truncated: lexeme.is_truncated(),
+            parser_outcome: parser_outcome_label(observation.parser_outcome()),
+            vote,
+            reason,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct FieldReport {
+    field: String,
+    address: String,
+    observations: u64,
+    votes: VoteReport,
+    evidence: Vec<EvidenceReport>,
+    proposed_type: Option<&'static str>,
+    unresolved_reasons: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct VoteReport {
+    int: u64,
+    float: u64,
+    no_value: u64,
+    unresolved: u64,
+}
+
+#[derive(Debug)]
+struct EffectiveConfig {
+    config: clinker_plan::config::PipelineConfig,
+    selection: SelectionReport,
+}
+
+/// Execute the read-only preview and print one stable JSON document.
+pub(crate) fn run(args: &GuessArgs) -> Result<u8, GuessError> {
+    let effective = resolve_effective_config(args)?;
+    let candidates = select_candidates(&effective.config, &args.fields)?;
+    let accumulators = Arc::new(Mutex::new(
+        (0..candidates.len())
+            .map(|_| FieldAccumulator::new())
+            .collect::<Vec<_>>(),
+    ));
+    let config_dir = args
+        .config
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+        .canonicalize()
+        .map_err(|error| {
+            GuessError::infrastructure(format!(
+                "cannot resolve pipeline directory for {}: {error}",
+                args.config.display()
+            ))
+        })?;
+
+    let coverage = sample_sources(
+        &effective.config,
+        &candidates,
+        Arc::clone(&accumulators),
+        &config_dir,
+    )?;
+    let accumulators = accumulators
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut edits = Vec::new();
+    let fields = candidates
+        .iter()
+        .zip(accumulators.iter())
+        .map(|(candidate, accumulated)| {
+            let (proposed_type, unresolved_reasons) = accumulated.resolution();
+            if let Some(concrete) = proposed_type {
+                edits.push(PatchEdit {
+                    address: candidate.address.clone(),
+                    from_type: render_numeric_type(&candidate.declared_type, "numeric"),
+                    to_type: render_numeric_type(&candidate.declared_type, concrete),
+                });
+            }
+            FieldReport {
+                field: candidate.selector(),
+                address: candidate.address.clone(),
+                observations: accumulated.observed,
+                votes: VoteReport {
+                    int: accumulated.int_votes,
+                    float: accumulated.float_votes,
+                    no_value: accumulated.no_value_votes,
+                    unresolved: accumulated.unresolved_votes,
+                },
+                evidence: accumulated.evidence.clone(),
+                proposed_type,
+                unresolved_reasons,
+            }
+        })
+        .collect();
+    let patch = render_patch(&edits);
+    let report = GuessReport {
+        schema: "clinker.guess.preview",
+        version: 1,
+        target: effective.config.pipeline.name.clone(),
+        selection: effective.selection,
+        limits: LimitsReport {
+            max_files_per_source: MAX_FILES_PER_SOURCE,
+            max_records_per_file: MAX_RECORDS_PER_FILE,
+            max_input_bytes_per_file: MAX_INPUT_BYTES_PER_FILE,
+            max_evidence_per_field: MAX_EVIDENCE_PER_FIELD,
+        },
+        coverage,
+        fields,
+        patch,
+    };
+    let output = serde_json::to_string_pretty(&report)
+        .map_err(|error| GuessError::infrastructure(format!("cannot render preview: {error}")))?;
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(output.as_bytes()).map_err(|error| {
+        GuessError::infrastructure(format!("cannot write preview to stdout: {error}"))
+    })?;
+    stdout.write_all(b"\n").map_err(|error| {
+        GuessError::infrastructure(format!("cannot finish preview on stdout: {error}"))
+    })?;
+    Ok(0)
+}
+
+fn resolve_effective_config(args: &GuessArgs) -> Result<EffectiveConfig, GuessError> {
+    if args.channel.is_some() && args.group.is_some() {
+        return Err(GuessError::configuration(
+            "choose exactly one effective configuration: remove either `--channel ID` or `--group NAME`",
+        ));
+    }
+    let (workspace_root, _) = crate::resolve_compile_anchor(&args.config, args.base_dir.as_deref());
+    let clinker_toml = clinker_plan::config::ClinkerToml::load_from_workspace(&workspace_root)
+        .map_err(|error| GuessError::configuration(format!("clinker.toml: {error}")))?;
+
+    let overlay = if args.channel.is_none() && args.group.is_none() {
+        None
+    } else {
+        if let Some(group_name) = args.group.as_deref() {
+            let groups = clinker_channel::scan_groups(&clinker_toml.group, &workspace_root)
+                .map_err(crate::diag_message("group scan failed"))
+                .map_err(GuessError::configuration)?;
+            let matches = groups
+                .iter()
+                .filter(|group| group.name == group_name)
+                .count();
+            if matches != 1 {
+                return Err(GuessError::configuration(if matches == 0 {
+                    format!(
+                        "no group named {group_name:?}; correction: pass one name reported by `clinker channels group members NAME`"
+                    )
+                } else {
+                    format!(
+                        "group selector {group_name:?} is ambiguous across {matches} files; correction: keep one group declaration with that name"
+                    )
+                }));
+            }
+        }
+        let catalog =
+            clinker_plan::resources::WorkspaceCatalog::load(&workspace_root, &clinker_toml.catalog)
+                .map_err(|error| GuessError::configuration(error.to_string()))?;
+        let pipeline_id =
+            crate::catalog_pipeline_id(&workspace_root, &clinker_toml.catalog, &args.config)
+                .map_err(GuessError::configuration)?;
+        let explicit_groups = args.group.iter().cloned().collect::<Vec<_>>();
+        Some(
+            clinker_channel::resolve_target_channel(
+                &workspace_root,
+                &catalog,
+                &clinker_toml.group,
+                &pipeline_id,
+                args.channel.as_deref(),
+                &explicit_groups,
+                args.channel.is_some(),
+            )
+            .map_err(|error| {
+                GuessError::configuration(format!(
+                    "effective configuration selection failed: {error}; correction: choose one cataloged channel or one target-admitted group"
+                ))
+            })?,
+        )
+    };
+
+    let empty_patches = indexmap::IndexMap::new();
+    let source_patches = overlay
+        .as_ref()
+        .and_then(clinker_channel::OverlayResolution::source_patches)
+        .unwrap_or(&empty_patches);
+    let mut config =
+        clinker_plan::config::load_config_with_vars_and_patches(&args.config, &[], source_patches)
+            .map_err(|error| GuessError::configuration(error.to_string()))?;
+    if let Some(resolution) = &overlay
+        && !resolution.op_stream().is_empty()
+    {
+        config.nodes = clinker_plan::apply_overlay_ops(
+            std::mem::take(&mut config.nodes),
+            resolution.op_stream().to_vec(),
+        )
+        .map_err(|error| {
+            GuessError::configuration(format!("cannot apply selected structural overlay: {error}"))
+        })?;
+    }
+
+    let selection = match (args.channel.as_ref(), args.group.as_ref()) {
+        (Some(channel), None) => SelectionReport {
+            kind: "channel",
+            name: Some(channel.clone()),
+            applied_groups: overlay
+                .as_ref()
+                .map(|resolution| {
+                    resolution
+                        .applied_groups()
+                        .iter()
+                        .map(|group| group.name.clone())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        },
+        (None, Some(group)) => SelectionReport {
+            kind: "group",
+            name: Some(group.clone()),
+            applied_groups: vec![group.clone()],
+        },
+        (None, None) => SelectionReport {
+            kind: "base",
+            name: None,
+            applied_groups: Vec::new(),
+        },
+        (Some(_), Some(_)) => unreachable!("selector conflict returned above"),
+    };
+    Ok(EffectiveConfig { config, selection })
+}
+
+fn select_candidates(
+    config: &clinker_plan::config::PipelineConfig,
+    requested: &[String],
+) -> Result<Vec<Candidate>, GuessError> {
+    let mut candidates = Vec::new();
+    let mut all_fields = HashMap::new();
+    for node in &config.nodes {
+        let PipelineNode::Source {
+            header,
+            config: body,
+        } = &node.value
+        else {
+            continue;
+        };
+        let Some(columns) = body.schema.as_columns() else {
+            continue;
+        };
+        for column in columns {
+            let selector = format!("{}.{}", header.name, column.name);
+            all_fields.insert(selector.clone(), column.ty.clone());
+            if contains_numeric_leaf(&column.ty) {
+                candidates.push(Candidate {
+                    source: header.name.clone(),
+                    column: column.name.clone(),
+                    physical_column: column.physical_name().to_owned(),
+                    address: ScopedSchemaAddress::new(&header.name, &column.name, "type").render(),
+                    declared_type: column.ty.clone(),
+                });
+            }
+        }
+    }
+    if candidates.is_empty() {
+        return Err(GuessError::configuration(
+            "the selected effective configuration has no literal `numeric` source-schema leaves; correction: declare `type: numeric` on an inference-only source column",
+        ));
+    }
+    if requested.is_empty() {
+        return Ok(candidates);
+    }
+
+    let mut requested_once = IndexSet::new();
+    for field in requested {
+        if field.split('.').count() != 2 || field.starts_with('.') || field.ends_with('.') {
+            return Err(GuessError::configuration(format!(
+                "invalid --field {field:?}; correction: use `--field node.column`"
+            )));
+        }
+        requested_once.insert(field.clone());
+    }
+    let by_selector = candidates
+        .into_iter()
+        .map(|candidate| (candidate.selector(), candidate))
+        .collect::<HashMap<_, _>>();
+    requested_once
+        .into_iter()
+        .map(|field| {
+            if let Some(candidate) = by_selector.get(&field) {
+                return Ok(candidate.clone());
+            }
+            if let Some(concrete) = all_fields.get(&field) {
+                Err(GuessError::configuration(format!(
+                    "--field {field:?} is {concrete}, not `numeric`; correction: remove that selector or point it at a literal `numeric` source column"
+                )))
+            } else {
+                Err(GuessError::configuration(format!(
+                    "unknown --field {field:?}; correction: use one of {}",
+                    {
+                        let mut selectors = by_selector.keys().cloned().collect::<Vec<_>>();
+                        selectors.sort();
+                        selectors.join(", ")
+                    }
+                )))
+            }
+        })
+        .collect()
+}
+
+fn sample_sources(
+    config: &clinker_plan::config::PipelineConfig,
+    candidates: &[Candidate],
+    accumulators: Arc<Mutex<Vec<FieldAccumulator>>>,
+    config_dir: &Path,
+) -> Result<Vec<SourceCoverage>, GuessError> {
+    let selected_sources = candidates
+        .iter()
+        .map(|candidate| candidate.source.as_str())
+        .collect::<IndexSet<_>>();
+    let mut coverage = Vec::new();
+    for source_name in selected_sources {
+        let body = config
+            .nodes
+            .iter()
+            .find_map(|node| match &node.value {
+                PipelineNode::Source { header, config } if header.name == source_name => {
+                    Some(config)
+                }
+                _ => None,
+            })
+            .ok_or_else(|| {
+                GuessError::configuration(format!(
+                    "selected source {source_name:?} disappeared from the effective configuration"
+                ))
+            })?;
+        if !matches!(&body.source.transport, SourceTransport::File) {
+            coverage.push(SourceCoverage {
+                source: source_name.to_owned(),
+                format: body.source.format.format_name(),
+                discovered_files: 0,
+                files: Vec::new(),
+            });
+            continue;
+        }
+        let discovered = clinker_plan::config::discovery::discover(&body.source, config_dir)
+            .map_err(|error| match error {
+                clinker_plan::config::discovery::DiscoveryError::Io(_) => {
+                    GuessError::infrastructure(format!(
+                        "source {source_name:?} discovery failed: {error}"
+                    ))
+                }
+                _ => GuessError::configuration(format!(
+                    "source {source_name:?} discovery failed: {error}"
+                )),
+            })?;
+        let paths = discovered
+            .files()
+            .iter()
+            .map(|file| file.path.clone())
+            .collect::<Vec<_>>();
+        let mut files = Vec::with_capacity(paths.len());
+        for (file_index, path) in paths.iter().enumerate() {
+            let display_path = stable_input_path(path, config_dir);
+            let metadata = std::fs::metadata(path).map_err(|error| {
+                GuessError::infrastructure(format!(
+                    "cannot inspect source file {}: {error}",
+                    display_path
+                ))
+            })?;
+            if file_index >= MAX_FILES_PER_SOURCE {
+                files.push(FileCoverage {
+                    path: display_path,
+                    status: "uncovered_file_limit",
+                    input_bytes: Some(metadata.len()),
+                    bytes_read: 0,
+                    records_sampled: 0,
+                    truncated: true,
+                });
+                continue;
+            }
+            if metadata.len() > MAX_INPUT_BYTES_PER_FILE {
+                files.push(FileCoverage {
+                    path: display_path,
+                    status: "uncovered_file_byte_limit",
+                    input_bytes: Some(metadata.len()),
+                    bytes_read: 0,
+                    records_sampled: 0,
+                    truncated: true,
+                });
+                continue;
+            }
+
+            let field_map = observer_field_map(candidates, source_name);
+            let target = Arc::clone(&accumulators);
+            let observer = NumericObserver::new(move |field, observation| {
+                let Some(indices) = field_map.get(field) else {
+                    return;
+                };
+                let mut accumulated = target
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                for index in indices {
+                    accumulated[*index].observe(&observation);
+                }
+            });
+            let tally = ByteTally::new();
+            let source = ReopenableSource::path(path).with_tally(tally.clone());
+            let mut reader = clinker_exec::executor::build_source_format_reader(
+                &body.source,
+                &body.schema,
+                body.on_unmapped.clone(),
+                source,
+                Some(observer),
+            )
+            .map_err(reader_error)?;
+            let mut records = 0u64;
+            while records < MAX_RECORDS_PER_FILE {
+                match reader.next_record().map_err(|error| {
+                    GuessError::infrastructure(format!(
+                        "cannot sample source {source_name:?} file {display_path}: {error}"
+                    ))
+                })? {
+                    Some(_) => records = records.saturating_add(1),
+                    None => break,
+                }
+            }
+            let truncated = records == MAX_RECORDS_PER_FILE;
+            files.push(FileCoverage {
+                path: display_path,
+                status: if truncated {
+                    "truncated_record_limit"
+                } else {
+                    "sampled"
+                },
+                input_bytes: Some(metadata.len()),
+                bytes_read: tally.read(),
+                records_sampled: records,
+                truncated,
+            });
+        }
+        coverage.push(SourceCoverage {
+            source: source_name.to_owned(),
+            format: body.source.format.format_name(),
+            discovered_files: paths.len(),
+            files,
+        });
+    }
+    Ok(coverage)
+}
+
+fn observer_field_map(candidates: &[Candidate], source: &str) -> HashMap<String, Vec<usize>> {
+    let mut fields: HashMap<String, Vec<usize>> = HashMap::new();
+    for (index, candidate) in candidates.iter().enumerate() {
+        if candidate.source != source {
+            continue;
+        }
+        for name in [&candidate.column, &candidate.physical_column] {
+            let indices = fields.entry(name.clone()).or_default();
+            if !indices.contains(&index) {
+                indices.push(index);
+            }
+        }
+    }
+    fields
+}
+
+fn reader_error(error: PipelineError) -> GuessError {
+    match error {
+        PipelineError::Config(_) | PipelineError::Compilation { .. } => {
+            GuessError::configuration(error.to_string())
+        }
+        _ => GuessError::infrastructure(error.to_string()),
+    }
+}
+
+fn stable_input_path(path: &Path, config_dir: &Path) -> String {
+    path.strip_prefix(config_dir)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+struct PatchEdit {
+    address: String,
+    from_type: String,
+    to_type: String,
+}
+
+fn render_patch(edits: &[PatchEdit]) -> String {
+    let mut patch = String::from("edits:\n");
+    for edit in edits {
+        patch.push_str(&format!(
+            "  - address: {}\n    from: {}\n    to: {}\n",
+            edit.address, edit.from_type, edit.to_type
+        ));
+    }
+    patch
+}
+
+fn render_numeric_type(declared: &Type, numeric_leaf: &str) -> String {
+    match declared {
+        Type::Numeric => numeric_leaf.to_owned(),
+        Type::Nullable(inner) => {
+            format!("nullable({})", render_numeric_type(inner, numeric_leaf))
+        }
+        _ => unreachable!("guess candidates contain a literal numeric leaf"),
+    }
+}
+
+fn contains_numeric_leaf(ty: &Type) -> bool {
+    match ty {
+        Type::Numeric => true,
+        Type::Nullable(inner) => contains_numeric_leaf(inner),
+        Type::Null
+        | Type::Bool
+        | Type::Int
+        | Type::Float
+        | Type::Decimal
+        | Type::String
+        | Type::Date
+        | Type::DateTime
+        | Type::Array
+        | Type::Map
+        | Type::Any => false,
+    }
+}
+
+fn boundary_label(boundary: NumericBoundary) -> &'static str {
+    match boundary {
+        NumericBoundary::Json => "json",
+        NumericBoundary::Xml => "xml",
+        NumericBoundary::Positional => "positional",
+        NumericBoundary::SchemaCoerce => "schema_coerce",
+    }
+}
+
+fn issue_label(issue: NumericIssue) -> &'static str {
+    match issue {
+        NumericIssue::InvalidNumeric => "invalid_numeric",
+        NumericIssue::IntegerOverflow => "integer_overflow",
+        NumericIssue::NonFinite => "non_finite",
+        NumericIssue::UnsafeIntegerWidening => "unsafe_integer_widening",
+        NumericIssue::UnderflowToZero => "underflow_to_zero",
+        NumericIssue::PrecisionLoss => "precision_loss",
+        NumericIssue::RepresentationChanged => "representation_changed",
+    }
+}
+
+fn parser_outcome_label(outcome: &NumericParserOutcome) -> &'static str {
+    match outcome {
+        NumericParserOutcome::NoValue => "no_value",
+        NumericParserOutcome::Integer(_) => "integer",
+        NumericParserOutcome::Float(_) => "float",
+        NumericParserOutcome::NonNumeric => "non_numeric",
+        NumericParserOutcome::Rejected(_) => "rejected",
+    }
+}

--- a/crates/clinker/src/guess.rs
+++ b/crates/clinker/src/guess.rs
@@ -10,12 +10,12 @@ use clinker_format::numeric_observation::{
     NumericAcceptance, NumericBoundary, NumericIssue, NumericObservation, NumericParserOutcome,
     NumericVote,
 };
-use clinker_format::{ByteTally, NumericObserver, ReopenableSource};
-use clinker_plan::config::composition::ScopedSchemaAddress;
+use clinker_format::{ByteTally, Column, NumericObserver, ReopenableSource, SourceSchema};
+use clinker_plan::config::composition::ScopedSchemaLeafAddress;
 use clinker_plan::config::{PipelineNode, SourceTransport};
 use clinker_plan::error::PipelineError;
 use cxl::typecheck::Type;
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use serde::Serialize;
 
 use crate::GuessArgs;
@@ -74,9 +74,16 @@ impl std::error::Error for GuessError {}
 struct Candidate {
     source: String,
     column: String,
-    physical_column: String,
-    address: String,
+    owners: Vec<NumericOwner>,
+}
+
+#[derive(Debug, Clone)]
+struct NumericOwner {
+    address: ScopedSchemaLeafAddress,
     declared_type: Type,
+    record: Option<String>,
+    observed_fields: Vec<String>,
+    accumulator_index: usize,
 }
 
 impl Candidate {
@@ -235,6 +242,11 @@ impl From<&NumericObservation> for EvidenceReport {
 #[derive(Debug, Serialize)]
 struct FieldReport {
     field: String,
+    owners: Vec<OwnerReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct OwnerReport {
     address: String,
     observations: u64,
     votes: VoteReport,
@@ -260,9 +272,10 @@ struct EffectiveConfig {
 /// Execute the read-only preview and print one stable JSON document.
 pub(crate) fn run(args: &GuessArgs) -> Result<u8, GuessError> {
     let effective = resolve_effective_config(args)?;
-    let candidates = select_candidates(&effective.config, &args.fields)?;
+    let mut candidates = select_candidates(&effective.config, &args.fields)?;
+    let accumulator_count = index_numeric_owners(&mut candidates);
     let accumulators = Arc::new(Mutex::new(
-        (0..candidates.len())
+        (0..accumulator_count)
             .map(|_| FieldAccumulator::new())
             .collect::<Vec<_>>(),
     ));
@@ -291,29 +304,38 @@ pub(crate) fn run(args: &GuessArgs) -> Result<u8, GuessError> {
     let mut edits = Vec::new();
     let fields = candidates
         .iter()
-        .zip(accumulators.iter())
-        .map(|(candidate, accumulated)| {
-            let (proposed_type, unresolved_reasons) = accumulated.resolution();
-            if let Some(concrete) = proposed_type {
-                edits.push(PatchEdit {
-                    address: candidate.address.clone(),
-                    from_type: render_numeric_type(&candidate.declared_type, "numeric"),
-                    to_type: render_numeric_type(&candidate.declared_type, concrete),
-                });
-            }
+        .map(|candidate| {
+            let owners = candidate
+                .owners
+                .iter()
+                .map(|owner| {
+                    let accumulated = &accumulators[owner.accumulator_index];
+                    let (proposed_type, unresolved_reasons) = accumulated.resolution();
+                    if let Some(concrete) = proposed_type {
+                        edits.push(PatchEdit {
+                            address: owner.address.render(),
+                            from_type: render_numeric_type(&owner.declared_type, "numeric"),
+                            to_type: render_numeric_type(&owner.declared_type, concrete),
+                        });
+                    }
+                    OwnerReport {
+                        address: owner.address.render(),
+                        observations: accumulated.observed,
+                        votes: VoteReport {
+                            int: accumulated.int_votes,
+                            float: accumulated.float_votes,
+                            no_value: accumulated.no_value_votes,
+                            unresolved: accumulated.unresolved_votes,
+                        },
+                        evidence: accumulated.evidence.clone(),
+                        proposed_type,
+                        unresolved_reasons,
+                    }
+                })
+                .collect();
             FieldReport {
                 field: candidate.selector(),
-                address: candidate.address.clone(),
-                observations: accumulated.observed,
-                votes: VoteReport {
-                    int: accumulated.int_votes,
-                    float: accumulated.float_votes,
-                    no_value: accumulated.no_value_votes,
-                    unresolved: accumulated.unresolved_votes,
-                },
-                evidence: accumulated.evidence.clone(),
-                proposed_type,
-                unresolved_reasons,
+                owners,
             }
         })
         .collect();
@@ -457,8 +479,8 @@ fn select_candidates(
     config: &clinker_plan::config::PipelineConfig,
     requested: &[String],
 ) -> Result<Vec<Candidate>, GuessError> {
-    let mut candidates = Vec::new();
-    let mut all_fields = HashMap::new();
+    let mut candidates = IndexMap::new();
+    let mut all_fields: HashMap<String, Vec<Type>> = HashMap::new();
     for node in &config.nodes {
         let PipelineNode::Source {
             header,
@@ -467,21 +489,34 @@ fn select_candidates(
         else {
             continue;
         };
-        let Some(columns) = body.schema.as_columns() else {
-            continue;
-        };
-        for column in columns {
-            let selector = format!("{}.{}", header.name, column.name);
-            all_fields.insert(selector.clone(), column.ty.clone());
-            if contains_numeric_leaf(&column.ty) {
-                candidates.push(Candidate {
-                    source: header.name.clone(),
-                    column: column.name.clone(),
-                    physical_column: column.physical_name().to_owned(),
-                    address: ScopedSchemaAddress::new(&header.name, &column.name, "type").render(),
-                    declared_type: column.ty.clone(),
-                });
+        match &body.schema {
+            SourceSchema::Columns(columns) => {
+                for column in columns {
+                    register_candidate_column(
+                        &mut candidates,
+                        &mut all_fields,
+                        &header.name,
+                        None,
+                        column,
+                        true,
+                    );
+                }
             }
+            SourceSchema::MultiRecord { record_types, .. } => {
+                for record_type in record_types {
+                    for column in &record_type.columns {
+                        register_candidate_column(
+                            &mut candidates,
+                            &mut all_fields,
+                            &header.name,
+                            Some(&record_type.id),
+                            column,
+                            false,
+                        );
+                    }
+                }
+            }
+            SourceSchema::Generated(_) | SourceSchema::File(_) => {}
         }
     }
     if candidates.is_empty() {
@@ -490,7 +525,7 @@ fn select_candidates(
         ));
     }
     if requested.is_empty() {
-        return Ok(candidates);
+        return Ok(candidates.into_values().collect());
     }
 
     let mut requested_once = IndexSet::new();
@@ -502,10 +537,7 @@ fn select_candidates(
         }
         requested_once.insert(field.clone());
     }
-    let by_selector = candidates
-        .into_iter()
-        .map(|candidate| (candidate.selector(), candidate))
-        .collect::<HashMap<_, _>>();
+    let by_selector = candidates;
     requested_once
         .into_iter()
         .map(|field| {
@@ -513,8 +545,15 @@ fn select_candidates(
                 return Ok(candidate.clone());
             }
             if let Some(concrete) = all_fields.get(&field) {
+                let concrete = concrete
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<BTreeSet<_>>()
+                    .into_iter()
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 Err(GuessError::configuration(format!(
-                    "--field {field:?} is {concrete}, not `numeric`; correction: remove that selector or point it at a literal `numeric` source column"
+                    "--field {field:?} has only concrete declaration(s) ({concrete}), not `numeric`; correction: remove that selector or point it at a literal `numeric` source column"
                 )))
             } else {
                 Err(GuessError::configuration(format!(
@@ -528,6 +567,60 @@ fn select_candidates(
             }
         })
         .collect()
+}
+
+fn register_candidate_column(
+    candidates: &mut IndexMap<String, Candidate>,
+    all_fields: &mut HashMap<String, Vec<Type>>,
+    source: &str,
+    record: Option<&str>,
+    column: &Column,
+    observe_physical_name: bool,
+) {
+    let selector = format!("{source}.{}", column.name);
+    all_fields
+        .entry(selector.clone())
+        .or_default()
+        .push(column.ty.clone());
+    if !contains_numeric_leaf(&column.ty) {
+        return;
+    }
+    let address = match record {
+        Some(record) => {
+            ScopedSchemaLeafAddress::record_column(source, record, &column.name, "type")
+        }
+        None => ScopedSchemaLeafAddress::column(source, &column.name, "type"),
+    };
+    let candidate = candidates.entry(selector).or_insert_with(|| Candidate {
+        source: source.to_owned(),
+        column: column.name.clone(),
+        owners: Vec::new(),
+    });
+    let mut observed_fields = vec![column.name.clone()];
+    if observe_physical_name {
+        let physical = column.physical_name();
+        if !observed_fields.iter().any(|name| name == physical) {
+            observed_fields.push(physical.to_owned());
+        }
+    }
+    candidate.owners.push(NumericOwner {
+        address,
+        declared_type: column.ty.clone(),
+        record: record.map(str::to_owned),
+        observed_fields,
+        accumulator_index: usize::MAX,
+    });
+}
+
+fn index_numeric_owners(candidates: &mut [Candidate]) -> usize {
+    let mut next = 0;
+    for candidate in candidates {
+        for owner in &mut candidate.owners {
+            owner.accumulator_index = next;
+            next += 1;
+        }
+    }
+    next
 }
 
 fn sample_sources(
@@ -615,8 +708,8 @@ fn sample_sources(
 
             let field_map = observer_field_map(candidates, source_name);
             let target = Arc::clone(&accumulators);
-            let observer = NumericObserver::new(move |field, observation| {
-                let Some(indices) = field_map.get(field) else {
+            let observer = NumericObserver::new_scoped(move |scope, observation| {
+                let Some(indices) = field_map.indices(scope.record(), scope.field()) else {
                     return;
                 };
                 let mut accumulated = target
@@ -671,16 +764,41 @@ fn sample_sources(
     Ok(coverage)
 }
 
-fn observer_field_map(candidates: &[Candidate], source: &str) -> HashMap<String, Vec<usize>> {
-    let mut fields: HashMap<String, Vec<usize>> = HashMap::new();
-    for (index, candidate) in candidates.iter().enumerate() {
+#[derive(Debug, Default)]
+struct ObserverFieldMap {
+    columns: HashMap<String, Vec<usize>>,
+    records: HashMap<String, HashMap<String, Vec<usize>>>,
+}
+
+impl ObserverFieldMap {
+    fn indices(&self, record: Option<&str>, field: &str) -> Option<&[usize]> {
+        match record {
+            Some(record) => self
+                .records
+                .get(record)
+                .and_then(|fields| fields.get(field))
+                .map(Vec::as_slice),
+            None => self.columns.get(field).map(Vec::as_slice),
+        }
+    }
+}
+
+fn observer_field_map(candidates: &[Candidate], source: &str) -> ObserverFieldMap {
+    let mut fields = ObserverFieldMap::default();
+    for candidate in candidates {
         if candidate.source != source {
             continue;
         }
-        for name in [&candidate.column, &candidate.physical_column] {
-            let indices = fields.entry(name.clone()).or_default();
-            if !indices.contains(&index) {
-                indices.push(index);
+        for owner in &candidate.owners {
+            let target = match owner.record.as_deref() {
+                Some(record) => fields.records.entry(record.to_owned()).or_default(),
+                None => &mut fields.columns,
+            };
+            for name in &owner.observed_fields {
+                let indices = target.entry(name.clone()).or_default();
+                if !indices.contains(&owner.accumulator_index) {
+                    indices.push(owner.accumulator_index);
+                }
             }
         }
     }

--- a/crates/clinker/src/guess.rs
+++ b/crates/clinker/src/guess.rs
@@ -23,7 +23,8 @@ use crate::GuessArgs;
 const MAX_FILES_PER_SOURCE: usize = 4;
 const MAX_RECORDS_PER_FILE: u64 = 1_024;
 const MAX_INPUT_BYTES_PER_FILE: u64 = 8 * 1_024 * 1_024;
-const MAX_EVIDENCE_PER_FIELD: usize = 8;
+const MAX_EVIDENCE_PER_OWNER: usize = 8;
+const MAX_SCHEMA_LEAVES: usize = clinker_plan::yaml::MAX_NODES;
 
 /// A classified `guess` failure. Selection/configuration errors are command
 /// misuse (exit 1); source I/O and reader failures are infrastructure (exit 4).
@@ -133,7 +134,7 @@ impl FieldAccumulator {
                 self.unresolved.insert(issue_label(issue));
             }
         }
-        if self.evidence.len() < MAX_EVIDENCE_PER_FIELD {
+        if self.evidence.len() < MAX_EVIDENCE_PER_OWNER {
             self.evidence.push(EvidenceReport::from(observation));
         }
     }
@@ -179,10 +180,14 @@ struct SelectionReport {
 
 #[derive(Debug, Serialize)]
 struct LimitsReport {
+    max_yaml_input_bytes: usize,
+    max_yaml_nodes_per_document: usize,
+    max_schema_leaves: usize,
     max_files_per_source: usize,
     max_records_per_file: u64,
     max_input_bytes_per_file: u64,
-    max_evidence_per_field: usize,
+    max_numeric_lexeme_evidence_bytes: usize,
+    max_evidence_per_owner: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -190,6 +195,7 @@ struct SourceCoverage {
     source: String,
     format: &'static str,
     discovered_files: usize,
+    unreported_file_count: usize,
     files: Vec<FileCoverage>,
 }
 
@@ -346,10 +352,15 @@ pub(crate) fn run(args: &GuessArgs) -> Result<u8, GuessError> {
         target: effective.config.pipeline.name.clone(),
         selection: effective.selection,
         limits: LimitsReport {
+            max_yaml_input_bytes: clinker_plan::yaml::MAX_INPUT_BYTES,
+            max_yaml_nodes_per_document: clinker_plan::yaml::MAX_NODES,
+            max_schema_leaves: MAX_SCHEMA_LEAVES,
             max_files_per_source: MAX_FILES_PER_SOURCE,
             max_records_per_file: MAX_RECORDS_PER_FILE,
             max_input_bytes_per_file: MAX_INPUT_BYTES_PER_FILE,
-            max_evidence_per_field: MAX_EVIDENCE_PER_FIELD,
+            max_numeric_lexeme_evidence_bytes:
+                clinker_format::numeric_observation::MAX_NUMERIC_LEXEME_EVIDENCE_BYTES,
+            max_evidence_per_owner: MAX_EVIDENCE_PER_OWNER,
         },
         coverage,
         fields,
@@ -481,6 +492,7 @@ fn select_candidates(
 ) -> Result<Vec<Candidate>, GuessError> {
     let mut candidates = IndexMap::new();
     let mut all_fields: HashMap<String, Vec<Type>> = HashMap::new();
+    let mut schema_leaves = 0usize;
     for node in &config.nodes {
         let PipelineNode::Source {
             header,
@@ -495,11 +507,12 @@ fn select_candidates(
                     register_candidate_column(
                         &mut candidates,
                         &mut all_fields,
+                        &mut schema_leaves,
                         &header.name,
                         None,
                         column,
                         true,
-                    );
+                    )?;
                 }
             }
             SourceSchema::MultiRecord { record_types, .. } => {
@@ -508,11 +521,12 @@ fn select_candidates(
                         register_candidate_column(
                             &mut candidates,
                             &mut all_fields,
+                            &mut schema_leaves,
                             &header.name,
                             Some(&record_type.id),
                             column,
                             false,
-                        );
+                        )?;
                     }
                 }
             }
@@ -572,18 +586,25 @@ fn select_candidates(
 fn register_candidate_column(
     candidates: &mut IndexMap<String, Candidate>,
     all_fields: &mut HashMap<String, Vec<Type>>,
+    schema_leaves: &mut usize,
     source: &str,
     record: Option<&str>,
     column: &Column,
     observe_physical_name: bool,
-) {
+) -> Result<(), GuessError> {
+    if *schema_leaves >= MAX_SCHEMA_LEAVES {
+        return Err(GuessError::configuration(format!(
+            "the selected effective configuration exceeds the guess limit of {MAX_SCHEMA_LEAVES} source-schema leaves (the canonical YAML node cap); correction: narrow the selected configuration"
+        )));
+    }
+    *schema_leaves += 1;
     let selector = format!("{source}.{}", column.name);
     all_fields
         .entry(selector.clone())
         .or_default()
         .push(column.ty.clone());
     if !contains_numeric_leaf(&column.ty) {
-        return;
+        return Ok(());
     }
     let address = match record {
         Some(record) => {
@@ -610,6 +631,7 @@ fn register_candidate_column(
         observed_fields,
         accumulator_index: usize::MAX,
     });
+    Ok(())
 }
 
 fn index_numeric_owners(candidates: &mut [Candidate]) -> usize {
@@ -654,51 +676,35 @@ fn sample_sources(
                 source: source_name.to_owned(),
                 format: body.source.format.format_name(),
                 discovered_files: 0,
+                unreported_file_count: 0,
                 files: Vec::new(),
             });
             continue;
         }
-        let discovered = clinker_plan::config::discovery::discover(&body.source, config_dir)
-            .map_err(|error| match error {
-                clinker_plan::config::discovery::DiscoveryError::Io(_) => {
-                    GuessError::infrastructure(format!(
-                        "source {source_name:?} discovery failed: {error}"
-                    ))
-                }
-                _ => GuessError::configuration(format!(
-                    "source {source_name:?} discovery failed: {error}"
-                )),
-            })?;
-        let paths = discovered
-            .files()
-            .iter()
-            .map(|file| file.path.clone())
-            .collect::<Vec<_>>();
-        let mut files = Vec::with_capacity(paths.len());
-        for (file_index, path) in paths.iter().enumerate() {
+        let discovered = clinker_plan::config::discovery::discover_bounded(
+            &body.source,
+            config_dir,
+            MAX_FILES_PER_SOURCE,
+        )
+        .map_err(|error| match error {
+            clinker_plan::config::discovery::DiscoveryError::Io(_) => GuessError::infrastructure(
+                format!("source {source_name:?} discovery failed: {error}"),
+            ),
+            _ => GuessError::configuration(format!(
+                "source {source_name:?} discovery failed: {error}"
+            )),
+        })?;
+        let discovered_files = discovered.discovered_file_count();
+        let unreported_file_count = discovered_files.saturating_sub(discovered.files().len());
+        let mut files = Vec::with_capacity(discovered.files().len());
+        for discovered_file in discovered.files() {
+            let path = &discovered_file.path;
             let display_path = stable_input_path(path, config_dir);
-            let metadata = std::fs::metadata(path).map_err(|error| {
-                GuessError::infrastructure(format!(
-                    "cannot inspect source file {}: {error}",
-                    display_path
-                ))
-            })?;
-            if file_index >= MAX_FILES_PER_SOURCE {
-                files.push(FileCoverage {
-                    path: display_path,
-                    status: "uncovered_file_limit",
-                    input_bytes: Some(metadata.len()),
-                    bytes_read: 0,
-                    records_sampled: 0,
-                    truncated: true,
-                });
-                continue;
-            }
-            if metadata.len() > MAX_INPUT_BYTES_PER_FILE {
+            if discovered_file.size > MAX_INPUT_BYTES_PER_FILE {
                 files.push(FileCoverage {
                     path: display_path,
                     status: "uncovered_file_byte_limit",
-                    input_bytes: Some(metadata.len()),
+                    input_bytes: Some(discovered_file.size),
                     bytes_read: 0,
                     records_sampled: 0,
                     truncated: true,
@@ -748,7 +754,7 @@ fn sample_sources(
                 } else {
                     "sampled"
                 },
-                input_bytes: Some(metadata.len()),
+                input_bytes: Some(discovered_file.size),
                 bytes_read: tally.read(),
                 records_sampled: records,
                 truncated,
@@ -757,7 +763,8 @@ fn sample_sources(
         coverage.push(SourceCoverage {
             source: source_name.to_owned(),
             format: body.source.format.format_name(),
-            discovered_files: paths.len(),
+            discovered_files,
+            unreported_file_count,
             files,
         });
     }

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -11,6 +11,7 @@ use clinker_plan::config::utils::parse_memory_limit_bytes_strict;
 use clinker_plan::error::PipelineError;
 
 mod capability;
+mod guess;
 mod lifecycle;
 mod lineage;
 use lineage::*;
@@ -97,6 +98,20 @@ EXAMPLES:
   clinker run pipeline.yaml --metrics-spool-dir /var/spool/clinker"
     )]
     Run(RunArgs),
+    /// Preview concrete types for inference-only numeric source columns.
+    #[command(
+        long_about = "\
+Inspect the source bytes selected by one effective pipeline configuration and \
+preview exact `int` or `float` replacements for source columns declared \
+`numeric`. The command is read-only and emits one stable JSON document.",
+        after_long_help = "\
+EXAMPLES:
+  clinker guess pipeline.yaml
+  clinker guess pipeline.yaml --field orders.amount
+  clinker guess pipeline.yaml --channel acme
+  clinker guess pipeline.yaml --group enterprise"
+    )]
+    Guess(GuessArgs),
     /// Metrics utilities
     #[command(long_about = "\
 Utilities for collecting and managing pipeline execution metrics. Clinker \
@@ -681,6 +696,29 @@ impl RunArgs {
     }
 }
 
+/// Arguments for the read-only `clinker guess` preview.
+#[derive(Parser, Debug)]
+pub struct GuessArgs {
+    /// Path to the pipeline YAML configuration file.
+    pub config: PathBuf,
+
+    /// Select one cataloged channel and its derived groups.
+    #[arg(long, value_name = "ID")]
+    pub channel: Option<String>,
+
+    /// Select one explicit, target-admitted group without a channel.
+    #[arg(long, value_name = "NAME")]
+    pub group: Option<String>,
+
+    /// Narrow the effective config's numeric leaves (repeatable).
+    #[arg(long = "field", value_name = "NODE.COLUMN")]
+    pub fields: Vec<String>,
+
+    /// Workspace root holding clinker.toml and channel/group roots.
+    #[arg(long, value_name = "DIR")]
+    pub base_dir: Option<PathBuf>,
+}
+
 /// Subcommands for `clinker metrics`.
 #[derive(Subcommand, Debug)]
 pub enum MetricsCommands {
@@ -1118,6 +1156,20 @@ fn main() -> ExitCode {
                     }
                     render_pipeline_error(&e, &args.config);
                     ExitCode::from(exit_code)
+                }
+            }
+        }
+        Commands::Guess(args) => {
+            tracing_subscriber::fmt()
+                .with_max_level(tracing_subscriber::filter::LevelFilter::WARN)
+                .with_writer(std::io::stderr)
+                .with_ansi(false)
+                .init();
+            match guess::run(args) {
+                Ok(code) => ExitCode::from(code),
+                Err(error) => {
+                    eprintln!("clinker guess error: {error}");
+                    ExitCode::from(error.exit_code())
                 }
             }
         }
@@ -1753,7 +1805,7 @@ fn resolve_overlay_config_before_compile(
 /// the pipeline file's directory. Paths are canonicalized when they exist so
 /// the result is symlink- and `..`-stable; a non-existent path falls back to
 /// its lexical form rather than failing the run.
-fn resolve_compile_anchor(
+pub(crate) fn resolve_compile_anchor(
     config: &std::path::Path,
     base_dir: Option<&std::path::Path>,
 ) -> (std::path::PathBuf, std::path::PathBuf) {
@@ -6764,7 +6816,7 @@ fn run_channels_lint(args: &LintArgs) -> Result<u8, Box<dyn std::error::Error>> 
 
 /// Find the logical pipeline identity for a CLI path. Runtime overlay
 /// selection never derives identity from a filename or current directory.
-fn catalog_pipeline_id(
+pub(crate) fn catalog_pipeline_id(
     workspace_root: &std::path::Path,
     catalog: &clinker_plan::resources::CatalogConfig,
     pipeline_path: &std::path::Path,

--- a/crates/clinker/tests/fixtures/guess/channel.yaml
+++ b/crates/clinker/tests/fixtures/guess/channel.yaml
@@ -1,9 +1,6 @@
 channel:
   target: guess.pipeline
 sources:
-  csv_orders:
-    schema:
-      amount: { type: int }
   json_orders:
     schema:
       ratio: { type: numeric }

--- a/crates/clinker/tests/fixtures/guess/channel.yaml
+++ b/crates/clinker/tests/fixtures/guess/channel.yaml
@@ -1,0 +1,9 @@
+channel:
+  target: guess.pipeline
+sources:
+  csv_orders:
+    schema:
+      amount: { type: int }
+  json_orders:
+    schema:
+      ratio: { type: numeric }

--- a/crates/clinker/tests/fixtures/guess/expected-preview.json
+++ b/crates/clinker/tests/fixtures/guess/expected-preview.json
@@ -1,0 +1,78 @@
+{
+  "schema": "clinker.guess.preview",
+  "version": 1,
+  "target": "guess_preview",
+  "selection": {
+    "kind": "base",
+    "name": null,
+    "applied_groups": []
+  },
+  "limits": {
+    "max_files_per_source": 4,
+    "max_records_per_file": 1024,
+    "max_input_bytes_per_file": 8388608,
+    "max_evidence_per_field": 8
+  },
+  "coverage": [
+    {
+      "source": "csv_orders",
+      "format": "csv",
+      "discovered_files": 1,
+      "files": [
+        {
+          "path": "input.csv",
+          "status": "sampled",
+          "input_bytes": 37,
+          "bytes_read": 37,
+          "records_sampled": 3,
+          "truncated": false
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "field": "csv_orders.amount",
+      "address": "/v1/schema/sources/csv_orders/columns/amount/attributes/type",
+      "observations": 3,
+      "votes": {
+        "int": 3,
+        "float": 0,
+        "no_value": 0,
+        "unresolved": 0
+      },
+      "evidence": [
+        {
+          "boundary": "schema_coerce",
+          "lexeme": "10",
+          "original_bytes": 2,
+          "truncated": false,
+          "parser_outcome": "integer",
+          "vote": "int",
+          "reason": null
+        },
+        {
+          "boundary": "schema_coerce",
+          "lexeme": "20",
+          "original_bytes": 2,
+          "truncated": false,
+          "parser_outcome": "integer",
+          "vote": "int",
+          "reason": null
+        },
+        {
+          "boundary": "schema_coerce",
+          "lexeme": "30",
+          "original_bytes": 2,
+          "truncated": false,
+          "parser_outcome": "integer",
+          "vote": "int",
+          "reason": null
+        }
+      ],
+      "proposed_type": "int",
+      "unresolved_reasons": []
+    }
+  ],
+  "patch": "edits:\n  - address: /v1/schema/sources/csv_orders/columns/amount/attributes/type\n    from: numeric\n    to: int\n"
+}

--- a/crates/clinker/tests/fixtures/guess/expected-preview.json
+++ b/crates/clinker/tests/fixtures/guess/expected-preview.json
@@ -8,16 +8,21 @@
     "applied_groups": []
   },
   "limits": {
+    "max_yaml_input_bytes": 33554432,
+    "max_yaml_nodes_per_document": 100000,
+    "max_schema_leaves": 100000,
     "max_files_per_source": 4,
     "max_records_per_file": 1024,
     "max_input_bytes_per_file": 8388608,
-    "max_evidence_per_field": 8
+    "max_numeric_lexeme_evidence_bytes": 128,
+    "max_evidence_per_owner": 8
   },
   "coverage": [
     {
       "source": "csv_orders",
       "format": "csv",
       "discovered_files": 1,
+      "unreported_file_count": 0,
       "files": [
         {
           "path": "input.csv",

--- a/crates/clinker/tests/fixtures/guess/expected-preview.json
+++ b/crates/clinker/tests/fixtures/guess/expected-preview.json
@@ -22,8 +22,8 @@
         {
           "path": "input.csv",
           "status": "sampled",
-          "input_bytes": 37,
-          "bytes_read": 37,
+          "input_bytes": 50,
+          "bytes_read": 50,
           "records_sampled": 3,
           "truncated": false
         }
@@ -33,46 +33,55 @@
   "fields": [
     {
       "field": "csv_orders.amount",
-      "address": "/v1/schema/sources/csv_orders/columns/amount/attributes/type",
-      "observations": 3,
-      "votes": {
-        "int": 3,
-        "float": 0,
-        "no_value": 0,
-        "unresolved": 0
-      },
-      "evidence": [
+      "owners": [
         {
-          "boundary": "schema_coerce",
-          "lexeme": "10",
-          "original_bytes": 2,
-          "truncated": false,
-          "parser_outcome": "integer",
-          "vote": "int",
-          "reason": null
+          "address": "/v1/schema/sources/csv_orders/records/detail/columns/amount/attributes/type",
+          "observations": 1,
+          "votes": {
+            "int": 1,
+            "float": 0,
+            "no_value": 0,
+            "unresolved": 0
+          },
+          "evidence": [
+            {
+              "boundary": "positional",
+              "lexeme": "10",
+              "original_bytes": 2,
+              "truncated": false,
+              "parser_outcome": "integer",
+              "vote": "int",
+              "reason": null
+            }
+          ],
+          "proposed_type": "int",
+          "unresolved_reasons": []
         },
         {
-          "boundary": "schema_coerce",
-          "lexeme": "20",
-          "original_bytes": 2,
-          "truncated": false,
-          "parser_outcome": "integer",
-          "vote": "int",
-          "reason": null
-        },
-        {
-          "boundary": "schema_coerce",
-          "lexeme": "30",
-          "original_bytes": 2,
-          "truncated": false,
-          "parser_outcome": "integer",
-          "vote": "int",
-          "reason": null
+          "address": "/v1/schema/sources/csv_orders/records/adjustment/columns/amount/attributes/type",
+          "observations": 1,
+          "votes": {
+            "int": 0,
+            "float": 1,
+            "no_value": 0,
+            "unresolved": 0
+          },
+          "evidence": [
+            {
+              "boundary": "positional",
+              "lexeme": "20.5",
+              "original_bytes": 4,
+              "truncated": false,
+              "parser_outcome": "float",
+              "vote": "float",
+              "reason": null
+            }
+          ],
+          "proposed_type": "float",
+          "unresolved_reasons": []
         }
-      ],
-      "proposed_type": "int",
-      "unresolved_reasons": []
+      ]
     }
   ],
-  "patch": "edits:\n  - address: /v1/schema/sources/csv_orders/columns/amount/attributes/type\n    from: numeric\n    to: int\n"
+  "patch": "edits:\n  - address: /v1/schema/sources/csv_orders/records/detail/columns/amount/attributes/type\n    from: numeric\n    to: int\n  - address: /v1/schema/sources/csv_orders/records/adjustment/columns/amount/attributes/type\n    from: nullable(numeric)\n    to: nullable(float)\n"
 }

--- a/crates/clinker/tests/fixtures/guess/expected.patch
+++ b/crates/clinker/tests/fixtures/guess/expected.patch
@@ -1,0 +1,4 @@
+edits:
+  - address: /v1/schema/sources/csv_orders/columns/amount/attributes/type
+    from: numeric
+    to: int

--- a/crates/clinker/tests/fixtures/guess/expected.patch
+++ b/crates/clinker/tests/fixtures/guess/expected.patch
@@ -1,4 +1,7 @@
 edits:
-  - address: /v1/schema/sources/csv_orders/columns/amount/attributes/type
+  - address: /v1/schema/sources/csv_orders/records/detail/columns/amount/attributes/type
     from: numeric
     to: int
+  - address: /v1/schema/sources/csv_orders/records/adjustment/columns/amount/attributes/type
+    from: nullable(numeric)
+    to: nullable(float)

--- a/crates/clinker/tests/fixtures/guess/group.yaml
+++ b/crates/clinker/tests/fixtures/guess/group.yaml
@@ -1,0 +1,13 @@
+group:
+  name: xml_preview
+  targets: { pipelines: [guess.pipeline] }
+  priority: 10
+overrides:
+  - op: patch_schema
+    target: csv_orders
+    schema:
+      amount: { type: int }
+  - op: patch_schema
+    target: xml_orders
+    schema:
+      total: { type: numeric }

--- a/crates/clinker/tests/fixtures/guess/group.yaml
+++ b/crates/clinker/tests/fixtures/guess/group.yaml
@@ -4,10 +4,6 @@ group:
   priority: 10
 overrides:
   - op: patch_schema
-    target: csv_orders
-    schema:
-      amount: { type: int }
-  - op: patch_schema
     target: xml_orders
     schema:
       total: { type: numeric }

--- a/crates/clinker/tests/fixtures/guess/input.csv
+++ b/crates/clinker/tests/fixtures/guess/input.csv
@@ -1,4 +1,4 @@
-order_id,amount
-c-1,10
-c-2,20
-c-3,30
+kind,order_id,amount
+D,c-1,10
+A,c-2,20.5
+S,c-3,30

--- a/crates/clinker/tests/fixtures/guess/input.csv
+++ b/crates/clinker/tests/fixtures/guess/input.csv
@@ -1,0 +1,4 @@
+order_id,amount
+c-1,10
+c-2,20
+c-3,30

--- a/crates/clinker/tests/fixtures/guess/input.json
+++ b/crates/clinker/tests/fixtures/guess/input.json
@@ -1,0 +1,4 @@
+[
+  {"order_id":"j-1","ratio":1.25},
+  {"order_id":"j-2","ratio":2.5}
+]

--- a/crates/clinker/tests/fixtures/guess/input.xml
+++ b/crates/clinker/tests/fixtures/guess/input.xml
@@ -1,0 +1,4 @@
+<root>
+  <row><order_id>x-1</order_id><total>7</total></row>
+  <row><order_id>x-2</order_id><total>11</total></row>
+</root>

--- a/crates/clinker/tests/fixtures/guess/manifest.yaml
+++ b/crates/clinker/tests/fixtures/guess/manifest.yaml
@@ -1,0 +1,22 @@
+version: 1
+configuration_files:
+  - pipeline.yaml
+  - channel.yaml
+  - group.yaml
+inputs:
+  - input.csv
+  - input.json
+  - input.xml
+expected_artifacts:
+  - expected-preview.json
+  - expected.patch
+cases:
+  - name: preview_selector_base_csv
+    selector: base
+    field: csv_orders.amount
+  - name: preview_selector_channel_json
+    selector: channel:json_preview
+    field: json_orders.ratio
+  - name: preview_selector_group_xml
+    selector: group:xml_preview
+    field: xml_orders.total

--- a/crates/clinker/tests/fixtures/guess/pipeline.yaml
+++ b/crates/clinker/tests/fixtures/guess/pipeline.yaml
@@ -8,8 +8,26 @@ nodes:
       type: csv
       path: input.csv
       schema:
-        - { name: order_id, type: string }
-        - { name: amount, type: numeric }
+        discriminator: { field: kind }
+        records:
+          - id: detail
+            tag: D
+            columns:
+              - { name: kind, type: string }
+              - { name: order_id, type: string }
+              - { name: amount, type: numeric }
+          - id: adjustment
+            tag: A
+            columns:
+              - { name: kind, type: string }
+              - { name: order_id, type: string }
+              - { name: amount, type: { nullable: numeric } }
+          - id: summary
+            tag: S
+            columns:
+              - { name: kind, type: string }
+              - { name: order_id, type: string }
+              - { name: amount, type: int }
   - type: source
     name: json_orders
     config:

--- a/crates/clinker/tests/fixtures/guess/pipeline.yaml
+++ b/crates/clinker/tests/fixtures/guess/pipeline.yaml
@@ -1,0 +1,34 @@
+pipeline:
+  name: guess_preview
+nodes:
+  - type: source
+    name: csv_orders
+    config:
+      name: csv_orders
+      type: csv
+      path: input.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: numeric }
+  - type: source
+    name: json_orders
+    config:
+      name: json_orders
+      type: json
+      path: input.json
+      options:
+        format: array
+      schema:
+        - { name: order_id, type: string }
+        - { name: ratio, type: int }
+  - type: source
+    name: xml_orders
+    config:
+      name: xml_orders
+      type: xml
+      path: input.xml
+      options:
+        record_path: root/row
+      schema:
+        - { name: order_id, type: string }
+        - { name: total, type: int }

--- a/crates/clinker/tests/guess_cli.rs
+++ b/crates/clinker/tests/guess_cli.rs
@@ -1,0 +1,227 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const FIXTURE_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/guess");
+const FIXTURE_FILES: &[&str] = &[
+    "manifest.yaml",
+    "pipeline.yaml",
+    "channel.yaml",
+    "group.yaml",
+    "input.csv",
+    "input.json",
+    "input.xml",
+    "expected-preview.json",
+    "expected.patch",
+];
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new(FIXTURE_ROOT).join(name)
+}
+
+fn copy_fixture(root: &Path, name: &str, destination: &str) {
+    let destination = root.join(destination);
+    std::fs::create_dir_all(destination.parent().expect("fixture destination parent"))
+        .expect("create fixture destination");
+    std::fs::copy(fixture_path(name), destination).expect("copy guess fixture");
+}
+
+fn workspace() -> tempfile::TempDir {
+    let workspace = tempfile::tempdir().expect("temporary guess workspace");
+    let root = workspace.path();
+    for name in ["pipeline.yaml", "input.csv", "input.json", "input.xml"] {
+        copy_fixture(root, name, name);
+    }
+    copy_fixture(
+        root,
+        "channel.yaml",
+        "channel/json_preview/pipeline.channel.yaml",
+    );
+    copy_fixture(root, "group.yaml", "group/xml_preview.group.yaml");
+    std::fs::write(
+        root.join("channel/json_preview/channel.cfg.yaml"),
+        "channel:\n  name: json_preview\n  targets: [guess.pipeline]\n",
+    )
+    .expect("write channel manifest");
+    std::fs::write(
+        root.join("clinker.toml"),
+        "[catalog.pipelines]\n\"guess.pipeline\" = \"pipeline.yaml\"\n\n\
+         [catalog.channels]\njson_preview = \"channel/json_preview\"\n\n\
+         [channel]\nroot = \"channel\"\n\n[group]\nroot = \"group\"\n",
+    )
+    .expect("write workspace catalog");
+    workspace
+}
+
+fn guess(root: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_clinker"))
+        .current_dir(root)
+        .arg("guess")
+        .arg("pipeline.yaml")
+        .args(args)
+        .output()
+        .expect("spawn clinker guess")
+}
+
+fn parse_success(output: &Output) -> serde_json::Value {
+    assert!(
+        output.status.success(),
+        "guess failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).expect("guess stdout is one JSON document")
+}
+
+#[test]
+fn preview_selector_corpus_manifest_lists_every_committed_artifact_once() {
+    let manifest_text =
+        std::fs::read_to_string(fixture_path("manifest.yaml")).expect("read manifest");
+    let manifest: serde_json::Value =
+        clinker_plan::yaml::from_str(&manifest_text).expect("parse manifest");
+    assert_eq!(manifest["version"], 1);
+
+    let serialized = serde_json::to_string(&manifest).expect("serialize manifest");
+    for name in FIXTURE_FILES {
+        assert!(fixture_path(name).is_file(), "missing fixture {name}");
+        let expected_mentions = usize::from(*name != "manifest.yaml");
+        assert_eq!(
+            serialized.matches(name).count(),
+            expected_mentions,
+            "fixture {name} must be listed exactly once when it is an input or expected artifact",
+        );
+    }
+
+    let case_names = manifest["cases"]
+        .as_array()
+        .expect("manifest cases")
+        .iter()
+        .map(|case| case["name"].as_str().expect("case name"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        case_names,
+        [
+            "preview_selector_base_csv",
+            "preview_selector_channel_json",
+            "preview_selector_group_xml",
+        ]
+    );
+}
+
+#[test]
+fn preview_selector_base_is_deterministic_and_matches_byte_goldens() {
+    let workspace = workspace();
+    let first = guess(workspace.path(), &["--field", "csv_orders.amount"]);
+    let second = guess(workspace.path(), &["--field", "csv_orders.amount"]);
+    assert_eq!(first.stdout, second.stdout, "preview must be byte stable");
+    assert_eq!(
+        first.stdout,
+        std::fs::read(fixture_path("expected-preview.json")).expect("read preview golden")
+    );
+
+    let report = parse_success(&first);
+    assert_eq!(
+        report["patch"],
+        std::fs::read_to_string(fixture_path("expected.patch")).expect("read patch golden")
+    );
+}
+
+#[test]
+fn preview_selector_channel_uses_effective_json_schema_and_parser() {
+    let workspace = workspace();
+    let output = guess(
+        workspace.path(),
+        &[
+            "--base-dir",
+            ".",
+            "--channel",
+            "json_preview",
+            "--field",
+            "json_orders.ratio",
+        ],
+    );
+    let report = parse_success(&output);
+    assert_eq!(report["selection"]["kind"], "channel");
+    assert_eq!(report["fields"][0]["proposed_type"], "float");
+    assert_eq!(report["fields"][0]["evidence"][0]["boundary"], "json");
+    assert_eq!(report["coverage"][0]["files"][0]["path"], "input.json");
+}
+
+#[test]
+fn preview_selector_group_uses_effective_xml_schema_and_parser() {
+    let workspace = workspace();
+    let output = guess(
+        workspace.path(),
+        &[
+            "--base-dir",
+            ".",
+            "--group",
+            "xml_preview",
+            "--field",
+            "xml_orders.total",
+        ],
+    );
+    let report = parse_success(&output);
+    assert_eq!(report["selection"]["kind"], "group");
+    assert_eq!(report["fields"][0]["proposed_type"], "int");
+    assert_eq!(report["fields"][0]["evidence"][0]["boundary"], "xml");
+    assert_eq!(report["coverage"][0]["files"][0]["path"], "input.xml");
+}
+
+#[test]
+fn preview_selector_conflict_absence_and_ambiguity_exit_one() {
+    let workspace = workspace();
+    let conflict = guess(
+        workspace.path(),
+        &["--channel", "json_preview", "--group", "xml_preview"],
+    );
+    assert_eq!(conflict.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&conflict.stderr).contains("choose exactly one"));
+
+    let absent = guess(workspace.path(), &["--channel", "missing"]);
+    assert_eq!(absent.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&absent.stderr).contains("missing"));
+
+    copy_fixture(workspace.path(), "group.yaml", "group/duplicate.group.yaml");
+    let ambiguous = guess(workspace.path(), &["--group", "xml_preview"]);
+    assert_eq!(ambiguous.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&ambiguous.stderr).contains("xml_preview"));
+}
+
+#[test]
+fn preview_selector_fields_deduplicate_and_reject_unknown_or_concrete_fields() {
+    let workspace = workspace();
+    let deduplicated = guess(
+        workspace.path(),
+        &[
+            "--field",
+            "csv_orders.amount",
+            "--field",
+            "csv_orders.amount",
+        ],
+    );
+    let report = parse_success(&deduplicated);
+    assert_eq!(report["fields"].as_array().expect("fields").len(), 1);
+
+    for field in ["csv_orders.missing", "json_orders.ratio", "amount"] {
+        let rejected = guess(workspace.path(), &["--field", field]);
+        assert_eq!(rejected.status.code(), Some(1), "field {field}");
+        let stderr = String::from_utf8_lossy(&rejected.stderr);
+        assert!(stderr.contains(field), "stderr for {field}: {stderr}");
+        assert!(stderr.contains("--field"), "stderr for {field}: {stderr}");
+    }
+
+    let pipeline_path = workspace.path().join("pipeline.yaml");
+    let pipeline = std::fs::read_to_string(&pipeline_path).expect("read pipeline fixture");
+    std::fs::write(
+        &pipeline_path,
+        pipeline.replacen("type: numeric", "type: { nullable: numeric }", 1),
+    )
+    .expect("make amount nullable");
+    let nullable = parse_success(&guess(workspace.path(), &["--field", "csv_orders.amount"]));
+    assert!(
+        nullable["patch"]
+            .as_str()
+            .expect("patch")
+            .contains("from: nullable(numeric)\n    to: nullable(int)",)
+    );
+}

--- a/crates/clinker/tests/guess_cli.rs
+++ b/crates/clinker/tests/guess_cli.rs
@@ -126,6 +126,37 @@ fn preview_selector_base_is_deterministic_and_matches_byte_goldens() {
 }
 
 #[test]
+fn preview_selector_multi_record_field_reports_each_literal_numeric_owner() {
+    let workspace = workspace();
+    let report = parse_success(&guess(workspace.path(), &["--field", "csv_orders.amount"]));
+    let owners = report["fields"][0]["owners"]
+        .as_array()
+        .expect("exact owner reports");
+    assert_eq!(owners.len(), 2);
+    assert_eq!(
+        owners[0]["address"],
+        "/v1/schema/sources/csv_orders/records/detail/columns/amount/attributes/type"
+    );
+    assert_eq!(owners[0]["observations"], 1);
+    assert_eq!(owners[0]["proposed_type"], "int");
+    assert_eq!(owners[0]["evidence"][0]["lexeme"], "10");
+    assert_eq!(
+        owners[1]["address"],
+        "/v1/schema/sources/csv_orders/records/adjustment/columns/amount/attributes/type"
+    );
+    assert_eq!(owners[1]["observations"], 1);
+    assert_eq!(owners[1]["proposed_type"], "float");
+    assert_eq!(owners[1]["evidence"][0]["lexeme"], "20.5");
+    let patch = report["patch"].as_str().expect("patch");
+    assert!(patch.contains("records/detail/columns/amount/attributes/type"));
+    assert!(patch.contains("records/adjustment/columns/amount/attributes/type"));
+    assert!(
+        !patch.contains("records/summary/columns/amount/attributes/type"),
+        "the concrete summary declaration must not be proposed as an edit: {patch}"
+    );
+}
+
+#[test]
 fn preview_selector_channel_uses_effective_json_schema_and_parser() {
     let workspace = workspace();
     let output = guess(
@@ -141,8 +172,11 @@ fn preview_selector_channel_uses_effective_json_schema_and_parser() {
     );
     let report = parse_success(&output);
     assert_eq!(report["selection"]["kind"], "channel");
-    assert_eq!(report["fields"][0]["proposed_type"], "float");
-    assert_eq!(report["fields"][0]["evidence"][0]["boundary"], "json");
+    assert_eq!(report["fields"][0]["owners"][0]["proposed_type"], "float");
+    assert_eq!(
+        report["fields"][0]["owners"][0]["evidence"][0]["boundary"],
+        "json"
+    );
     assert_eq!(report["coverage"][0]["files"][0]["path"], "input.json");
 }
 
@@ -162,8 +196,11 @@ fn preview_selector_group_uses_effective_xml_schema_and_parser() {
     );
     let report = parse_success(&output);
     assert_eq!(report["selection"]["kind"], "group");
-    assert_eq!(report["fields"][0]["proposed_type"], "int");
-    assert_eq!(report["fields"][0]["evidence"][0]["boundary"], "xml");
+    assert_eq!(report["fields"][0]["owners"][0]["proposed_type"], "int");
+    assert_eq!(
+        report["fields"][0]["owners"][0]["evidence"][0]["boundary"],
+        "xml"
+    );
     assert_eq!(report["coverage"][0]["files"][0]["path"], "input.xml");
 }
 

--- a/crates/clinker/tests/guess_cli.rs
+++ b/crates/clinker/tests/guess_cli.rs
@@ -157,6 +157,52 @@ fn preview_selector_multi_record_field_reports_each_literal_numeric_owner() {
 }
 
 #[test]
+fn preview_many_files_keeps_fixed_coverage_and_evidence_storage() {
+    let workspace = workspace();
+    let pipeline_path = workspace.path().join("pipeline.yaml");
+    let pipeline = std::fs::read_to_string(&pipeline_path).expect("read pipeline fixture");
+    std::fs::write(
+        &pipeline_path,
+        pipeline.replacen("path: input.csv", "glob: input-*.csv", 1),
+    )
+    .expect("select a many-file input set");
+    let body = format!(
+        "kind,order_id,amount\n{}",
+        "D,c-detail,10\nA,c-adjustment,20.5\n".repeat(10)
+    );
+    for index in 0..12 {
+        std::fs::write(
+            workspace.path().join(format!("input-{index:02}.csv")),
+            &body,
+        )
+        .expect("write sampled input");
+    }
+
+    let report = parse_success(&guess(workspace.path(), &["--field", "csv_orders.amount"]));
+    let coverage = &report["coverage"][0];
+    assert_eq!(coverage["discovered_files"], 12);
+    assert_eq!(coverage["unreported_file_count"], 8);
+    let files = coverage["files"].as_array().expect("bounded file reports");
+    assert_eq!(files.len(), 4);
+    assert_eq!(files[0]["path"], "input-00.csv");
+    assert_eq!(files[3]["path"], "input-03.csv");
+
+    for owner in report["fields"][0]["owners"]
+        .as_array()
+        .expect("owner reports")
+    {
+        assert_eq!(owner["observations"], 40);
+        assert_eq!(
+            owner["evidence"]
+                .as_array()
+                .expect("bounded evidence")
+                .len(),
+            8
+        );
+    }
+}
+
+#[test]
 fn preview_selector_channel_uses_effective_json_schema_and_parser() {
     let workspace = workspace();
     let output = guess(

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -81,6 +81,61 @@ with a new execution ID for every retry.
 
 ---
 
+## clinker guess
+
+Preview concrete `int` or `float` replacements for inference-only `numeric`
+columns without editing the pipeline.
+
+```text
+clinker guess [OPTIONS] <CONFIG>
+```
+
+With no selector, `guess` reads the base pipeline. `--channel <ID>` selects one
+cataloged channel plus its target-admitted derived groups; `--group <NAME>`
+selects one explicit, target-admitted group without a channel. The two
+selectors conflict. A missing or ambiguous selector is an error rather than a
+fallback to the base pipeline, so the report always describes exactly one
+effective configuration.
+
+| Flag | Description |
+|------|-------------|
+| `<CONFIG>` | Pipeline YAML containing the source-schema `numeric` leaves to inspect. |
+| `--channel <ID>` | Select one cataloged channel and its derived, target-admitted groups. |
+| `--group <NAME>` | Select one explicit, target-admitted group without a channel. |
+| `--field <NODE.COLUMN>` | Narrow the preview to one `numeric` source column. Repeatable; repeated selectors are deduplicated in request order. Unknown, malformed, or already-concrete fields are rejected. |
+| `--base-dir <DIR>` | Workspace root holding `clinker.toml` and the channel/group roots. Defaults to the pipeline file's directory. |
+
+The command constructs readers through the same CSV, JSON, and XML option and
+schema-coercion path as runtime ingest. It emits one deterministic JSON document
+containing the selected configuration, bounded coverage, parser-owned numeric
+evidence, unresolved reasons, proposed types, and an exact semantic YAML patch.
+The patch is a preview string inside the report; this command never changes the
+pipeline or an overlay.
+
+Sampling is bounded to four discovered files per selected source, 1,024 records
+per sampled file, 8 MiB per file, and eight retained evidence items per field.
+Files beyond either file bound are reported as uncovered, and hitting the
+record bound is reported as truncated. The limits and every sampled or
+uncovered file are included in the report so a proposal is never presented as
+having broader evidence than Clinker actually read.
+
+Exit `0` means a complete preview document was written, including when one or
+more fields remain unresolved. Selection, configuration, and field errors exit
+`1`; source discovery, input I/O, reader, and stdout failures exit `4`.
+
+```bash
+# Preview every inference-only numeric leaf in the base pipeline
+clinker guess pipeline.yaml
+
+# Preview one field under a cataloged channel
+clinker guess pipeline.yaml --channel acme --field orders.amount
+
+# Preview one explicit group without a channel
+clinker guess pipeline.yaml --group enterprise
+```
+
+---
+
 ## clinker explain
 
 Inspect one compiled field's provenance or discover registry-owned diagnostic

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -102,7 +102,7 @@ effective configuration.
 | `<CONFIG>` | Pipeline YAML containing the source-schema `numeric` leaves to inspect. |
 | `--channel <ID>` | Select one cataloged channel and its derived, target-admitted groups. |
 | `--group <NAME>` | Select one explicit, target-admitted group without a channel. |
-| `--field <NODE.COLUMN>` | Narrow the preview to one `numeric` source column. Repeatable; repeated selectors are deduplicated in request order. Unknown, malformed, or already-concrete fields are rejected. |
+| `--field <NODE.COLUMN>` | Narrow the preview to one `numeric` source field. Repeatable; repeated selectors are deduplicated in request order. In a multi-record schema, one selector covers every same-named literal `numeric` owner across `records:` while leaving same-named concrete declarations unchanged. Unknown, malformed, or entirely concrete fields are rejected. |
 | `--base-dir <DIR>` | Workspace root holding `clinker.toml` and the channel/group roots. Defaults to the pipeline file's directory. |
 
 The command constructs readers through the same CSV, JSON, and XML option and
@@ -111,6 +111,14 @@ containing the selected configuration, bounded coverage, parser-owned numeric
 evidence, unresolved reasons, proposed types, and an exact semantic YAML patch.
 The patch is a preview string inside the report; this command never changes the
 pipeline or an overlay.
+
+Each field report carries an `owners` array. Every owner has its own evidence,
+votes, proposed type, unresolved reasons, and exact address. A single-record
+field has one canonical `/v1/schema/sources/.../columns/...` owner.
+Multi-record owners use
+`/v1/schema/sources/.../records/.../columns/...`, in authored record order, so
+same-named leaves never collapse into a fake single-record address or share a
+proposal derived from another record type.
 
 Sampling is bounded to four discovered files per selected source, 1,024 records
 per sampled file, 8 MiB per file, and eight retained evidence items per field.

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -120,12 +120,20 @@ Multi-record owners use
 same-named leaves never collapse into a fake single-record address or share a
 proposal derived from another record type.
 
-Sampling is bounded to four discovered files per selected source, 1,024 records
-per sampled file, 8 MiB per file, and eight retained evidence items per field.
-Files beyond either file bound are reported as uncovered, and hitting the
-record bound is reported as truncated. The limits and every sampled or
-uncovered file are included in the report so a proposal is never presented as
-having broader evidence than Clinker actually read.
+Discovery streams through the matcher and retains a deterministic sample of at
+most four files per selected source; the report includes the complete
+`discovered_files` count and one `unreported_file_count` aggregate instead of
+retaining a path/report for every omitted file. Sampling then reads at most
+1,024 records and 8 MiB per retained file. Hitting the record bound is reported
+as truncated, and a retained file over the byte bound is reported as uncovered.
+
+Candidate storage is capped at 100,000 source-schema leaves, matching the
+canonical YAML parser's 100,000-node limit; each YAML document is also capped
+at 32 MiB. Each parser-owned `NumericObservation` retains at most 128 numeric
+lexeme bytes, and each exact schema owner retains at most eight evidence items.
+These limits appear in the JSON report. Candidate, observation, evidence, and
+coverage collections are therefore fixed-bounded independently of source file
+count; the preview does not register a runtime memory consumer.
 
 Exit `0` means a complete preview document was written, including when one or
 more fields remain unresolved. Selection, configuration, and field errors exit


### PR DESCRIPTION
## Summary

- add a read-only `clinker guess CONFIG` preview for inference-only `numeric` source fields
- resolve base, channel, or group effective configuration and support repeatable `node.column` selectors
- collect parser-owned evidence through the same reader and schema-coercion constructors used by normal execution
- preserve exact multi-record ownership with typed record-column addresses and independent proposals
- bound discovery, records, bytes, numeric lexemes, schema owners, and retained evidence

## Validation

- bounded discovery unit tests (24 passed)
- schema leaf address round-trip test (passed)
- multi-record format tests (22 passed)
- numeric reader parity target (17 passed)
- guess CLI target with CSV, JSON, XML, selectors, multi-record owners, goldens, and many-file bounds (8 passed)
- focused Clippy for the affected crates with warnings denied
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This is stacked on #1091, which exposes the parser-owned numeric observations consumed here.

This first command slice is preview-only. Exhaustive check/write modes, compare-and-swap edits, and fixed-cardinality command telemetry remain separate dependent PRs; this preview should not be retargeted or merged by itself before those obligations land.

## Contracts

- The command never edits pipeline, channel, group, or input files.
- Multi-record fields keep one exact report and patch owner per authored record type; concrete siblings are never proposed for change.
- Discovery retains at most four deterministic file entries per source plus aggregate counts. Evidence retains at most eight items per exact owner, with a 128-byte numeric lexeme cap.
- This authoring command does not change pipeline row values, routing, or external dataset identity, so runtime lineage is unaffected.
