### PR TITLE
Migrate executor internal fixtures to Sink syntax

### DIFF
--- a/crates/clinker-exec/src/executor/tests/composition_port_admission_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/composition_port_admission_overshoot.rs
@@ -77,7 +77,7 @@ nodes:
   use: ../compositions/port_passthrough.comp.yaml
   inputs:
     data: src
-- type: output
+- type: sink
   name: out
   input: port_enrich_call
   config:

--- a/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
@@ -48,7 +48,7 @@ nodes:
       emit department = department
       emit total = total
       emit scaled = total * 2
-- type: output
+- type: sink
   name: out
   input: scaled
   config:
@@ -266,7 +266,7 @@ nodes:
       emit department = department
       emit total = total
       emit budget = budget
-- type: output
+- type: sink
   name: out
   input: tail
   config:
@@ -427,7 +427,7 @@ nodes:
       emit department = department
       emit total = total
       emit ratio = 1 / (total - 60)
-- type: output
+- type: sink
   name: out
   input: ratio
   config:
@@ -521,7 +521,7 @@ nodes:
       emit department = department
       emit total = total
       emit ratio = 1 / (total - 60)
-- type: output
+- type: sink
   name: out
   input: ratio
   config:
@@ -720,7 +720,7 @@ nodes:
     use: ../compositions/relaxed_ratio.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: body
     config:
@@ -966,7 +966,7 @@ nodes:
     use: ../compositions/outer_wrap.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: outer
     config:

--- a/crates/clinker-exec/src/executor/tests/diamond_node_buffer_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/diamond_node_buffer_overshoot.rs
@@ -103,7 +103,7 @@ nodes:
   inputs:
     - branch_a
     - branch_b
-- type: output
+- type: sink
   name: out
   input: joined
   config:
@@ -265,7 +265,7 @@ nodes:
 - type: merge
   name: joined
   inputs: [branch_a, branch_b, branch_c]
-- type: output
+- type: sink
   name: out
   input: joined
   config: { name: out, type: csv, path: out.csv }
@@ -377,15 +377,15 @@ nodes:
 - type: merge
   name: high_one
   inputs: [splitter.high, empty_d]
-- type: output
+- type: sink
   name: low_out_one
   input: low_one
   config: { name: low_out_one, type: csv, path: low-one.csv }
-- type: output
+- type: sink
   name: low_out_two
   input: low_two
   config: { name: low_out_two, type: csv, path: low-two.csv }
-- type: output
+- type: sink
   name: high_out
   input: high_one
   config: { name: high_out, type: csv, path: high.csv }

--- a/crates/clinker-exec/src/executor/tests/iejoin_pre_output_budget.rs
+++ b/crates/clinker-exec/src/executor/tests/iejoin_pre_output_budget.rs
@@ -146,7 +146,7 @@ nodes:
       emit amount = orders.amount
       emit band_id = bands.band_id
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: banded
   config:
@@ -488,7 +488,7 @@ nodes:
       emit order_id = orders.order_id
       emit band_id = bands.band_id
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: banded
   config:
@@ -565,7 +565,7 @@ nodes:
     cxl: |
       emit order_id = order_id
       emit band_id = band_id
-- type: output
+- type: sink
   name: out
   input: passthrough
   config:
@@ -803,7 +803,7 @@ nodes:
       emit amount = orders.amount
       emit lo = bands.lo
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: banded
   config:
@@ -1047,7 +1047,7 @@ nodes:
       emit order_id = orders.order_id
       emit q = orders.amount / bands.divisor
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: banded
   config:

--- a/crates/clinker-exec/src/executor/tests/nested_composition_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/nested_composition_overshoot.rs
@@ -63,7 +63,7 @@ nodes:
   use: ../compositions/issue_123_nested_hard_fail.comp.yaml
   inputs:
     records: events
-- type: output
+- type: sink
   name: out
   input: enrich_call
   config:

--- a/crates/clinker-exec/src/executor/tests/scheduling.rs
+++ b/crates/clinker-exec/src/executor/tests/scheduling.rs
@@ -68,7 +68,7 @@ nodes:
       cxl: |
         emit k = k
         emit total = sum(v)
-  - type: output
+  - type: sink
     name: out_small
     input: agg_small
     config:
@@ -76,7 +76,7 @@ nodes:
       type: csv
       path: out_small.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_large
     input: agg_large
     config:
@@ -281,7 +281,7 @@ nodes:
       cxl: |
         emit k = k
         emit total = sum(v)
-  - type: output
+  - type: sink
     name: out_heavy
     input: agg_heavy
     config:
@@ -289,7 +289,7 @@ nodes:
       type: csv
       path: out_heavy.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_light
     input: agg_light
     config:
@@ -510,7 +510,7 @@ nodes:
       cxl: |
         emit k = k
         emit items = collect(v)
-  - type: output
+  - type: sink
     name: out
     input: agg
     config:
@@ -612,7 +612,7 @@ nodes:
       cxl: |
         emit k = k
         emit items = collect(v)
-  - type: output
+  - type: sink
     name: out
     input: agg
     config:
@@ -694,7 +694,7 @@ nodes:
         emit ratio = 1 / (total - 30)
       analytic_window:
         group_by: [department]
-  - type: output
+  - type: sink
     name: out
     input: running
     config:

--- a/crates/clinker-exec/src/executor/tests/source_consumer_release.rs
+++ b/crates/clinker-exec/src/executor/tests/source_consumer_release.rs
@@ -102,7 +102,7 @@ nodes:
     schema:
       - { name: id, type: string }
       - { name: region, type: string }
-- type: output
+- type: sink
   name: out
   input: events
   config:
@@ -173,7 +173,7 @@ nodes:
   inputs: [src_a, src_b]
   config:
     mode: interleave
-- type: output
+- type: sink
   name: out
   input: merged
   config:
@@ -232,7 +232,7 @@ nodes:
     cxl: |
       emit id = id
       emit region = region
-- type: output
+- type: sink
   name: out
   input: shape
   config:
@@ -317,7 +317,7 @@ nodes:
     schema:
       - { name: id, type: string }
       - { name: region, type: string }
-- type: output
+- type: sink
   name: out
   input: events
   config:
@@ -413,7 +413,7 @@ nodes:
     schema:
       - { name: id, type: string }
       - { name: region, type: string }
-- type: output
+- type: sink
   name: out
   input: events
   config:

--- a/crates/clinker-exec/src/executor/tests/source_pause_liveness.rs
+++ b/crates/clinker-exec/src/executor/tests/source_pause_liveness.rs
@@ -185,7 +185,7 @@ nodes:
   inputs: [src_a, src_b]
   config:
     mode: concat
-- type: output
+- type: sink
   name: out
   input: merged
   config:
@@ -253,7 +253,7 @@ nodes:
   inputs: [src_a, src_b]
   config:
     mode: interleave
-- type: output
+- type: sink
   name: out
   input: merged
   config:
@@ -277,7 +277,7 @@ nodes:
     cxl: |
       emit region = region
       emit n = count()
-- type: output
+- type: sink
   name: out_pre
   input: agg_pre
   config:
@@ -341,7 +341,7 @@ nodes:
     cxl: |
       emit id = id
       emit region = region
-- type: output
+- type: sink
   name: out
   input: shape
   config:
@@ -365,7 +365,7 @@ nodes:
     cxl: |
       emit region = region
       emit n = count()
-- type: output
+- type: sink
   name: out_pre
   input: agg_pre
   config:

--- a/crates/clinker-exec/src/executor/tests/spill_backed_drain_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/spill_backed_drain_overshoot.rs
@@ -118,7 +118,7 @@ nodes:
     cxl: |
       emit id = id
       emit amount = amount
-- type: output
+- type: sink
   name: out
   input: stage_two
   config:
@@ -150,7 +150,7 @@ nodes:
     cxl: |
       emit dept = dept
       emit lo = min(amount)
-- type: output
+- type: sink
   name: out
   input: rollup
   config:

--- a/crates/clinker-exec/src/executor/tests/spill_dir_unavailable_midrun.rs
+++ b/crates/clinker-exec/src/executor/tests/spill_dir_unavailable_midrun.rs
@@ -85,7 +85,7 @@ nodes:
       cxl: |
         emit k = k
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_key
     config:

--- a/crates/clinker-exec/src/executor/tests/transient_node_buffer_reservations.rs
+++ b/crates/clinker-exec/src/executor/tests/transient_node_buffer_reservations.rs
@@ -194,7 +194,7 @@ nodes:
       type: csv
       path: src.csv
       schema: [ { name: id, type: string } ]
-  - type: output
+  - type: sink
     name: sibling
     input: src
     config: { name: sibling, type: csv, path: sibling.csv }
@@ -204,7 +204,7 @@ nodes:
     use: ../compositions/passthrough_check.comp.yaml
     inputs:
       data: src
-  - type: output
+  - type: sink
     name: out
     input: passthrough_call
     config: { name: out, type: csv, path: out.csv }
@@ -267,11 +267,11 @@ nodes:
   - type: merge
     name: m2
     inputs: [shared, c]
-  - type: output
+  - type: sink
     name: out1
     input: m1
     config: { name: out1, type: csv, path: out1.csv }
-  - type: output
+  - type: sink
     name: out2
     input: m2
     config: { name: out2, type: csv, path: out2.csv }
@@ -325,11 +325,11 @@ nodes:
     config:
       cxl: |
         emit marker = "ready"
-  - type: output
+  - type: sink
     name: alpha
     input: prepared
     config: { name: alpha, type: csv, path: alpha.csv }
-  - type: output
+  - type: sink
     name: beta
     input: prepared
     config: { name: beta, type: csv, path: beta.csv }
@@ -382,7 +382,7 @@ nodes:
     use: ../compositions/exec_transform_check.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: composition_out
     input: doubled_call
     config: { name: composition_out, type: csv, path: composition.csv, include_unmapped: true }
@@ -462,7 +462,7 @@ nodes:
     use: ../compositions/source_boundary_collision.comp.yaml
     inputs:
       collision: body_feed
-  - type: output
+  - type: sink
     name: body_out
     input: body_call
     config: { name: body_out, type: csv, path: body-out.csv, include_unmapped: false }
@@ -479,7 +479,7 @@ nodes:
         emit id = id
         emit origin = "top-transform"
         emit $record.boundary = $record.boundary
-  - type: output
+  - type: sink
     name: top_out
     input: top_transform
     config: { name: top_out, type: csv, path: top-out.csv, include_unmapped: false }
@@ -614,7 +614,7 @@ nodes:
     use: ../compositions/exec_runtime_error.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: composition_out
     input: failing_call
     config: { name: composition_out, type: csv, path: composition.csv }
@@ -661,7 +661,7 @@ nodes:
     use: ../compositions/transient_clone_harvest_error.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: harvest_call
     config: { name: out, type: csv, path: out.csv }

--- a/crates/clinker-exec/src/executor/util.rs
+++ b/crates/clinker-exec/src/executor/util.rs
@@ -738,7 +738,7 @@ nodes:
       path: in.csv
       schema:
         - { name: a, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -140,7 +140,7 @@ nodes:
       - { name: name, type: string }
       - { name: age, type: int }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -191,7 +191,7 @@ nodes:
     cxl: 'emit result = value.to_int() * 2
 
       '
-- type: output
+- type: sink
   name: dest
   input: will_fail_some
   config:
@@ -229,7 +229,7 @@ nodes:
     cxl: 'emit result = value.to_int() + 1
 
       '
-- type: output
+- type: sink
   name: dest
   input: will_fail
   config:
@@ -275,7 +275,7 @@ nodes:
     cxl: 'emit dept_upper = department.upper()
 
       '
-- type: output
+- type: sink
   name: transformed
   input: compute_upper_dept
   config:
@@ -371,7 +371,7 @@ nodes:
     - {{ name: first_name, type: string }}
     - {{ name: last_name, type: string }}
     - {{ name: department, type: string }}
-- type: output
+- type: sink
   name: out
   input: employees
   config:
@@ -479,7 +479,7 @@ nodes:
     options:
       has_header: true
     schema:
-{schema}- type: output
+{schema}- type: sink
   name: out
   input: orders
   config:
@@ -525,7 +525,7 @@ nodes:
       has_header: true
     schema:
     - { name: first_name, type: string }
-- type: output
+- type: sink
   name: out
   input: people
   config:
@@ -584,7 +584,7 @@ nodes:
     cxl: |
       emit employee_id = employee_id
       emit parsed_value = value.to_int()
-- type: output
+- type: sink
   name: out
   input: parse_value
   config:
@@ -652,7 +652,7 @@ nodes:
     cxl: |
       emit employee_id = employee_id
       emit value = value
-- type: output
+- type: sink
   name: out
   input: passthrough
   config:
@@ -719,7 +719,7 @@ nodes:
     path: test.json
     schema:
     - { name: first_name, type: string }
-- type: output
+- type: sink
   name: out
   input: people
   config:
@@ -786,7 +786,7 @@ nodes:
     schema:
     - { name: order_id, type: string }
     - { name: customer_id, type: string }
-- type: output
+- type: sink
   name: out
   input: orders
   config:
@@ -837,7 +837,7 @@ nodes:
     schema:
     - { name: first_name, type: string }
     - { name: nickname, type: string }
-- type: output
+- type: sink
   name: out
   input: people
   config:
@@ -890,7 +890,7 @@ nodes:
   input: src
   config:
     cxl: emit x = 1
-- type: output
+- type: sink
   name: dest
   input: t1
   config:
@@ -958,7 +958,7 @@ nodes:
   input: src
   config:
     cxl: emit id = id
-- type: output
+- type: sink
   name: dest
   input: t1
   config:
@@ -1051,7 +1051,7 @@ nodes:
             .collect::<Vec<_>>()
             .join("\n");
         format!(
-            "pipeline:\n  name: filter_test\nnodes:\n  - type: source\n    name: src\n    config:\n      name: src\n      type: csv\n      path: input.csv\n      schema:\n        - {{ name: id, type: any }}\n        - {{ name: name, type: any }}\n        - {{ name: status, type: any }}\n        - {{ name: value, type: any }}\n        - {{ name: amount, type: any }}\n        - {{ name: category, type: any }}\n        - {{ name: code, type: any }}\n        - {{ name: dept, type: any }}\n        - {{ name: department, type: any }}\n        - {{ name: priority, type: any }}\n        - {{ name: optional, type: any }}\n        - {{ name: required, type: any }}\n        - {{ name: active, type: any }}\n        - {{ name: first, type: any }}\n        - {{ name: last, type: any }}\n        - {{ name: first_name, type: any }}\n  - type: transform\n    name: t1\n    input: src\n    config:\n      cxl: |\n{indented}\n  - type: output\n    name: dest\n    input: t1\n    config:\n      name: dest\n      type: csv\n      path: output.csv\n"
+            "pipeline:\n  name: filter_test\nnodes:\n  - type: source\n    name: src\n    config:\n      name: src\n      type: csv\n      path: input.csv\n      schema:\n        - {{ name: id, type: any }}\n        - {{ name: name, type: any }}\n        - {{ name: status, type: any }}\n        - {{ name: value, type: any }}\n        - {{ name: amount, type: any }}\n        - {{ name: category, type: any }}\n        - {{ name: code, type: any }}\n        - {{ name: dept, type: any }}\n        - {{ name: department, type: any }}\n        - {{ name: priority, type: any }}\n        - {{ name: optional, type: any }}\n        - {{ name: required, type: any }}\n        - {{ name: active, type: any }}\n        - {{ name: first, type: any }}\n        - {{ name: last, type: any }}\n        - {{ name: first_name, type: any }}\n  - type: transform\n    name: t1\n    input: src\n    config:\n      cxl: |\n{indented}\n  - type: sink\n    name: dest\n    input: t1\n    config:\n      name: dest\n      type: csv\n      path: output.csv\n"
         )
     }
 
@@ -1428,7 +1428,7 @@ nodes:
       emit out_name = name
 
       '
-- type: output
+- type: sink
   name: dest
   input: t1
   config:
@@ -1510,7 +1510,7 @@ nodes:
   input: src
   config:
     cxl: 'emit id = id'
-- type: output
+- type: sink
   name: dest
   input: identity
   config:
@@ -1600,7 +1600,7 @@ nodes:
         emit quantity = orders.quantity
       propagate_ck: driver
 
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:

--- a/crates/clinker-exec/src/log_dispatch.rs
+++ b/crates/clinker-exec/src/log_dispatch.rs
@@ -725,7 +725,7 @@ nodes:
           every: 1
           message: seen
           fields: [amount]{gate}
-  - type: output
+  - type: sink
     name: output
     input: observe
     config:
@@ -776,7 +776,7 @@ nodes:
     config:
       cxl: |
         emit amount = amount
-  - type: output
+  - type: sink
     name: output
     input: "{node_name}"
     config:


### PR DESCRIPTION
## Summary

- migrate 70 positive executor-internal fixtures from `type: output` to `type: sink`
- preserve output port and artifact terminology where it describes data rather than the retired node kind
- keep scheduling, memory-pressure, spill, source-release, and integration scenarios otherwise unchanged

## Validation

- exact affected executor library filters (114 passed)
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This executor corpus shard is stacked on #1101.

The full executor library run reached 971 passes and isolated 16 remaining fixture failures to five exact source owners. Those owners are intentionally left to the next focused PR. No production behavior, dependencies, telemetry vocabulary, or memory ownership changes here.
