### PR TITLE
Migrate remaining executor library fixtures to Sink

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -1663,7 +1663,7 @@ nodes:
       schema:
         - {{ name: id, type: string }}
         - {{ name: name, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: probe
     config:
@@ -1843,7 +1843,7 @@ nodes:
       path: placeholder.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: edi
     config:

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1920,7 +1920,7 @@ nodes:
     input: orders
     config:
       cxl: "emit id = id"
-  - type: output
+  - type: sink
     name: out
     input: normalize_orders
     config:
@@ -1983,7 +1983,7 @@ nodes:
       path: input.json
       schema:
         - { name: id, type: string }
-  - type: output
+  - type: sink
     name: z_out
     input: source
     config:
@@ -1992,7 +1992,7 @@ nodes:
       path: z.csv
       mapping:
         - z_missing
-  - type: output
+  - type: sink
     name: a_out
     input: source
     config:

--- a/crates/clinker-exec/src/executor/tests/aggregation.rs
+++ b/crates/clinker-exec/src/executor/tests/aggregation.rs
@@ -171,7 +171,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:

--- a/crates/clinker-exec/src/executor/tests/combine_consumer_lifecycle.rs
+++ b/crates/clinker-exec/src/executor/tests/combine_consumer_lifecycle.rs
@@ -155,7 +155,7 @@ nodes:
       emit amount = orders.amount
       emit bracket_id = tax_brackets.bracket_id
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: bracketed
   config:
@@ -254,7 +254,7 @@ nodes:
       emit price = products.price
       emit bracket_id = brackets.bracket_id
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: assign_bracket
   config:
@@ -349,7 +349,7 @@ nodes:
       emit product_id = orders.product_id
       emit name = products.name
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: enriched
   config:
@@ -441,7 +441,7 @@ nodes:
       emit amount = orders.amount
       emit bracket_id = tax_brackets.bracket_id
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: bracketed
   config:
@@ -522,7 +522,7 @@ nodes:
       emit product_id = orders.product_id
       emit name = products.name
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: enriched
   config:
@@ -622,7 +622,7 @@ nodes:
       emit product_id = orders.product_id
       emit name = products.name
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: enriched
   config:

--- a/crates/clinker-exec/src/source/order_barrier.rs
+++ b/crates/clinker-exec/src/source/order_barrier.rs
@@ -1347,7 +1347,7 @@ nodes:
         - { name: key, type: int }
         - { name: payload, type: string }
       sort_order: [key]
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:


### PR DESCRIPTION
## Summary

- migrate the final 13 positive inline fixtures blocking the executor library
- cover ingest, aggregation, combine-consumer lifecycle, executor entry, and source ordering owners
- leave runtime behavior and assertions unchanged

## Validation

- all 16 previously failing exact tests passed
- `cargo test -p clinker-exec --lib --locked --offline` (987 passed)
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This five-file closer is stacked on #1103 and restores the full executor library suite on the Sink stack.

No production behavior, dependencies, telemetry vocabulary, or memory ownership changes here.
