### PR TITLE
Migrate executor integration fixtures to Sink syntax

### DIFF
--- a/crates/clinker-exec/tests/aggregate_integration.rs
+++ b/crates/clinker-exec/tests/aggregate_integration.rs
@@ -138,7 +138,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -197,7 +197,7 @@ nodes:
       emit mean = avg(salary.to_int())
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -259,7 +259,7 @@ nodes:
       emit names = collect(name)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -332,7 +332,7 @@ nodes:
       emit wavg = weighted_avg(salary.to_float(), hours.to_float())
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -403,7 +403,7 @@ nodes:
       emit rows = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: globals
   config:
@@ -464,7 +464,7 @@ nodes:
       emit n_all = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -532,7 +532,7 @@ nodes:
       emit total = sum(comp.to_int())
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -596,7 +596,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -648,7 +648,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -720,7 +720,7 @@ nodes:
       emit avg_w_sum = avg(w_sum)
       emit record_count = count(*)
 
-- type: output
+- type: sink
   name: sink
   input: summarize
   config:
@@ -837,7 +837,7 @@ nodes:
         emit dept = dept
         emit total = sum(salary)
         emit $pipeline.last_total = sum(salary)
-  - type: output
+  - type: sink
     name: out
     input: agg
     config:
@@ -896,7 +896,7 @@ nodes:
       emit late_name = max(name) > ''M''
 
       '
-- type: output
+- type: sink
   name: out
   input: by_team
   config:
@@ -964,7 +964,7 @@ nodes:
       emit average = avg(amount)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -1022,7 +1022,7 @@ nodes:
       emit average = avg(amount)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -1076,7 +1076,7 @@ nodes:
       emit average = avg(amount)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -1140,7 +1140,7 @@ nodes:
       emit average = avg(amount)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:

--- a/crates/clinker-exec/tests/aggregate_materialized_fixes.rs
+++ b/crates/clinker-exec/tests/aggregate_materialized_fixes.rs
@@ -100,7 +100,7 @@ nodes:
       cxl: |
         emit category = category
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -179,7 +179,7 @@ nodes:
       group_by: []
       cxl: |
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: total
     config:
@@ -214,7 +214,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:

--- a/crates/clinker-exec/tests/aggregate_per_document_flush.rs
+++ b/crates/clinker-exec/tests/aggregate_per_document_flush.rs
@@ -85,7 +85,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -136,7 +136,7 @@ nodes:
         emit category = category
         emit n = count(*)
         emit sample = min(payload)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -354,7 +354,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -490,7 +490,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -613,7 +613,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -727,7 +727,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -843,7 +843,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -984,7 +984,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:

--- a/crates/clinker-exec/tests/aggregate_spill_cap.rs
+++ b/crates/clinker-exec/tests/aggregate_spill_cap.rs
@@ -68,7 +68,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: {AGG_NODE}
     config:

--- a/crates/clinker-exec/tests/aggregation_dispatch.rs
+++ b/crates/clinker-exec/tests/aggregation_dispatch.rs
@@ -81,7 +81,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: by_dept
   config:
@@ -131,7 +131,7 @@ nodes:
     cxl: 'emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: total
   config:

--- a/crates/clinker-exec/tests/auto_widen_integration.rs
+++ b/crates/clinker-exec/tests/auto_widen_integration.rs
@@ -156,7 +156,7 @@ nodes:
     cxl: |
       emit dept = dept
       emit total = sum(salary)
-- type: output
+- type: sink
   name: out
   input: agg
   config:
@@ -220,7 +220,7 @@ nodes:
       emit order_id = o.order_id
       emit product_id = o.product_id
       emit product_name = p.name
-- type: output
+- type: sink
   name: out
   input: enriched
   config:
@@ -303,7 +303,7 @@ nodes:
     on_miss: skip
     cxl: ""
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: enriched
   config:
@@ -387,7 +387,7 @@ nodes:
 - type: merge
   name: merged
   inputs: [src_a, src_b]
-- type: output
+- type: sink
   name: out
   input: merged
   config:
@@ -464,7 +464,7 @@ nodes:
     schema:
       - { name: id, type: string }
       - { name: name, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -517,7 +517,7 @@ nodes:
     path: in.csv
     schema:
       - { name: id, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -721,7 +721,7 @@ nodes:
     cxl: |
       emit id = id
       emit amount = amount.to_int()
-- type: output
+- type: sink
   name: out
   input: validate
   config:
@@ -812,7 +812,7 @@ nodes:
     schema:
       - { name: id, type: string }
       - { name: name, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -887,7 +887,7 @@ nodes:
   input: merged
   config:
     cxl: "emit id = id"
-- type: output
+- type: sink
   name: out
   input: passthrough
   config:
@@ -946,7 +946,7 @@ nodes:
 - type: merge
   name: merged
   inputs: [src_a, src_b]
-- type: output
+- type: sink
   name: out
   input: merged
   config:
@@ -1016,7 +1016,7 @@ nodes:
     schema:
       - { name: id, type: string }
       - { name: name, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -1055,7 +1055,7 @@ nodes:
     path: in.csv
     schema:
       - { name: id, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:

--- a/crates/clinker-exec/tests/batch_size_config.rs
+++ b/crates/clinker-exec/tests/batch_size_config.rs
@@ -25,7 +25,7 @@ nodes:
       batch_size: 64
       cxl: |
         emit id = id
-  - type: output
+  - type: sink
     name: out
     input: t
     config:
@@ -71,7 +71,7 @@ nodes:
     config:
       cxl: |
         emit id = id
-  - type: output
+  - type: sink
     name: out
     input: t
     config:
@@ -101,7 +101,7 @@ nodes:
       path: in.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -138,7 +138,7 @@ nodes:
       batch_size: 0
       cxl: |
         emit id = id
-  - type: output
+  - type: sink
     name: out
     input: t
     config:

--- a/crates/clinker-exec/tests/bind_schema_test.rs
+++ b/crates/clinker-exec/tests/bind_schema_test.rs
@@ -95,7 +95,7 @@ nodes:
       schema:
         - { name: a, type: string }
         - { name: b, type: int }
-  - type: output
+  - type: sink
     name: out1
     input: source1
     config:
@@ -156,7 +156,7 @@ nodes:
     input: src
     config:
       cxl: "emit y = x"
-  - type: output
+  - type: sink
     name: out
     input: tx
     config:
@@ -191,7 +191,7 @@ nodes:
     input: s1
     config:
       cxl: "emit doubled = id"
-  - type: output
+  - type: sink
     name: o1
     input: t1
     config:
@@ -264,7 +264,7 @@ nodes:
       schema:
         - { name: employee_id, type: string }
         - { name: salary, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -334,7 +334,7 @@ nodes:
       schema:
         - { name: employee_id, type: string }
         - { name: salary, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -404,7 +404,7 @@ nodes:
         - { name: employee_id, type: string }
         - { name: tenant, type: int }
         - { name: salary, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -464,7 +464,7 @@ nodes:
     input: src
     config:
       cxl: "emit doubled = amount"
-  - type: output
+  - type: sink
     name: out
     input: tx
     config:
@@ -534,7 +534,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [src_widen, src_drop]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -596,7 +596,7 @@ nodes:
       group_by:
         - dept
       cxl: "emit total = sum(salary)"
-  - type: output
+  - type: sink
     name: out
     input: agg
     config:
@@ -665,7 +665,7 @@ nodes:
       correlation_key: nonexistent
       schema:
         - { name: employee_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -722,7 +722,7 @@ nodes:
     use: ../compositions/passthrough_check.comp.yaml
     inputs:
       data: src
-  - type: output
+  - type: sink
     name: out
     input: passthrough.data
     config:
@@ -823,7 +823,7 @@ nodes:
         emit region = c.region
         emit amount = o.amount
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -873,7 +873,7 @@ nodes:
       path: in.csv
       schema:
         - { name: order_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -909,7 +909,7 @@ nodes:
       type: edifact
       path: dummy.edi
       schema: { generated: {} }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -962,7 +962,7 @@ nodes:
         split_fields:
           - { field: f08, components: 2 }
       schema: { generated: {} }
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:
@@ -1002,7 +1002,7 @@ nodes:
       type: swift
       path: dummy.mt
       schema: { generated: {} }
-  - type: output
+  - type: sink
     name: out
     input: mt
     config:
@@ -1034,7 +1034,7 @@ nodes:
       type: csv
       path: dummy.csv
       schema: { generated: {} }
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:

--- a/crates/clinker-exec/tests/branching.rs
+++ b/crates/clinker-exec/tests/branching.rs
@@ -552,7 +552,7 @@ nodes:
     cxl: 'emit doubled = name.concat("_doubled")
 
       '
-- type: output
+- type: sink
   name: dest
   input: calc
   config:
@@ -610,7 +610,7 @@ nodes:
     analytic_window:
       group_by:
       - dept
-- type: output
+- type: sink
   name: dest
   input: window_calc
   config:

--- a/crates/clinker-exec/tests/ck_aligned_partition_runtime.rs
+++ b/crates/clinker-exec/tests/ck_aligned_partition_runtime.rs
@@ -46,7 +46,7 @@ nodes:
       emit department = department
       emit amount = amount
       emit ratio = 1 / (amount - 30)
-- type: output
+- type: sink
   name: out
   input: ratio
   config:

--- a/crates/clinker-exec/tests/combine_build_direct_rollback.rs
+++ b/crates/clinker-exec/tests/combine_build_direct_rollback.rs
@@ -116,7 +116,7 @@ nodes:
         emit id = d.id
         emit ratio = d.amt / b.factor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:

--- a/crates/clinker-exec/tests/combine_datetime_nanos.rs
+++ b/crates/clinker-exec/tests/combine_datetime_nanos.rs
@@ -188,7 +188,7 @@ __SORT_BLD__
         emit did = drivers.did
         emit bid = builds.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -342,7 +342,7 @@ nodes:
       cxl: |
         emit ts = ts
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_ts
     config:

--- a/crates/clinker-exec/tests/combine_grouped_output_row_dlq.rs
+++ b/crates/clinker-exec/tests/combine_grouped_output_row_dlq.rs
@@ -98,7 +98,7 @@ nodes:
         emit id = d.id
         emit ratio = d.amt / b.factor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:

--- a/crates/clinker-exec/tests/common/branch_fixtures.rs
+++ b/crates/clinker-exec/tests/common/branch_fixtures.rs
@@ -26,6 +26,6 @@ pub fn branch_pipeline(name: &str, body: &str) -> String {
 - type: source\n  name: src\n  config:\n    name: src\n    type: csv\n    path: input.csv\n    schema:\n      - {{ name: id, type: string }}\n      - {{ name: amount, type: string }}\n\n\
 - type: transform\n  name: classify_emit\n  input: src\n  config:\n    cxl: 'emit amount_val = amount.to_int()\n\n      '\n\
 {body}\
-- type: output\n  name: dest\n  input: combine\n  config:\n    name: dest\n    type: csv\n    path: output.csv\n    include_unmapped: true\n"
+- type: sink\n  name: dest\n  input: combine\n  config:\n    name: dest\n    type: csv\n    path: output.csv\n    include_unmapped: true\n"
     )
 }


### PR DESCRIPTION
## Summary

- migrate 71 positive Sink fixtures across aggregation, schema binding, branching, and combine integration targets
- update the shared branching helper consumed by ten of the owned cases
- preserve all runtime scenarios and assertions unchanged

## Validation

- 13 exact affected integration targets (86 passed)
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This bounded integration corpus shard is stacked on #1104.

No production behavior, dependencies, telemetry vocabulary, or memory ownership changes here.
