### PR TITLE
Instrument credential lifecycle operations

### DIFF
--- a/crates/clinker-exec/src/telemetry.rs
+++ b/crates/clinker-exec/src/telemetry.rs
@@ -1669,9 +1669,49 @@ mod tests {
 
     use super::{
         AdmissionLane, AdmissionOutcome, DrainOutcome, DropReason, LogEvent, MAX_IDENTITY_BYTES,
-        RunCorrelation, Severity, SignalField, SpanFact, SpanName, SpanStatus, TRUNCATION_MARKER,
-        TelemetryArena, TelemetryProducer, TelemetryReceiver, bounded_utf8,
+        MetricKey, RunCorrelation, Severity, SignalField, SpanFact, SpanName, SpanStatus,
+        TRUNCATION_MARKER, TelemetryArena, TelemetryProducer, TelemetryReceiver, bounded_utf8,
     };
+
+    #[test]
+    fn lifecycle_metric_keys_have_one_stable_index_each() {
+        let expected = [
+            MetricKey::TransformStarted,
+            MetricKey::TransformCompleted,
+            MetricKey::TransformRecords,
+            MetricKey::TransformErrors,
+            MetricKey::CredentialResolveStarted,
+            MetricKey::CredentialResolveCompleted,
+            MetricKey::CredentialResolveFailed,
+            MetricKey::CredentialResolveInterrupted,
+            MetricKey::ResourceOpenStarted,
+            MetricKey::ResourceOpenCompleted,
+            MetricKey::ResourceOpenFailed,
+            MetricKey::ResourceOpenInterrupted,
+            MetricKey::CredentialRenewStarted,
+            MetricKey::CredentialRenewCompleted,
+            MetricKey::CredentialRenewFailed,
+            MetricKey::CredentialRenewInterrupted,
+            MetricKey::CredentialRevokeStarted,
+            MetricKey::CredentialRevokeCompleted,
+            MetricKey::CredentialRevokeFailed,
+            MetricKey::CredentialRevokeInterrupted,
+        ];
+
+        assert_eq!(MetricKey::COUNT, expected.len());
+        assert_eq!(MetricKey::ALL, expected);
+        for (index, key) in MetricKey::ALL.into_iter().enumerate() {
+            assert_eq!(key.index(), index, "{key:?} has a mismatched index");
+            assert_eq!(
+                MetricKey::ALL
+                    .iter()
+                    .filter(|candidate| **candidate == key)
+                    .count(),
+                1,
+                "{key:?} appears more than once"
+            );
+        }
+    }
 
     /// A policy whose only variable is the attribute cap under test. Declares
     /// one `allow` field and one `replace` field so both rendering paths are

--- a/crates/clinker-exec/src/telemetry.rs
+++ b/crates/clinker-exec/src/telemetry.rs
@@ -120,23 +120,74 @@ pub enum MetricKey {
     TransformCompleted,
     TransformRecords,
     TransformErrors,
+    CredentialResolveStarted,
+    CredentialResolveCompleted,
+    CredentialResolveFailed,
+    CredentialResolveInterrupted,
+    ResourceOpenStarted,
+    ResourceOpenCompleted,
+    ResourceOpenFailed,
+    ResourceOpenInterrupted,
+    CredentialRenewStarted,
+    CredentialRenewCompleted,
+    CredentialRenewFailed,
+    CredentialRenewInterrupted,
+    CredentialRevokeStarted,
+    CredentialRevokeCompleted,
+    CredentialRevokeFailed,
+    CredentialRevokeInterrupted,
 }
 
 impl MetricKey {
-    const ALL: [Self; 4] = [
+    /// Every fixed metric key in stable counter-index order.
+    pub const ALL: [Self; 20] = [
         Self::TransformStarted,
         Self::TransformCompleted,
         Self::TransformRecords,
         Self::TransformErrors,
+        Self::CredentialResolveStarted,
+        Self::CredentialResolveCompleted,
+        Self::CredentialResolveFailed,
+        Self::CredentialResolveInterrupted,
+        Self::ResourceOpenStarted,
+        Self::ResourceOpenCompleted,
+        Self::ResourceOpenFailed,
+        Self::ResourceOpenInterrupted,
+        Self::CredentialRenewStarted,
+        Self::CredentialRenewCompleted,
+        Self::CredentialRenewFailed,
+        Self::CredentialRenewInterrupted,
+        Self::CredentialRevokeStarted,
+        Self::CredentialRevokeCompleted,
+        Self::CredentialRevokeFailed,
+        Self::CredentialRevokeInterrupted,
     ];
-    const COUNT: usize = Self::ALL.len();
+    /// Number of entries in [`Self::ALL`].
+    pub const COUNT: usize = Self::ALL.len();
 
-    const fn index(self) -> usize {
+    /// Stable position of this key in the fixed counter array.
+    pub const fn index(self) -> usize {
         match self {
             Self::TransformStarted => 0,
             Self::TransformCompleted => 1,
             Self::TransformRecords => 2,
             Self::TransformErrors => 3,
+            Self::CredentialResolveStarted => 4,
+            Self::CredentialResolveCompleted => 5,
+            Self::CredentialResolveFailed => 6,
+            Self::CredentialResolveInterrupted => 7,
+            Self::ResourceOpenStarted => 8,
+            Self::ResourceOpenCompleted => 9,
+            Self::ResourceOpenFailed => 10,
+            Self::ResourceOpenInterrupted => 11,
+            Self::CredentialRenewStarted => 12,
+            Self::CredentialRenewCompleted => 13,
+            Self::CredentialRenewFailed => 14,
+            Self::CredentialRenewInterrupted => 15,
+            Self::CredentialRevokeStarted => 16,
+            Self::CredentialRevokeCompleted => 17,
+            Self::CredentialRevokeFailed => 18,
+            Self::CredentialRevokeInterrupted => 19,
         }
     }
 }
@@ -146,6 +197,10 @@ impl MetricKey {
 #[serde(rename_all = "snake_case")]
 pub enum SpanName {
     Transform,
+    CredentialResolve,
+    ResourceOpen,
+    CredentialRenew,
+    CredentialRevoke,
 }
 
 /// Bounded span result fact.

--- a/crates/clinker/src/credential_profile.rs
+++ b/crates/clinker/src/credential_profile.rs
@@ -690,11 +690,23 @@ fn resolve_explicit_profile_inner<'run>(
     requirement: &CredentialRequirement,
     producer: Option<&TelemetryProducer>,
 ) -> Result<LeasedCredentialHandle<'run>, CredentialResolutionError> {
+    observe_operation(producer, RESOLVE_SIGNALS, || {
+        resolve_explicit_profile_attempt(selected, catalog, requirement, producer)
+    })
+}
+
+fn resolve_explicit_profile_attempt<'run>(
+    selected: &CredentialProfileName,
+    catalog: &CredentialProfileCatalog<'run>,
+    requirement: &CredentialRequirement,
+    producer: Option<&TelemetryProducer>,
+) -> Result<LeasedCredentialHandle<'run>, CredentialResolutionError> {
     let provider = compatible_provider(selected, catalog, requirement)?;
     let declared_lease_bytes = provider
         .lease_retained_bytes(requirement)
         .map_err(resolution_provider_error)?;
-    let mut lease = observe_operation(producer, RESOLVE_SIGNALS, || provider.resolve(requirement))
+    let mut lease = provider
+        .resolve(requirement)
         .map_err(resolution_provider_error)?;
     if lease.retained_bytes() != declared_lease_bytes {
         let _ = observe_operation(producer, REVOKE_SIGNALS, || lease.revoke());
@@ -702,9 +714,12 @@ fn resolve_explicit_profile_inner<'run>(
             CredentialResolutionErrorKind::RetainedBytesMismatch,
         ));
     }
-    let retained_bytes = handle_dynamic_bytes(requirement, declared_lease_bytes).ok_or(
-        CredentialResolutionError::new(CredentialResolutionErrorKind::RetainedBytesMismatch),
-    )?;
+    let Some(retained_bytes) = handle_dynamic_bytes(requirement, declared_lease_bytes) else {
+        let _ = observe_operation(producer, REVOKE_SIGNALS, || lease.revoke());
+        return Err(CredentialResolutionError::new(
+            CredentialResolutionErrorKind::RetainedBytesMismatch,
+        ));
+    };
     Ok(LeasedCredentialHandle {
         requirement_name: requirement.name().clone(),
         provider_kind: requirement.provider_kind().clone(),
@@ -963,6 +978,17 @@ where
         selected: &CredentialProfileName,
         requirement: &CredentialRequirement,
     ) -> Result<&LeasedCredentialHandle<'run>, CredentialRegistryError> {
+        let telemetry = self.telemetry.clone();
+        observe_operation(telemetry.as_ref(), RESOLVE_SIGNALS, || {
+            self.acquire_attempt(selected, requirement)
+        })
+    }
+
+    fn acquire_attempt(
+        &mut self,
+        selected: &CredentialProfileName,
+        requirement: &CredentialRequirement,
+    ) -> Result<&LeasedCredentialHandle<'run>, CredentialRegistryError> {
         self.honor_memory_signals()?;
         if self.handles.len() >= self.catalog.limits.max_live_handles {
             return Err(self.fail_and_close(CredentialRegistryErrorKind::HandleLimitExceeded));
@@ -996,9 +1022,7 @@ where
             return Err(self.fail_and_close(CredentialRegistryErrorKind::MemoryLimitExceeded));
         }
 
-        let mut lease = match observe_operation(self.telemetry.as_ref(), RESOLVE_SIGNALS, || {
-            provider.resolve(requirement)
-        }) {
+        let mut lease = match provider.resolve(requirement) {
             Ok(lease) => lease,
             Err(failure) => {
                 self.memory_handle.set_bytes(self.retained_bytes);

--- a/crates/clinker/src/credential_profile.rs
+++ b/crates/clinker/src/credential_profile.rs
@@ -11,6 +11,9 @@ use std::sync::Arc;
 use clinker_exec::pipeline::memory::{
     ConsumerHandle, ConsumerId, ConsumerSpillError, MemoryArbitrator, MemoryConsumer,
 };
+use clinker_exec::telemetry::{
+    MetricKey, SpanFact, SpanName, SpanStatus, TelemetryProducer, unix_nanos_now,
+};
 use clinker_plan::credentials::{
     CredentialCapability, CredentialHandleUnits, CredentialLifetime, CredentialProviderKind,
     CredentialRenewal, CredentialRequirement, CredentialRequirementName, CredentialRevocation,
@@ -68,6 +71,60 @@ pub const DEFAULT_MAX_CREDENTIAL_PROVIDERS: usize = 256;
 pub const DEFAULT_MAX_CREDENTIAL_DEFINITION_BYTES: usize = 1_048_576;
 /// Default maximum number of simultaneously live credential handles.
 pub const DEFAULT_MAX_LIVE_CREDENTIAL_HANDLES: usize = 256;
+
+const CREDENTIAL_LIFECYCLE_SCOPE: &str = "credential-lifecycle";
+
+#[derive(Clone, Copy)]
+struct OperationSignals {
+    started: MetricKey,
+    completed: MetricKey,
+    failed: MetricKey,
+    span: SpanName,
+}
+
+const RESOLVE_SIGNALS: OperationSignals = OperationSignals {
+    started: MetricKey::CredentialResolveStarted,
+    completed: MetricKey::CredentialResolveCompleted,
+    failed: MetricKey::CredentialResolveFailed,
+    span: SpanName::CredentialResolve,
+};
+
+const REVOKE_SIGNALS: OperationSignals = OperationSignals {
+    started: MetricKey::CredentialRevokeStarted,
+    completed: MetricKey::CredentialRevokeCompleted,
+    failed: MetricKey::CredentialRevokeFailed,
+    span: SpanName::CredentialRevoke,
+};
+
+fn observe_operation<T, E>(
+    producer: Option<&TelemetryProducer>,
+    signals: OperationSignals,
+    operation: impl FnOnce() -> Result<T, E>,
+) -> Result<T, E> {
+    let Some(producer) = producer else {
+        return operation();
+    };
+
+    let started_at_unix_nanos = unix_nanos_now();
+    producer.record_metric(signals.started, 1);
+    let result = operation();
+    let status = if result.is_ok() {
+        producer.record_metric(signals.completed, 1);
+        SpanStatus::Ok
+    } else {
+        producer.record_metric(signals.failed, 1);
+        SpanStatus::Error
+    };
+    let ended_at_unix_nanos = unix_nanos_now().max(started_at_unix_nanos);
+    let _ = producer.emit_span(SpanFact {
+        name: signals.span,
+        status,
+        logical_node: CREDENTIAL_LIFECYCLE_SCOPE,
+        started_at_unix_nanos,
+        ended_at_unix_nanos,
+    });
+    result
+}
 
 /// Fixed admission limits for profile definitions and live handles.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -456,6 +513,7 @@ pub struct LeasedCredentialHandle<'run> {
     retained_bytes: u64,
     lease: Box<dyn CredentialLease>,
     revoked: bool,
+    telemetry: Option<TelemetryProducer>,
     _run: PhantomData<&'run CredentialProfile<'run>>,
 }
 
@@ -483,7 +541,9 @@ impl LeasedCredentialHandle<'_> {
         if self.revoked {
             return Ok(());
         }
-        let result = self.lease.revoke();
+        let result = observe_operation(self.telemetry.as_ref(), REVOKE_SIGNALS, || {
+            self.lease.revoke()
+        });
         self.revoked = true;
         result
     }
@@ -606,15 +666,38 @@ pub fn resolve_explicit_profile<'run>(
     catalog: &CredentialProfileCatalog<'run>,
     requirement: &CredentialRequirement,
 ) -> Result<LeasedCredentialHandle<'run>, CredentialResolutionError> {
+    resolve_explicit_profile_inner(selected, catalog, requirement, None)
+}
+
+/// Resolve one supplied requirement and emit lifecycle signals when configured.
+///
+/// The emitted vocabulary is closed and carries no profile name, provider
+/// kind, logical requirement, lease payload, or record value. Signal admission
+/// is optional: a dropped completed span cannot change the returned handle or
+/// error, and revocation remains owned by the handle.
+pub fn resolve_explicit_profile_with_telemetry<'run>(
+    selected: &CredentialProfileName,
+    catalog: &CredentialProfileCatalog<'run>,
+    requirement: &CredentialRequirement,
+    producer: &TelemetryProducer,
+) -> Result<LeasedCredentialHandle<'run>, CredentialResolutionError> {
+    resolve_explicit_profile_inner(selected, catalog, requirement, Some(producer))
+}
+
+fn resolve_explicit_profile_inner<'run>(
+    selected: &CredentialProfileName,
+    catalog: &CredentialProfileCatalog<'run>,
+    requirement: &CredentialRequirement,
+    producer: Option<&TelemetryProducer>,
+) -> Result<LeasedCredentialHandle<'run>, CredentialResolutionError> {
     let provider = compatible_provider(selected, catalog, requirement)?;
     let declared_lease_bytes = provider
         .lease_retained_bytes(requirement)
         .map_err(resolution_provider_error)?;
-    let mut lease = provider
-        .resolve(requirement)
+    let mut lease = observe_operation(producer, RESOLVE_SIGNALS, || provider.resolve(requirement))
         .map_err(resolution_provider_error)?;
     if lease.retained_bytes() != declared_lease_bytes {
-        let _ = lease.revoke();
+        let _ = observe_operation(producer, REVOKE_SIGNALS, || lease.revoke());
         return Err(CredentialResolutionError::new(
             CredentialResolutionErrorKind::RetainedBytesMismatch,
         ));
@@ -629,6 +712,7 @@ pub fn resolve_explicit_profile<'run>(
         retained_bytes,
         lease,
         revoked: false,
+        telemetry: producer.cloned(),
         _run: PhantomData,
     })
 }
@@ -784,6 +868,7 @@ where
     consumer_id: Option<ConsumerId>,
     handles: Vec<LeasedCredentialHandle<'run>>,
     retained_bytes: u64,
+    telemetry: Option<TelemetryProducer>,
 }
 
 impl<'catalog, 'run> CredentialHandleRegistry<'catalog, 'run>
@@ -804,6 +889,33 @@ where
     pub fn new(
         arbitrator: &'catalog MemoryArbitrator,
         catalog: &'catalog CredentialProfileCatalog<'run>,
+    ) -> Result<Self, CredentialRegistryError> {
+        Self::new_inner(arbitrator, catalog, None)
+    }
+
+    /// Create a registry whose actual resolve and revoke calls emit lifecycle
+    /// signals through the supplied fixed arena.
+    ///
+    /// Signal admission is behavior-neutral. The producer is a fixed set of
+    /// shared handles, and each preallocated credential slot already includes
+    /// the size of its optional producer clone in registered table bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CredentialRegistryErrorKind::AllocationFailed`] under the
+    /// same fixed-table conditions as [`Self::new`].
+    pub fn new_with_telemetry(
+        arbitrator: &'catalog MemoryArbitrator,
+        catalog: &'catalog CredentialProfileCatalog<'run>,
+        producer: TelemetryProducer,
+    ) -> Result<Self, CredentialRegistryError> {
+        Self::new_inner(arbitrator, catalog, Some(producer))
+    }
+
+    fn new_inner(
+        arbitrator: &'catalog MemoryArbitrator,
+        catalog: &'catalog CredentialProfileCatalog<'run>,
+        telemetry: Option<TelemetryProducer>,
     ) -> Result<Self, CredentialRegistryError> {
         let mut handles = Vec::new();
         handles
@@ -830,6 +942,7 @@ where
             consumer_id: Some(consumer_id),
             handles,
             retained_bytes: table_bytes,
+            telemetry,
         })
     }
 
@@ -883,7 +996,9 @@ where
             return Err(self.fail_and_close(CredentialRegistryErrorKind::MemoryLimitExceeded));
         }
 
-        let mut lease = match provider.resolve(requirement) {
+        let mut lease = match observe_operation(self.telemetry.as_ref(), RESOLVE_SIGNALS, || {
+            provider.resolve(requirement)
+        }) {
             Ok(lease) => lease,
             Err(failure) => {
                 self.memory_handle.set_bytes(self.retained_bytes);
@@ -893,7 +1008,7 @@ where
             }
         };
         if lease.retained_bytes() != lease_bytes {
-            let _ = lease.revoke();
+            let _ = observe_operation(self.telemetry.as_ref(), REVOKE_SIGNALS, || lease.revoke());
             self.memory_handle.set_bytes(self.retained_bytes);
             return Err(self.fail_and_close(CredentialRegistryErrorKind::RetainedBytesMismatch));
         }
@@ -905,6 +1020,7 @@ where
             retained_bytes: dynamic_bytes,
             lease,
             revoked: false,
+            telemetry: self.telemetry.clone(),
             _run: PhantomData,
         });
         self.retained_bytes = prospective_bytes;

--- a/crates/clinker/src/observability/export.rs
+++ b/crates/clinker/src/observability/export.rs
@@ -1892,6 +1892,95 @@ mod tests {
         serde_json::to_value(value).expect("envelope serializes")
     }
 
+    #[test]
+    fn lifecycle_metric_and_span_wire_names_are_stable() {
+        let metric_names = [
+            (MetricKey::TransformStarted, "clinker.transform.started"),
+            (MetricKey::TransformCompleted, "clinker.transform.completed"),
+            (MetricKey::TransformRecords, "clinker.transform.records"),
+            (MetricKey::TransformErrors, "clinker.transform.errors"),
+            (
+                MetricKey::CredentialResolveStarted,
+                "clinker.credential.resolve.started",
+            ),
+            (
+                MetricKey::CredentialResolveCompleted,
+                "clinker.credential.resolve.completed",
+            ),
+            (
+                MetricKey::CredentialResolveFailed,
+                "clinker.credential.resolve.failed",
+            ),
+            (
+                MetricKey::CredentialResolveInterrupted,
+                "clinker.credential.resolve.interrupted",
+            ),
+            (
+                MetricKey::ResourceOpenStarted,
+                "clinker.resource.open.started",
+            ),
+            (
+                MetricKey::ResourceOpenCompleted,
+                "clinker.resource.open.completed",
+            ),
+            (
+                MetricKey::ResourceOpenFailed,
+                "clinker.resource.open.failed",
+            ),
+            (
+                MetricKey::ResourceOpenInterrupted,
+                "clinker.resource.open.interrupted",
+            ),
+            (
+                MetricKey::CredentialRenewStarted,
+                "clinker.credential.renew.started",
+            ),
+            (
+                MetricKey::CredentialRenewCompleted,
+                "clinker.credential.renew.completed",
+            ),
+            (
+                MetricKey::CredentialRenewFailed,
+                "clinker.credential.renew.failed",
+            ),
+            (
+                MetricKey::CredentialRenewInterrupted,
+                "clinker.credential.renew.interrupted",
+            ),
+            (
+                MetricKey::CredentialRevokeStarted,
+                "clinker.credential.revoke.started",
+            ),
+            (
+                MetricKey::CredentialRevokeCompleted,
+                "clinker.credential.revoke.completed",
+            ),
+            (
+                MetricKey::CredentialRevokeFailed,
+                "clinker.credential.revoke.failed",
+            ),
+            (
+                MetricKey::CredentialRevokeInterrupted,
+                "clinker.credential.revoke.interrupted",
+            ),
+        ];
+        assert_eq!(metric_names.len(), MetricKey::COUNT);
+        for (key, expected) in metric_names {
+            assert_eq!(metric_name(key), expected, "stable name for {key:?}");
+        }
+
+        let span_names = [
+            (SpanName::Transform, "clinker.transform"),
+            (SpanName::CredentialResolve, "clinker.credential.resolve"),
+            (SpanName::ResourceOpen, "clinker.resource.open"),
+            (SpanName::CredentialRenew, "clinker.credential.renew"),
+            (SpanName::CredentialRevoke, "clinker.credential.revoke"),
+        ];
+        for (name, expected) in span_names {
+            assert_eq!(span_name(name), expected, "stable name for {name:?}");
+        }
+    }
+
     fn spans_of(envelope: &Value) -> &Vec<Value> {
         envelope["resourceSpans"][0]["scopeSpans"][0]["spans"]
             .as_array()

--- a/crates/clinker/src/observability/export.rs
+++ b/crates/clinker/src/observability/export.rs
@@ -1649,12 +1649,32 @@ fn metric_name(key: MetricKey) -> &'static str {
         MetricKey::TransformCompleted => "clinker.transform.completed",
         MetricKey::TransformRecords => "clinker.transform.records",
         MetricKey::TransformErrors => "clinker.transform.errors",
+        MetricKey::CredentialResolveStarted => "clinker.credential.resolve.started",
+        MetricKey::CredentialResolveCompleted => "clinker.credential.resolve.completed",
+        MetricKey::CredentialResolveFailed => "clinker.credential.resolve.failed",
+        MetricKey::CredentialResolveInterrupted => "clinker.credential.resolve.interrupted",
+        MetricKey::ResourceOpenStarted => "clinker.resource.open.started",
+        MetricKey::ResourceOpenCompleted => "clinker.resource.open.completed",
+        MetricKey::ResourceOpenFailed => "clinker.resource.open.failed",
+        MetricKey::ResourceOpenInterrupted => "clinker.resource.open.interrupted",
+        MetricKey::CredentialRenewStarted => "clinker.credential.renew.started",
+        MetricKey::CredentialRenewCompleted => "clinker.credential.renew.completed",
+        MetricKey::CredentialRenewFailed => "clinker.credential.renew.failed",
+        MetricKey::CredentialRenewInterrupted => "clinker.credential.renew.interrupted",
+        MetricKey::CredentialRevokeStarted => "clinker.credential.revoke.started",
+        MetricKey::CredentialRevokeCompleted => "clinker.credential.revoke.completed",
+        MetricKey::CredentialRevokeFailed => "clinker.credential.revoke.failed",
+        MetricKey::CredentialRevokeInterrupted => "clinker.credential.revoke.interrupted",
     }
 }
 
 fn span_name(name: SpanName) -> &'static str {
     match name {
         SpanName::Transform => "clinker.transform",
+        SpanName::CredentialResolve => "clinker.credential.resolve",
+        SpanName::ResourceOpen => "clinker.resource.open",
+        SpanName::CredentialRenew => "clinker.credential.renew",
+        SpanName::CredentialRevoke => "clinker.credential.revoke",
     }
 }
 

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -5,6 +5,11 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::Duration;
 
 use clinker_exec::pipeline::memory::MemoryArbitrator;
+use clinker_exec::telemetry::{
+    AdmissionOutcome, MetricKey, SpanFact, SpanName, SpanStatus, TelemetryArena, TelemetryProducer,
+    TelemetryReceiver,
+};
+use clinker_plan::config::ClinkerToml;
 use clinker_plan::credentials::{
     CredentialCapability, CredentialHandleUnits, CredentialLifetime, CredentialProviderKind,
     CredentialRenewal, CredentialRequirement, CredentialRequirementName, CredentialRevocation,
@@ -18,7 +23,7 @@ use credential_profile::{
     CredentialProfileAdmissionErrorKind, CredentialProfileCatalog, CredentialProfileLimits,
     CredentialProfileName, CredentialProvider, CredentialProviderFailure,
     CredentialRegistryErrorKind, CredentialResolutionErrorKind, LeasedCredentialHandle,
-    resolve_explicit_profile,
+    resolve_explicit_profile, resolve_explicit_profile_with_telemetry,
 };
 
 fn requirement(capabilities: Vec<CredentialCapability>) -> CredentialRequirement {
@@ -212,6 +217,59 @@ fn profile_limits(
 
 fn memory_arbitrator(limit: u64) -> MemoryArbitrator {
     MemoryArbitrator::with_policy(limit, 0.80, 0.70, MemoryArbitrator::default_policy())
+}
+
+fn telemetry_arena() -> (TelemetryProducer, TelemetryReceiver) {
+    let config = r#"
+[observability]
+arena_bytes = "768KB"
+ordinary_lane_bytes = "512KB"
+high_severity_lane_bytes = "256KB"
+max_batch_bytes = "8KB"
+max_attributes_per_event = 4
+max_attribute_bytes = "64B"
+drop_policy = "drop_newest"
+sample_every = 1
+rate_limit_per_second = 100000
+rate_limit_burst = 100000
+flush_timeout_ms = 1000
+
+[observability.otlp]
+endpoint = "https://collector.invalid"
+connect_timeout_ms = 100
+request_timeout_ms = 200
+retry_max_attempts = 1
+retry_total_timeout_ms = 500
+max_response_bytes = "1KB"
+
+[observability.otlp.auth]
+mode = "none"
+"#;
+    let policy = ClinkerToml::parse(config)
+        .expect("telemetry policy parses")
+        .resolve_observability(None)
+        .expect("telemetry policy resolves");
+    TelemetryArena::reserve(&policy).expect("telemetry arena reserves")
+}
+
+fn saturate_ordinary_lane(producer: &TelemetryProducer) {
+    for sequence in 0..20_000_u64 {
+        let outcome = producer.emit_span(SpanFact {
+            name: SpanName::Transform,
+            status: SpanStatus::Ok,
+            logical_node: "fixed-saturation-probe",
+            started_at_unix_nanos: sequence,
+            ended_at_unix_nanos: sequence,
+        });
+        if outcome.is_full() {
+            return;
+        }
+        assert!(
+            matches!(outcome, AdmissionOutcome::Accepted { .. }),
+            "saturation probe was dropped for an unexpected reason: {outcome:?}"
+        );
+    }
+    panic!("ordinary telemetry lane did not reach its fixed capacity");
 }
 
 fn provider_failure_kind(failure: CredentialProviderFailure) -> CredentialResolutionErrorKind {
@@ -979,4 +1037,230 @@ fn cleanup_revoke_failure_still_releases_every_handle_and_unregisters() {
             "revoke-3", "drop-3", "revoke-2", "drop-2", "revoke-1", "drop-1",
         ]
     );
+}
+
+#[test]
+fn lifecycle_resolve_and_revoke_emit_complete_redacted_signals() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("secret-profile-name").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = admitted_profiles(&profiles);
+    let selected =
+        CredentialProfileName::parse("secret-profile-name").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    let (producer, receiver) = telemetry_arena();
+
+    let handle =
+        resolve_explicit_profile_with_telemetry(&selected, &catalog, &requirement, &producer)
+            .expect("observed resolution succeeds");
+    drop(handle);
+
+    let batch = receiver
+        .try_recv_batch()
+        .expect("credential lifecycle signals are drainable");
+    for key in [
+        MetricKey::CredentialResolveStarted,
+        MetricKey::CredentialResolveCompleted,
+        MetricKey::CredentialRevokeStarted,
+        MetricKey::CredentialRevokeCompleted,
+    ] {
+        assert_eq!(batch.metric(key), 1, "one {key:?}");
+    }
+    for key in [
+        MetricKey::CredentialResolveFailed,
+        MetricKey::CredentialResolveInterrupted,
+        MetricKey::ResourceOpenStarted,
+        MetricKey::ResourceOpenCompleted,
+        MetricKey::ResourceOpenFailed,
+        MetricKey::ResourceOpenInterrupted,
+        MetricKey::CredentialRenewStarted,
+        MetricKey::CredentialRenewCompleted,
+        MetricKey::CredentialRenewFailed,
+        MetricKey::CredentialRenewInterrupted,
+        MetricKey::CredentialRevokeFailed,
+        MetricKey::CredentialRevokeInterrupted,
+    ] {
+        assert_eq!(
+            batch.metric(key),
+            0,
+            "an operation seam that did not run must not emit {key:?}"
+        );
+    }
+    assert_eq!(batch.traces().len(), 2);
+    assert_eq!(batch.traces()[0].name, SpanName::CredentialResolve);
+    assert_eq!(batch.traces()[0].status, SpanStatus::Ok);
+    assert_eq!(batch.traces()[1].name, SpanName::CredentialRevoke);
+    assert_eq!(batch.traces()[1].status, SpanStatus::Ok);
+    assert!(batch.traces().iter().all(|span| {
+        span.logical_node == "credential-lifecycle"
+            && span.started_at_unix_nanos <= span.ended_at_unix_nanos
+    }));
+
+    let representations = [
+        serde_json::to_string(&batch).expect("telemetry batch serializes"),
+        format!("{batch:?}"),
+    ];
+    for representation in representations {
+        for forbidden in [
+            "secret-profile-name",
+            "orders.api",
+            "request-signer",
+            "lease-secret-must-not-escape",
+        ] {
+            assert!(
+                !representation.contains(forbidden),
+                "credential context escaped into telemetry: {representation}"
+            );
+        }
+    }
+}
+
+#[test]
+fn lifecycle_failed_resolve_and_revoke_report_closed_failures() {
+    let mut resolve_provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    resolve_provider.failure = Some(CredentialProviderFailure::Refused);
+    let resolve_providers: [&dyn CredentialProvider; 1] = [&resolve_provider];
+    let resolve_profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("failure-profile").expect("valid explicit profile"),
+        &resolve_providers,
+    )];
+    let resolve_catalog = admitted_profiles(&resolve_profiles);
+    let selected = CredentialProfileName::parse("failure-profile").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    let (resolve_producer, resolve_receiver) = telemetry_arena();
+
+    let error = resolve_explicit_profile_with_telemetry(
+        &selected,
+        &resolve_catalog,
+        &requirement,
+        &resolve_producer,
+    )
+    .expect_err("provider refusal remains the operation result");
+    assert_eq!(error.kind(), CredentialResolutionErrorKind::ProviderRefused);
+    let resolve_batch = resolve_receiver
+        .try_recv_batch()
+        .expect("failed resolve signals are drainable");
+    assert_eq!(resolve_batch.metric(MetricKey::CredentialResolveStarted), 1);
+    assert_eq!(resolve_batch.metric(MetricKey::CredentialResolveFailed), 1);
+    assert_eq!(
+        resolve_batch.metric(MetricKey::CredentialResolveCompleted),
+        0
+    );
+    assert_eq!(resolve_batch.traces().len(), 1);
+    assert_eq!(resolve_batch.traces()[0].name, SpanName::CredentialResolve);
+    assert_eq!(resolve_batch.traces()[0].status, SpanStatus::Error);
+
+    let mut revoke_provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    revoke_provider.revoke_failure_at = Some(1);
+    let revoke_providers: [&dyn CredentialProvider; 1] = [&revoke_provider];
+    let revoke_profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("failure-profile").expect("valid explicit profile"),
+        &revoke_providers,
+    )];
+    let revoke_catalog = admitted_profiles(&revoke_profiles);
+    let arbitrator = memory_arbitrator(u64::MAX);
+    let (revoke_producer, revoke_receiver) = telemetry_arena();
+    let mut registry =
+        CredentialHandleRegistry::new_with_telemetry(&arbitrator, &revoke_catalog, revoke_producer)
+            .expect("observed registry starts");
+    registry
+        .acquire(&selected, &requirement)
+        .expect("credential resolves before failed cleanup");
+    let error = registry.close().expect_err("revoke failure remains typed");
+    assert_eq!(error.kind(), CredentialRegistryErrorKind::CleanupFailed);
+
+    let revoke_batch = revoke_receiver
+        .try_recv_batch()
+        .expect("failed revoke signals are drainable");
+    assert_eq!(revoke_batch.metric(MetricKey::CredentialRevokeStarted), 1);
+    assert_eq!(revoke_batch.metric(MetricKey::CredentialRevokeFailed), 1);
+    assert_eq!(revoke_batch.metric(MetricKey::CredentialRevokeCompleted), 0);
+    assert!(revoke_batch.traces().iter().any(|span| {
+        span.name == SpanName::CredentialRevoke && span.status == SpanStatus::Error
+    }));
+}
+
+#[test]
+fn admission_loss_preserves_resolution_and_reverse_cleanup() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let events = Arc::clone(&provider.events);
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("saturated-profile").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 2))
+        .expect("bounded profile catalog");
+    let selected =
+        CredentialProfileName::parse("saturated-profile").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    let arbitrator = memory_arbitrator(u64::MAX);
+    let (producer, receiver) = telemetry_arena();
+    saturate_ordinary_lane(&producer);
+    let drops_before = producer.snapshot().full_drops;
+    let mut registry =
+        CredentialHandleRegistry::new_with_telemetry(&arbitrator, &catalog, producer.clone())
+            .expect("observed registry starts under saturated telemetry");
+
+    registry
+        .acquire(&selected, &requirement)
+        .expect("first result ignores telemetry admission");
+    registry
+        .acquire(&selected, &requirement)
+        .expect("second result ignores telemetry admission");
+    registry
+        .close()
+        .expect("cleanup ignores telemetry admission");
+
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(provider.drops.load(Ordering::SeqCst), 2);
+    assert_eq!(arbitrator.consumer_count(), 0);
+    assert_eq!(
+        *events.lock().expect("fixture event mutex"),
+        ["revoke-2", "drop-2", "revoke-1", "drop-1"]
+    );
+    assert!(
+        producer.snapshot().full_drops >= drops_before.saturating_add(4),
+        "each completed resolve/revoke span may be dropped without changing behavior"
+    );
+    let batch = receiver
+        .try_recv_batch()
+        .expect("fixed counters remain drainable from a full arena");
+    assert_eq!(batch.metric(MetricKey::CredentialResolveStarted), 2);
+    assert_eq!(batch.metric(MetricKey::CredentialResolveCompleted), 2);
+    assert_eq!(batch.metric(MetricKey::CredentialRevokeStarted), 2);
+    assert_eq!(batch.metric(MetricKey::CredentialRevokeCompleted), 2);
+    assert!(batch.traces().iter().all(|span| {
+        !matches!(
+            span.name,
+            SpanName::CredentialResolve | SpanName::CredentialRevoke
+        )
+    }));
 }

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -1202,6 +1202,91 @@ fn lifecycle_failed_resolve_and_revoke_report_closed_failures() {
 }
 
 #[test]
+fn lifecycle_early_compatibility_failure_closes_one_resolve_attempt() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("early-failure").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = admitted_profiles(&profiles);
+    let selected = CredentialProfileName::parse("early-failure").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::OpenSession]);
+    let (producer, receiver) = telemetry_arena();
+
+    let error =
+        resolve_explicit_profile_with_telemetry(&selected, &catalog, &requirement, &producer)
+            .expect_err("unsupported capability fails before provider allocation");
+
+    assert_eq!(
+        error.kind(),
+        CredentialResolutionErrorKind::UnsupportedCapability
+    );
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 0);
+    let batch = receiver
+        .try_recv_batch()
+        .expect("failed resolve attempt is drainable");
+    assert_eq!(batch.metric(MetricKey::CredentialResolveStarted), 1);
+    assert_eq!(batch.metric(MetricKey::CredentialResolveFailed), 1);
+    assert_eq!(batch.metric(MetricKey::CredentialResolveCompleted), 0);
+    assert_eq!(batch.traces().len(), 1);
+    assert_eq!(batch.traces()[0].name, SpanName::CredentialResolve);
+    assert_eq!(batch.traces()[0].status, SpanStatus::Error);
+}
+
+#[test]
+fn lifecycle_registry_preallocation_failure_closes_one_resolve_attempt() {
+    let provider = provider(
+        vec![CredentialCapability::AuthenticateRequest],
+        vec![CredentialLifetime::Run],
+        true,
+        true,
+        2,
+    );
+    let providers: [&dyn CredentialProvider; 1] = [&provider];
+    let profiles = [CredentialProfile::new(
+        CredentialProfileName::parse("memory-failure").expect("valid explicit profile"),
+        &providers,
+    )];
+    let catalog = CredentialProfileCatalog::admit(&profiles, profile_limits(1, 1, usize::MAX, 1))
+        .expect("bounded profile catalog");
+    let selected = CredentialProfileName::parse("memory-failure").expect("valid explicit profile");
+    let requirement = requirement(vec![CredentialCapability::AuthenticateRequest]);
+    let arbitrator = memory_arbitrator(0);
+    let (producer, receiver) = telemetry_arena();
+    let mut registry =
+        CredentialHandleRegistry::new_with_telemetry(&arbitrator, &catalog, producer)
+            .expect("registry reserves its fixed table");
+
+    let error = registry
+        .acquire(&selected, &requirement)
+        .expect_err("run memory rejects the lease before provider allocation");
+
+    assert_eq!(
+        error.kind(),
+        CredentialRegistryErrorKind::MemoryLimitExceeded
+    );
+    assert_eq!(provider.resolve_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(registry.live_handle_count(), 0);
+    assert_eq!(arbitrator.consumer_count(), 0);
+    let batch = receiver
+        .try_recv_batch()
+        .expect("failed registry resolve attempt is drainable");
+    assert_eq!(batch.metric(MetricKey::CredentialResolveStarted), 1);
+    assert_eq!(batch.metric(MetricKey::CredentialResolveFailed), 1);
+    assert_eq!(batch.metric(MetricKey::CredentialResolveCompleted), 0);
+    assert_eq!(batch.traces().len(), 1);
+    assert_eq!(batch.traces()[0].name, SpanName::CredentialResolve);
+    assert_eq!(batch.traces()[0].status, SpanStatus::Error);
+}
+
+#[test]
 fn admission_loss_preserves_resolution_and_reverse_cleanup() {
     let provider = provider(
         vec![CredentialCapability::AuthenticateRequest],


### PR DESCRIPTION
## Summary

- add closed fixed-cardinality lifecycle metrics for credential resolve, resource open, credential renew, and credential revoke
- emit exactly one completed span and outcome for each full resolve attempt and each real revoke operation
- keep open, renew, and interruption vocabulary silent until those operation seams exist
- add exhaustive metric index and exporter wire-name coverage

## Validation

- credential profile target (22 passed)
- telemetry unit tests (22 passed)
- exporter tests (17 passed)
- Clippy for `clinker-exec` and `clinker` with warnings denied
- `cargo fmt --all --check`
- `git diff --check`

## Stack

This is stacked on #1099, which adds the bounded live-handle registry instrumented here.

## Contracts

- Signals carry only a fixed lifecycle scope, status, and timestamps—never profile names, provider identifiers, logical references, tokens, secrets, records, or resource IDs.
- Compatibility and pre-allocation failures still close exactly one failed resolve span without calling the provider.
- Arena saturation cannot alter resolution, revocation, cleanup, or returned errors.
- The telemetry arena and metric arrays remain fixed-sized; per-handle producer storage is included in the precharged registry slot.
- Lineage is unaffected because no row, field, routing, or dataset behavior changes.
