### PR TITLE
Migrate combine and composition fixtures to Sink

### DIFF
--- a/crates/clinker-exec/tests/combine_iejoin_prop.rs
+++ b/crates/clinker-exec/tests/combine_iejoin_prop.rs
@@ -476,7 +476,7 @@ nodes:
         emit did = drivers.did
         emit bid = builds.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -564,7 +564,7 @@ nodes:
         emit did = drivers.did
         emit bid = builds.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -1003,7 +1003,7 @@ nodes:
         emit did = drivers.did
         emit bid = builds.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -1216,7 +1216,7 @@ nodes:
         emit bid = builds.bid
         emit ratio = drivers.k1 / builds.factor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -1349,7 +1349,7 @@ nodes:
         emit did = drivers.did
         emit bid = builds.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -1488,7 +1488,7 @@ nodes:
         emit did = drivers.did
         emit bid = builds.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -1606,7 +1606,7 @@ nodes:
         emit did = drivers.did
         emit bid = builds.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:

--- a/crates/clinker-exec/tests/combine_match_first_body_skip.rs
+++ b/crates/clinker-exec/tests/combine_match_first_body_skip.rs
@@ -159,7 +159,7 @@ nodes:
       propagate_ck: driver
       cxl: |
 {BODY}
-  - type: output
+  - type: sink
     name: out
     input: j
     config:
@@ -224,7 +224,7 @@ nodes:
       propagate_ck: driver
       cxl: |
 {BODY}
-  - type: output
+  - type: sink
     name: out
     input: j
     config:
@@ -278,7 +278,7 @@ nodes:
       propagate_ck: driver
       cxl: |
 {BODY}
-  - type: output
+  - type: sink
     name: out
     input: j
     config:
@@ -344,7 +344,7 @@ nodes:
       propagate_ck: driver
       cxl: |
 {BODY}
-  - type: output
+  - type: sink
     name: out
     input: j
     config:
@@ -407,7 +407,7 @@ nodes:
       propagate_ck: driver
       cxl: |
 {BODY}
-  - type: output
+  - type: sink
     name: out
     input: j
     config:
@@ -663,7 +663,7 @@ nodes:
       cxl: |
         filter builds.keep.is_null() or builds.keep == 1
         emit did = drivers.did
-  - type: output
+  - type: sink
     name: out
     input: j
     config:

--- a/crates/clinker-exec/tests/combine_per_document_flush.rs
+++ b/crates/clinker-exec/tests/combine_per_document_flush.rs
@@ -203,7 +203,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -303,7 +303,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -399,7 +399,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -484,7 +484,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -570,7 +570,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -670,7 +670,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -776,7 +776,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -915,7 +915,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:

--- a/crates/clinker-exec/tests/combine_propagate_ck_test.rs
+++ b/crates/clinker-exec/tests/combine_propagate_ck_test.rs
@@ -127,7 +127,7 @@ nodes:
         emit amount = o.amount
         emit tier = l.tier
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config: { name: out, type: csv, path: out.csv }
@@ -184,7 +184,7 @@ nodes:
         emit amount = o.amount
         emit ledger_ref = l.ledger_ref
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: joined
     config: { name: out, type: csv, path: out.csv }
@@ -238,7 +238,7 @@ nodes:
         emit order_id = o.order_id
         emit ledger_ref = l.ledger_ref
       propagate_ck: { named: [order_id] }
-  - type: output
+  - type: sink
     name: out
     input: joined
     config: { name: out, type: csv, path: out.csv }
@@ -303,7 +303,7 @@ nodes:
         emit amount = orders.amount
         emit ledger_ref = ledger.ledger_ref
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -378,7 +378,7 @@ nodes:
         emit amount = o.amount
         emit ledger_ref = l.ledger_ref
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -446,7 +446,7 @@ nodes:
         emit amount = o.amount
         emit tag = s.tag
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -500,7 +500,7 @@ nodes:
       on_miss: null_fields
       cxl: ""
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -566,7 +566,7 @@ nodes:
         emit b_val = b.b_val
         emit c_val = c.c_val
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -640,7 +640,7 @@ nodes:
         emit amount = o.amount
         emit ledger_ref = l.ledger_ref
       propagate_ck: all
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -746,7 +746,7 @@ nodes:
         emit total = a.total
         emit budget = l.budget
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config: { name: out, type: csv, path: out.csv }
@@ -815,7 +815,7 @@ nodes:
         emit lead = d.lead
         emit total = a.total
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config: { name: out, type: csv, path: out.csv }
@@ -884,7 +884,7 @@ nodes:
         emit lead = d.lead
         emit total = a.total
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -1000,7 +1000,7 @@ nodes:
         emit total = a.total
         emit budget = l.budget
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -1208,14 +1208,14 @@ nodes:
       conditions:
         positive: "combined > 0"
       default: nonpositive
-  - type: output
+  - type: sink
     name: positive_out
     input: split.positive
     config:
       name: positive_out
       type: csv
       path: positive.csv
-  - type: output
+  - type: sink
     name: nonpositive_out
     input: split.nonpositive
     config:
@@ -1646,7 +1646,7 @@ nodes:
             yaml.push_str(&format!("        emit {c}_val = {c}.{c}_val\n", c = c));
         }
         yaml.push_str("      propagate_ck: driver\n");
-        yaml.push_str("  - type: output\n    name: joined8_out\n    input: joined8\n    config:\n");
+        yaml.push_str("  - type: sink\n    name: joined8_out\n    input: joined8\n    config:\n");
         yaml.push_str("      name: joined8_out\n      type: csv\n      path: /tmp/joined8.csv\n");
 
         let config: PipelineConfig =
@@ -2413,7 +2413,7 @@ nodes:
     config:
       cxl: |
         emit id = id
-  - type: output
+  - type: sink
     name: out
     input: pass_through
     config:
@@ -2535,7 +2535,7 @@ nodes:
         emit product_name = products.product_name
         emit quantity = orders.quantity
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:
@@ -2582,7 +2582,7 @@ nodes:
         emit employee_id = employees.employee_id
         emit rate_class = rate_bands.rate_class
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: result
     input: classify
     config:
@@ -2627,7 +2627,7 @@ nodes:
         emit order_id = orders.order_id
         emit product_name = products.product_name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:
@@ -2673,7 +2673,7 @@ nodes:
         emit department = employees.department
         emit project = assignments.project
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:
@@ -2720,7 +2720,7 @@ nodes:
         emit department = employees.department
         emit project = assignments.project
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:
@@ -2879,7 +2879,7 @@ nodes:
       conditions:
         priority_report: 'priority_level == "urgent" or priority_level == "high"'
       default: fulfilled_orders
-  - type: output
+  - type: sink
     name: fulfilled_orders
     input: priority_split
     config:
@@ -2887,7 +2887,7 @@ nodes:
       type: csv
       path: fulfilled_orders.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: priority_report
     input: priority_split
     config:
@@ -2954,7 +2954,7 @@ nodes:
       conditions:
         high_priority_out: 'not product_name.is_null() and product_name != "UNKNOWN"'
       default: standard_out
-  - type: output
+  - type: sink
     name: high_priority_out
     input: priority_split
     config:
@@ -2962,7 +2962,7 @@ nodes:
       type: csv
       path: high_priority_out.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: standard_out
     input: priority_split
     config:
@@ -3302,7 +3302,7 @@ nodes:
         emit product_name = products.name
         emit amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: enriched_out
     input: enriched
     config:
@@ -3409,7 +3409,7 @@ nodes:
       on_miss: null_fields
       cxl: ""
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: collected_out
     input: collected
     config:
@@ -3486,7 +3486,7 @@ nodes:
       on_miss: null_fields
       cxl: ""
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: collected_out
     input: collected
     config:
@@ -3559,7 +3559,7 @@ nodes:
       on_miss: null_fields
       cxl: ""
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: collected_out
     input: collected
     config:
@@ -3782,7 +3782,7 @@ nodes:
         emit order_id = orders.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: enriched_out
     input: enriched
     config:
@@ -3875,7 +3875,7 @@ nodes:
         emit order_id = orders.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: enriched_out
     input: enriched
     config:
@@ -3961,7 +3961,7 @@ nodes:
         emit amount = orders.amount
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: filtered_out
     input: filtered
     config:
@@ -4032,7 +4032,7 @@ nodes:
         emit order_id = orders.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: joined_out
     input: joined
     config:
@@ -4252,7 +4252,7 @@ nodes:
         emit x = drivers.x
         emit lo = builds.lo
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: bnd_out
     input: bnd
     config:
@@ -4392,7 +4392,7 @@ nodes:
         emit x = drivers.x
         emit y = builds.y
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: pure_range_out
     input: pure_range
     config:
@@ -4462,7 +4462,7 @@ nodes:
         emit x = drivers.x
         emit bid = builds.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: first_only_out
     input: first_only
     config:
@@ -4588,7 +4588,7 @@ nodes:
         emit did = drivers.did
         emit tid = builds.tid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -4756,7 +4756,7 @@ nodes:
         emit ax = a.x
         emit bx = b.y
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -4840,7 +4840,7 @@ nodes:
         emit ax = a.x
         emit bx = b.y
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -4919,7 +4919,7 @@ nodes:
         emit ax = a.x
         emit bx = b.y
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -4971,7 +4971,7 @@ nodes:
         emit ax = a.x
         emit bx = b.y
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -5022,7 +5022,7 @@ nodes:
         emit ax = a.x
         emit bx = b.y
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -5074,7 +5074,7 @@ nodes:
         emit ai = a.i
         emit bx = b.y
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -5129,7 +5129,7 @@ nodes:
         emit department = employees.department
         emit project = assignments.project
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:
@@ -5210,7 +5210,7 @@ nodes:
         emit price = products.price
         emit bracket_id = brackets.bracket_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: result
     input: assign_bracket
     config:
@@ -5294,7 +5294,7 @@ nodes:
         emit p = probe.p
         emit b = build.b
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: result
     input: joined
     config:
@@ -5584,7 +5584,7 @@ nodes:
       emit b_c0 = b.c0
       emit c_c0 = c.c0
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: joined3
   config:
@@ -5679,7 +5679,7 @@ nodes:
       emit probe_c0 = probe.c0
       emit build_c0 = build.c0
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: joined
   config:

--- a/crates/clinker-exec/tests/common/dlq_fixtures.rs
+++ b/crates/clinker-exec/tests/common/dlq_fixtures.rs
@@ -27,6 +27,6 @@ pub fn dlq_validate_pipeline(name: &str, correlation_key: &str, schema: &str) ->
 - type: source\n  name: src\n  config:\n    name: src\n    path: input.csv\n    correlation_key: {correlation_key}\n    type: csv\n    schema:\n\
 {schema}\
 - type: transform\n  name: validate\n  input: src\n  config:\n    cxl: 'emit emp_id = employee_id\n\n      emit val = value.to_int()\n\n      '\n\
-- type: output\n  name: out\n  input: validate\n  config:\n    name: out\n    path: output.csv\n    type: csv\n    include_unmapped: true\n"
+- type: sink\n  name: out\n  input: validate\n  config:\n    name: out\n    path: output.csv\n    type: csv\n    include_unmapped: true\n"
     )
 }

--- a/crates/clinker-exec/tests/compiled_path_e2e.rs
+++ b/crates/clinker-exec/tests/compiled_path_e2e.rs
@@ -116,7 +116,7 @@ nodes:
         emit comment = (note ?? "none").trim()
         emit expensive = prices.filter(it => it > 10)
         emit price_count = prices.length()
-  - type: output
+  - type: sink
     name: out
     input: derive
     config:
@@ -199,7 +199,7 @@ nodes:
         distinct by region
         emit region_upper = region.upper()
         emit seq = seq
-  - type: output
+  - type: sink
     name: out
     input: dedup
     config:
@@ -279,7 +279,7 @@ nodes:
           emit sku = it["sku"].upper()
           emit band = if it["qty"] >= 100 then "bulk" else "retail"
         }
-  - type: output
+  - type: sink
     name: out
     input: explode
     config:

--- a/crates/clinker-exec/tests/composition_binding_test.rs
+++ b/crates/clinker-exec/tests/composition_binding_test.rs
@@ -130,7 +130,7 @@ nodes:
       fuzzy_threshold: 0.9
       lookup_table: "customers_lookup"
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -216,7 +216,7 @@ nodes:
       fuzzy_threshold: 0.9
       lookup_table: "customers_lookup"
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -297,7 +297,7 @@ nodes:
       fuzzy_threshold: 0.9
       lookup_table: "customers_lookup"
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -363,7 +363,7 @@ nodes:
     config:
       strict_mode: false
 
-  - type: output
+  - type: sink
     name: final_out
     input: raw_src
     config:
@@ -430,7 +430,7 @@ nodes:
     inputs:
       data: src
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -518,7 +518,7 @@ nodes:
     inputs: {}
     config: {}
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -588,7 +588,7 @@ nodes:
       fuzzy_threshold: 0.9
       lookup_table: "customers_lookup"
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -687,7 +687,7 @@ nodes:
     inputs:
       data: src
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -768,7 +768,7 @@ nodes:
     inputs:
       data: src
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -836,7 +836,7 @@ nodes:
     inputs:
       data: src
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -944,7 +944,7 @@ nodes:
     inputs:
       data: src
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -1125,7 +1125,7 @@ nodes:
     input: src
     config:
       cxl: "emit total = amount"
-  - type: output
+  - type: sink
     name: out
     input: xform
     config:
@@ -1158,7 +1158,7 @@ nodes:
         active: "status == 'active'"
         inactive: "status == 'inactive'"
       default: inactive
-  - type: output
+  - type: sink
     name: out
     input: router.active
     config:
@@ -1191,7 +1191,7 @@ nodes:
                     node_types.contains(&"transform"),
                     "{name}: missing transform"
                 );
-                assert!(node_types.contains(&"output"), "{name}: missing output");
+                assert!(node_types.contains(&"sink"), "{name}: missing sink");
                 // No compositions should appear.
                 assert!(
                     !node_types.contains(&"composition"),
@@ -1201,7 +1201,7 @@ nodes:
             "source_route_output" => {
                 assert!(node_types.contains(&"source"), "{name}: missing source");
                 assert!(node_types.contains(&"route"), "{name}: missing route");
-                assert!(node_types.contains(&"output"), "{name}: missing output");
+                assert!(node_types.contains(&"sink"), "{name}: missing sink");
             }
             _ => {}
         }

--- a/crates/clinker-exec/tests/composition_body_window.rs
+++ b/crates/clinker-exec/tests/composition_body_window.rs
@@ -145,7 +145,7 @@ nodes:
   use: ../compositions/body_post_aggregate_window.comp.yaml
   inputs:
     inp: src
-- type: output
+- type: sink
   name: out
   input: body
   config:
@@ -217,7 +217,7 @@ nodes:
   use: ../compositions/body_parent_node_window.comp.yaml
   inputs:
     inp: src
-- type: output
+- type: sink
   name: out
   input: body
   config:
@@ -320,7 +320,7 @@ nodes:
   use: ../compositions/outer.comp.yaml
   inputs:
     inp: src
-- type: output
+- type: sink
   name: out
   input: outer
   config:
@@ -442,7 +442,7 @@ nodes:
   input: src
   use: ../compositions/outer.comp.yaml
   inputs: { inp: src }
-- type: output
+- type: sink
   name: out
   input: outer
   config: { name: out, type: csv, path: out.csv, include_unmapped: true }
@@ -521,7 +521,7 @@ nodes:
   input: src
   use: ../compositions/cross_source.comp.yaml
   inputs: { inp: src }
-- type: output
+- type: sink
   name: out
   input: body
   config: { name: out, type: csv, path: out.csv, include_unmapped: true }
@@ -589,7 +589,7 @@ nodes:
   input: src
   use: ../compositions/merge_root.comp.yaml
   inputs: { left: src, right: src }
-- type: output
+- type: sink
   name: out
   input: body
   config: { name: out, type: csv, path: out.csv, include_unmapped: true }
@@ -626,7 +626,7 @@ nodes:
   use: ../compositions/body_post_aggregate_window.comp.yaml
   inputs:
     inp: src
-- type: output
+- type: sink
   name: out
   input: body
   config:
@@ -743,7 +743,7 @@ nodes:
   input: src
   use: ../compositions/outer.comp.yaml
   inputs: { inp: src }
-- type: output
+- type: sink
   name: out
   input: outer
   config: { name: out, type: csv, path: out.csv, include_unmapped: true }
@@ -818,7 +818,7 @@ nodes:
   input: src
   use: ../compositions/outer.comp.yaml
   inputs: { inp: src }
-- type: output
+- type: sink
   name: out
   input: outer
   config: { name: out, type: csv, path: out.csv, include_unmapped: true }
@@ -861,7 +861,7 @@ nodes:
   input: src
   use: ../compositions/inner.comp.yaml
   inputs: { inp: src }
-- type: output
+- type: sink
   name: out
   input: body
   config: { name: out, type: csv, path: out.csv, include_unmapped: true }
@@ -931,7 +931,7 @@ nodes:
   use: ../compositions/body_e150b.comp.yaml
   inputs:
     inp: src
-- type: output
+- type: sink
   name: out
   input: body
   config:

--- a/crates/clinker-exec/tests/composition_combine_test.rs
+++ b/crates/clinker-exec/tests/composition_combine_test.rs
@@ -133,7 +133,7 @@ nodes:
     inputs:
       orders: orders_src
       products: products_src
-  - type: output
+  - type: sink
     name: out
     input: enrich_call
     config:
@@ -198,7 +198,7 @@ nodes:
     inputs:
       orders: orders_src
       products: products_src
-  - type: output
+  - type: sink
     name: out
     input: enrich_call
     config:
@@ -279,7 +279,7 @@ nodes:
     inputs:
       orders: orders_src
       products: products_src
-  - type: output
+  - type: sink
     name: out
     input: nested_call
     config:
@@ -350,7 +350,7 @@ nodes:
     inputs:
       orders: orders_src
       products: products_src
-  - type: output
+  - type: sink
     name: out
     input: collect_call
     config:
@@ -448,7 +448,7 @@ nodes:
     inputs:
       a: a_src
       b: b_src
-  - type: output
+  - type: sink
     name: out
     input: bad_call
     config:
@@ -616,7 +616,7 @@ nodes:
     inputs:
       orders: orders_src
       products: products_src
-  - type: output
+  - type: sink
     name: out_a
     input: join_a
     config:
@@ -624,7 +624,7 @@ nodes:
       type: csv
       path: out_a.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_b
     input: join_b
     config:

--- a/crates/clinker-exec/tests/composition_executor_test.rs
+++ b/crates/clinker-exec/tests/composition_executor_test.rs
@@ -170,7 +170,7 @@ nodes:
     use: ../compositions/source_boundary_collision.comp.yaml
     inputs:
       collision: body_group
-  - type: output
+  - type: sink
     name: body_out
     input: body_call
     config:
@@ -196,7 +196,7 @@ nodes:
         emit id = id
         emit origin = "top-transform"
         emit $record.boundary = $record.boundary
-  - type: output
+  - type: sink
     name: top_out
     input: top_transform
     config:
@@ -257,7 +257,7 @@ nodes:
     use: ../compositions/source_boundary_collision.comp.yaml
     inputs:
       collision: body_group
-  - type: output
+  - type: sink
     name: body_out
     input: body_call
     config:
@@ -298,7 +298,7 @@ nodes:
         emit id = id
         emit origin = origin
         emit $record.boundary = $record.boundary
-  - type: output
+  - type: sink
     name: top_out
     input: top_passthrough
     config:
@@ -355,7 +355,7 @@ nodes:
     use: ../compositions/exec_transform_check.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: doubler_call
     config:
@@ -407,7 +407,7 @@ nodes:
     use: ../compositions/does_not_exist.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: missing_call
     config:
@@ -452,7 +452,7 @@ nodes:
     use: ../compositions/exec_nested_check.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: nested_call
     config:
@@ -508,7 +508,7 @@ nodes:
     use: ../compositions/exec_route_merge_check.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: split_call
     config:
@@ -581,7 +581,7 @@ nodes:
   - type: merge
     name: top_merged
     inputs: [top_hot, top_cold]
-  - type: output
+  - type: sink
     name: top_out
     input: top_merged
     config:
@@ -595,7 +595,7 @@ nodes:
     use: ../compositions/route_scope_body.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: comp_out
     input: comp
     config:
@@ -674,7 +674,7 @@ nodes:
     use: ../compositions/exec_runtime_error.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: doubler_call
     config:
@@ -738,7 +738,7 @@ nodes:
     use: ../compositions/exec_merge_interleave_check.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: split_merge
     config:

--- a/crates/clinker-exec/tests/correlated_dlq.rs
+++ b/crates/clinker-exec/tests/correlated_dlq.rs
@@ -180,7 +180,7 @@ nodes:
       emit val = value.to_int()
 
       '
-- type: output
+- type: sink
   name: out
   input: validate
   config:
@@ -242,7 +242,7 @@ nodes:
       emit val = value.to_int()
 
       '
-- type: output
+- type: sink
   name: out
   input: validate
   config:
@@ -322,7 +322,7 @@ nodes:
       b: 'emp != ""'
     default: a
 
-- type: output
+- type: sink
   name: out_a
   input: split.a
   config:
@@ -331,7 +331,7 @@ nodes:
     type: csv
     include_unmapped: true
 
-- type: output
+- type: sink
   name: out_b
   input: split.b
   config:
@@ -423,7 +423,7 @@ nodes:
     cxl: |
       emit emp = employee_id
       emit s = $window.sum(value)
-- type: output
+- type: sink
   name: out
   input: with_window
   config:
@@ -480,7 +480,7 @@ nodes:
     cxl: 'emit total = sum(value)
 
       '
-- type: output
+- type: sink
   name: out
   input: agg
   config:
@@ -575,7 +575,7 @@ nodes:
       emit total = sum(val)
 
       '
-- type: output
+- type: sink
   name: out
   input: agg
   config:
@@ -653,7 +653,7 @@ nodes:
       emit val = value.to_int()
 
       '
-- type: output
+- type: sink
   name: out
   input: rewrite
   config:
@@ -726,7 +726,7 @@ nodes:
       emit total = sum(val)
 
       '
-- type: output
+- type: sink
   name: out
   input: agg
   config:
@@ -833,7 +833,7 @@ nodes:
       emit dept = d.dept
     propagate_ck: driver
 
-- type: output
+- type: sink
   name: out
   input: enriched
   config:
@@ -1012,7 +1012,7 @@ nodes:
       emit amount_int = o.amount_int
     propagate_ck: driver
 
-- type: output
+- type: sink
   name: out
   input: enriched
   config:
@@ -1140,7 +1140,7 @@ nodes:
       good: 'amount.to_int() > 0'
     default: good
 
-- type: output
+- type: sink
   name: out
   input: split.good
   config:
@@ -1237,7 +1237,7 @@ nodes:
       emit session_start = s.session_start
     propagate_ck: driver
 
-- type: output
+- type: sink
   name: out
   input: enriched
   config:

--- a/crates/clinker-exec/tests/correlated_dlq_retract.rs
+++ b/crates/clinker-exec/tests/correlated_dlq_retract.rs
@@ -124,7 +124,7 @@ nodes:
       emit total = sum(amount)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -183,7 +183,7 @@ nodes:
       emit val = value.to_int()
 
       '
-- type: output
+- type: sink
   name: out
   input: validate
   config:
@@ -231,7 +231,7 @@ nodes:
       emit val = value.to_int()
 
       '
-- type: output
+- type: sink
   name: out
   input: validate
   config:
@@ -306,7 +306,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -461,7 +461,7 @@ nodes:
       emit mean = avg(amount_int)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_stats
   config:
@@ -591,7 +591,7 @@ nodes:
       emit per_capita = total / n
 
       '
-- type: output
+- type: sink
   name: out
   input: per_capita
   config:
@@ -715,7 +715,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -858,7 +858,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -990,7 +990,7 @@ nodes:
       emit total = sum(amount_int)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -1075,7 +1075,7 @@ nodes:
       emit total = sum(amount_int)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -1158,7 +1158,7 @@ nodes:
       emit total = sum(amount_int)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -1239,7 +1239,7 @@ nodes:
       emit lo = min(payload)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_stats
   config:
@@ -1316,7 +1316,7 @@ nodes:
       emit lo = min(payload)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_stats
   config:

--- a/crates/clinker-exec/tests/fixtures/combine/combine_empty_build.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/combine_empty_build.yaml
@@ -51,7 +51,7 @@ nodes:
         emit category = products.category
         emit amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: enriched_out
     input: enriched
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/combine_then_transform.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/combine_then_transform.yaml
@@ -45,7 +45,7 @@ nodes:
         emit order_id = order_id
         emit product_name = product_name
         emit doubled_amount = amount
-  - type: output
+  - type: sink
     name: upsize_out
     input: upsize
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/drive_hint.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/drive_hint.yaml
@@ -42,7 +42,7 @@ nodes:
         emit sample_order_id = orders.order_id
         emit sample_amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: product_driven_out
     input: product_driven
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_3part_ref.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_3part_ref.yaml
@@ -35,7 +35,7 @@ nodes:
       cxl: |
         emit order_id = orders.order_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: three_part_out
     input: three_part
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_body_unknown_field.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_body_unknown_field.yaml
@@ -32,7 +32,7 @@ nodes:
         emit order_id = orders.order_id
         emit bogus = products.nonexistent_field
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: bad_out
     input: bad
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_dotted_qualifier.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_dotted_qualifier.yaml
@@ -36,7 +36,7 @@ nodes:
       cxl: |
         emit order_id = orders.order_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: dotted_out
     input: dotted
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_literal_true.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_literal_true.yaml
@@ -36,7 +36,7 @@ nodes:
         emit order_id = orders.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: cross_out
     input: cross
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_no_cross_input.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_no_cross_input.yaml
@@ -33,7 +33,7 @@ nodes:
       cxl: |
         emit order_id = orders.order_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: bad_out
     input: bad
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_no_emit.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_no_emit.yaml
@@ -32,7 +32,7 @@ nodes:
       where: "orders.product_id == products.product_id"
       cxl: ""
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: bad_out
     input: bad
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_one_input.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_one_input.yaml
@@ -26,7 +26,7 @@ nodes:
         emit order_id = orders.order_id
         emit amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: lonely_out
     input: lonely
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_or_predicate.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_or_predicate.yaml
@@ -39,7 +39,7 @@ nodes:
         emit order_id = orders.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: combine_or_out
     input: combine_or
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_reserved_namespace.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_reserved_namespace.yaml
@@ -32,7 +32,7 @@ nodes:
       cxl: |
         emit order_id = orders.order_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: reserved_out
     input: reserved
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_unknown_field.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_unknown_field.yaml
@@ -31,7 +31,7 @@ nodes:
       cxl: |
         emit order_id = orders.order_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: bad_out
     input: bad
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/error_where_not_bool.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/error_where_not_bool.yaml
@@ -31,7 +31,7 @@ nodes:
       cxl: |
         emit order_id = orders.order_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: bad_out
     input: bad
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/expression_equi.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/expression_equi.yaml
@@ -43,7 +43,7 @@ nodes:
         emit order_id = orders.order_id
         emit product_id = products.product_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: expr_combine_out
     input: expr_combine
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/four_input_equi.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/four_input_equi.yaml
@@ -57,7 +57,7 @@ nodes:
         emit c_val = c.c_val
         emit d_val = d.d_val
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: joined4_out
     input: joined4
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_all_duplicates.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_all_duplicates.yaml
@@ -45,7 +45,7 @@ nodes:
         emit build_id = builds.build_id
         emit tag = builds.tag
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: duplicate_match_out
     input: duplicate_match
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_all_null_ranges.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_all_null_ranges.yaml
@@ -43,7 +43,7 @@ nodes:
         emit driver_id = drivers.driver_id
         emit build_id = builds.build_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: never_matches_out
     input: never_matches
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_empty_build.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_empty_build.yaml
@@ -42,7 +42,7 @@ nodes:
         emit income = employees.income
         emit rate = brackets.rate
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: assign_bracket_out
     input: assign_bracket
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_null_ranges.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_null_ranges.yaml
@@ -44,7 +44,7 @@ nodes:
         emit bracket_id = brackets.bracket_id
         emit rate = brackets.rate
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: assign_bracket_out
     input: assign_bracket
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_pure_range_null_fields.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_pure_range_null_fields.yaml
@@ -43,7 +43,7 @@ nodes:
         emit did = readings.did
         emit bid = bands.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: banded_out
     input: banded
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_single_row.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_single_row.yaml
@@ -42,7 +42,7 @@ nodes:
         emit driver_id = drivers.driver_id
         emit build_id = builds.build_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: single_match_out
     input: single_match
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_tax_bracket.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_tax_bracket.yaml
@@ -42,7 +42,7 @@ nodes:
         emit income = employees.income
         emit rate = brackets.rate
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: assign_bracket_out
     input: assign_bracket
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_temporal_overlap.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_temporal_overlap.yaml
@@ -46,7 +46,7 @@ nodes:
         emit session_start = sessions.start_ts
         emit session_end = sessions.end_ts
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: overlapping_out
     input: overlapping
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/iejoin_three_conjunct_residual.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/iejoin_three_conjunct_residual.yaml
@@ -46,7 +46,7 @@ nodes:
         emit did = applicants.did
         emit bid = tiers.bid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: tiered_out
     input: tiered
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/match_all.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/match_all.yaml
@@ -40,7 +40,7 @@ nodes:
         emit product_name = products.name
         emit amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: fanned_out
     input: fanned
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/match_collect.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/match_collect.yaml
@@ -38,7 +38,7 @@ nodes:
       on_miss: null_fields
       cxl: ""
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: collected_out
     input: collected
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/mixed_qualifier_expr.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/mixed_qualifier_expr.yaml
@@ -40,7 +40,7 @@ nodes:
         emit order_id = orders.order_id
         emit total = orders.amount + products.price
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: mixed_combine_out
     input: mixed_combine
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/on_miss_error.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/on_miss_error.yaml
@@ -39,7 +39,7 @@ nodes:
         emit product_name = products.name
         emit amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: strict_out
     input: strict
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/on_miss_skip.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/on_miss_skip.yaml
@@ -38,7 +38,7 @@ nodes:
         emit product_name = products.name
         emit amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: matched_only_out
     input: matched_only
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/sort_merge_price_range.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/sort_merge_price_range.yaml
@@ -43,7 +43,7 @@ nodes:
         emit bracket_id = brackets.bracket_id
         emit rate = brackets.rate
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: assign_bracket_out
     input: assign_bracket
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/three_input_mixed.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/three_input_mixed.yaml
@@ -52,7 +52,7 @@ nodes:
         emit fin = b.fin
         emit window_id = c.window_id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: joined_mixed_out
     input: joined_mixed
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/three_input_shared_key.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/three_input_shared_key.yaml
@@ -55,7 +55,7 @@ nodes:
         emit category_name = categories.category_name
         emit amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: fully_enriched_out
     input: fully_enriched
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/two_input_equi.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/two_input_equi.yaml
@@ -40,7 +40,7 @@ nodes:
         emit category = products.category
         emit amount = orders.amount
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: enriched_out
     input: enriched
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/two_input_mixed.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/two_input_mixed.yaml
@@ -52,7 +52,7 @@ nodes:
         emit min_order = products.min_order
         emit max_order = products.max_order
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: qualified_out
     input: qualified
     config:

--- a/crates/clinker-exec/tests/fixtures/combine/two_input_range.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/two_input_range.yaml
@@ -40,7 +40,7 @@ nodes:
         emit bracket_id = tax_brackets.bracket_id
         emit rate = tax_brackets.rate
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: bracketed_out
     input: bracketed
     config:


### PR DESCRIPTION
## Summary

- migrate combine, composition, and correlated-DLQ test pipelines from the retired terminal discriminator to `type: sink`
- update the two assertions that inspect the terminal node's authored type tag
- migrate the shared combine YAML corpus consumed by these integration targets while preserving each fixture's intended diagnostic

## Verification

- 12 focused `clinker-exec` integration targets: 227 passed, 0 failed
- `cargo fmt --all --check`
- `git diff --check`

This pull request is stacked on `executor-sink-fixtures-c` and contains only the next executable fixture slice.
