### PR TITLE
Migrate correlation and Cull fixtures to Sink

### DIFF
--- a/crates/clinker-exec/tests/correlated_post_aggregate_retract.rs
+++ b/crates/clinker-exec/tests/correlated_post_aggregate_retract.rs
@@ -127,7 +127,7 @@ nodes:
       emit ratio = 1 / (total - 60)
 
       '
-- type: output
+- type: sink
   name: out
   input: post_check
   config:
@@ -244,7 +244,7 @@ nodes:
       emit department = department
       emit total = total
       emit ratio = 1 / (total - 60)
-- type: output
+- type: sink
   name: out
   input: ratio
   config:
@@ -364,7 +364,7 @@ nodes:
       emit ratio = 1 / (total - 30)
 
       '
-- type: output
+- type: sink
   name: out
   input: post_check
   config:
@@ -462,7 +462,7 @@ nodes:
       emit ratio = 1 / (total - 60)
 
       '
-- type: output
+- type: sink
   name: out
   input: post_dept
   config:
@@ -548,7 +548,7 @@ nodes:
       emit ratio = 100 / (total - 30)
 
       '
-- type: output
+- type: sink
   name: out
   input: post_check
   config:

--- a/crates/clinker-exec/tests/correlated_window_after_aggregate_retract.rs
+++ b/crates/clinker-exec/tests/correlated_window_after_aggregate_retract.rs
@@ -94,7 +94,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:
@@ -291,7 +291,7 @@ nodes:
       emit ratio = 1 / (total - 60)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:

--- a/crates/clinker-exec/tests/correlated_window_retract.rs
+++ b/crates/clinker-exec/tests/correlated_window_retract.rs
@@ -215,7 +215,7 @@ nodes:
       emit total = sum(amount)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_summary
   config:
@@ -553,7 +553,7 @@ nodes:
       emit w_total = $window.sum(amount)
     analytic_window:
       group_by: [dept]
-- type: output
+- type: sink
   name: out
   input: windowed
   config:

--- a/crates/clinker-exec/tests/correlation_composition_test.rs
+++ b/crates/clinker-exec/tests/correlation_composition_test.rs
@@ -135,7 +135,7 @@ nodes:
     use: ../compositions/correlated_validate.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: validate_call
     config:
@@ -223,7 +223,7 @@ nodes:
     use: ../compositions/correlated_rewrite.comp.yaml
     inputs:
       inp: src
-  - type: output
+  - type: sink
     name: out
     input: rewrite_call
     config:

--- a/crates/clinker-exec/tests/correlation_overflow_rewind.rs
+++ b/crates/clinker-exec/tests/correlation_overflow_rewind.rs
@@ -94,7 +94,7 @@ nodes:
       cxl: |
         emit id = id
         emit amt = amt
-  - type: output
+  - type: sink
     name: out
     input: tfm
     config:
@@ -244,7 +244,7 @@ nodes:
       cxl: |
         emit id = id
         emit amt = amt
-  - type: output
+  - type: sink
     name: out
     input: tfm
     config:

--- a/crates/clinker-exec/tests/cross_scope_doc_attribution_test.rs
+++ b/crates/clinker-exec/tests/cross_scope_doc_attribution_test.rs
@@ -125,7 +125,7 @@ nodes:
     use: ../compositions/scoped_doc.comp.yaml
     inputs:
       inp: s_body
-  - type: output
+  - type: sink
     name: out_top
     input: shape
     config:
@@ -133,7 +133,7 @@ nodes:
       type: csv
       path: out_top.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_body
     input: body
     config:

--- a/crates/clinker-exec/tests/csv_charset.rs
+++ b/crates/clinker-exec/tests/csv_charset.rs
@@ -71,7 +71,7 @@ nodes:
         encoding: iso-8859-1
       schema:
         - { name: name, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -103,7 +103,7 @@ nodes:
         encoding: shift_jis
       schema:
         - { name: name, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -141,7 +141,7 @@ nodes:
         records:
           - { id: header, tag: H, columns: [ { name: record_type, type: string }, { name: batch_id, type: string } ] }
           - { id: detail, tag: D, columns: [ { name: record_type, type: string }, { name: batch_id, type: string } ] }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/csv_join_values_e2e.rs
+++ b/crates/clinker-exec/tests/csv_join_values_e2e.rs
@@ -65,7 +65,7 @@ nodes:
       schema:
         - { name: order_id, type: string }
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -131,7 +131,7 @@ nodes:
       cxl: |
         emit order_id = order_id
         emit tags = tags
-  - type: output
+  - type: sink
     name: out
     input: passthrough
     config:

--- a/crates/clinker-exec/tests/csv_split_values_e2e.rs
+++ b/crates/clinker-exec/tests/csv_split_values_e2e.rs
@@ -27,7 +27,7 @@ nodes:
       schema:
         - { name: order_id, type: string }
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:

--- a/crates/clinker-exec/tests/cull_explain_snapshot.rs
+++ b/crates/clinker-exec/tests/cull_explain_snapshot.rs
@@ -47,14 +47,14 @@ nodes:
       rules:
         - name: drop_error_groups
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
-  - type: output
+  - type: sink
     name: kept
     input: drop_bad
     config:
       name: kept
       type: csv
       path: kept.csv
-  - type: output
+  - type: sink
     name: audit
     input: drop_bad.removed
     config:
@@ -80,12 +80,12 @@ nodes:
         "the removed side-output port must be rendered: {text}"
     );
     assert!(
-        text.contains("edge cull.drop_bad -> output.kept:\n  buffer: node_buffer (slot=1)"),
+        text.contains("edge cull.drop_bad -> sink.kept:\n  buffer: node_buffer (slot=1)"),
         "the unnamed main slot must retain its exact producer identity: {text}"
     );
     assert!(
         text.contains(
-            "edge cull.drop_bad -> output.audit:\n  buffer: node_buffer (slot=1, port=removed)"
+            "edge cull.drop_bad -> sink.audit:\n  buffer: node_buffer (slot=1, port=removed)"
         ),
         "the removed slot must carry its exact producer-port identity: {text}"
     );

--- a/crates/clinker-exec/tests/cull_pipeline.rs
+++ b/crates/clinker-exec/tests/cull_pipeline.rs
@@ -111,14 +111,14 @@ nodes:
       rules:
         - name: drop_error_groups
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
-  - type: output
+  - type: sink
     name: out
     input: drop_bad
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: drop_bad.removed
     config:
@@ -155,14 +155,14 @@ nodes:
       rules:
         - name: drop_any_error
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
-  - type: output
+  - type: sink
     name: out
     input: drop_bad
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: drop_bad.removed
     config:
@@ -339,14 +339,14 @@ nodes:
       rules:
         - name: drop_error_groups
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0  # any error row in the group"
-  - type: output
+  - type: sink
     name: out
     input: drop_bad
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: drop_bad.removed
     config:
@@ -416,14 +416,14 @@ nodes:
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0  # any error row"
         - name: drop_big_groups
           drop_group_when: "sum(amount) > 500"
-  - type: output
+  - type: sink
     name: out
     input: drop_bad
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: drop_bad.removed
     config:
@@ -499,14 +499,14 @@ nodes:
       rules:
         - name: drop_large_groups
           drop_group_when: "count(*) > 100"
-  - type: output
+  - type: sink
     name: out
     input: drop_big
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: drop_big.removed
     config:
@@ -641,14 +641,14 @@ nodes:
       rules:
         - name: drop_large_groups
           drop_group_when: "count(*) > 100"
-  - type: output
+  - type: sink
     name: out
     input: drop_big
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: drop_big.removed
     config:
@@ -867,14 +867,14 @@ nodes:
         # comparison are Dates (a string literal would be a type error).
         - name: recent_hire
           drop_group_when: "max(hired) >= #2020-01-01#"
-  - type: output
+  - type: sink
     name: out
     input: drop_recent_or_late
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: audit
     input: drop_recent_or_late.removed
     config:
@@ -964,14 +964,14 @@ nodes:
       rules:
         - name: any_error
           drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
-  - type: output
+  - type: sink
     name: out
     input: drop_errors
     config:
       name: out
       type: json
       path: out.json
-  - type: output
+  - type: sink
     name: audit
     input: drop_errors.removed
     config:
@@ -1082,7 +1082,7 @@ nodes:
   - type: merge
     name: recombined
     inputs: [drop_bad, drop_bad.removed]
-  - type: output
+  - type: sink
     name: out
     input: recombined
     config:

--- a/crates/clinker-exec/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/tests/deferred_dispatch.rs
@@ -71,7 +71,7 @@ nodes:
       emit department = department
       emit total = total
       emit scaled = total * 2
-- type: output
+- type: sink
   name: out
   input: scaled
   config:
@@ -210,7 +210,7 @@ nodes:
     cxl: |
       emit department = department
       emit total = total
-- type: output
+- type: sink
   name: out
   input: post
   config:
@@ -376,7 +376,7 @@ nodes:
       emit department = department
       emit total = total
       emit budget = budget
-- type: output
+- type: sink
   name: out
   input: tail
   config:
@@ -535,7 +535,7 @@ nodes:
       emit total = p.total
       emit budget = b.budget
     propagate_ck: driver
-- type: output
+- type: sink
   name: out
   input: enriched
   config:
@@ -733,7 +733,7 @@ nodes:
         emit department = department
         emit total = total
         emit total_plus_one = total + 1
-  - type: output
+  - type: sink
     name: out
     input: bump
     config:
@@ -930,7 +930,7 @@ nodes:
         emit department = department
         emit total = total
         emit safe_ratio = 1 / (total - 60)
-  - type: output
+  - type: sink
     name: out
     input: bump
     config:
@@ -1109,7 +1109,7 @@ nodes:
         emit department = department
         emit total = total
         emit total_plus_one = total + 1
-  - type: output
+  - type: sink
     name: out
     input: bump
     config:
@@ -1251,7 +1251,7 @@ nodes:
     conditions:
       big: total > 100
     default: small
-- type: output
+- type: sink
   name: big
   input: classify
   config:
@@ -1259,7 +1259,7 @@ nodes:
     path: big.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: small
   input: classify
   config:

--- a/crates/clinker-exec/tests/dlq_rate_threshold.rs
+++ b/crates/clinker-exec/tests/dlq_rate_threshold.rs
@@ -78,7 +78,7 @@ nodes:
       cxl: |
         emit id = id
         emit ratio = if($source.name == "src_b") then (1 / 0) else amt
-  - type: output
+  - type: sink
     name: out
     input: tfm
     config:
@@ -380,7 +380,7 @@ nodes:
       path: a.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src_a
     config:
@@ -425,7 +425,7 @@ nodes:
       path: a.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src_a
     config:
@@ -470,7 +470,7 @@ nodes:
       path: a.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src_a
     config:
@@ -515,7 +515,7 @@ nodes:
       path: a.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src_a
     config:
@@ -555,14 +555,14 @@ nodes:
       path: a.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out1
     input: src_a
     config:
       name: out1
       type: csv
       path: shared.csv
-  - type: output
+  - type: sink
     name: out2
     input: src_a
     config:
@@ -645,7 +645,7 @@ nodes:
       path: a.csv
       schema:
         - {{ name: id, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: src_a
     config:

--- a/crates/clinker-exec/tests/doc_index_rss_proof.rs
+++ b/crates/clinker-exec/tests/doc_index_rss_proof.rs
@@ -184,7 +184,7 @@ nodes:
     config:
       cxl: |
         emit x = $doc.Head.batch_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -225,7 +225,7 @@ nodes:
     config:
       cxl: |
         emit x = $doc.Head.batch_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -435,7 +435,7 @@ nodes:
     config:
       cxl: |
         emit x = $doc.Head.blob
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:

--- a/crates/clinker-exec/tests/snapshots/cull_explain_snapshot__explain_cull_two_output_ports.snap
+++ b/crates/clinker-exec/tests/snapshots/cull_explain_snapshot__explain_cull_two_output_ports.snap
@@ -32,7 +32,7 @@ cull.drop_bad:
   buffer: materialized
   arbitration: spill_priority=15, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.audit:
+sink.audit:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -40,7 +40,7 @@ output.audit:
   buffer: streaming
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.kept:
+sink.kept:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -54,11 +54,11 @@ edge source.events -> cull.drop_bad:
   buffer: node_buffer (slot=0)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
 
-edge cull.drop_bad -> output.audit:
+edge cull.drop_bad -> sink.audit:
   buffer: node_buffer (slot=1, port=removed)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: cull)
 
-edge cull.drop_bad -> output.kept:
+edge cull.drop_bad -> sink.kept:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: cull)
 
@@ -84,5 +84,5 @@ Worker threads: 4
   ◆ FORK [cull] 'drop_bad' (line:17)
   ├──> main → drop_bad
   ├──> removed → drop_bad.removed
-  │ [output] audit (line:33)
-  │ [output] kept (line:26)
+  │ [sink] audit (line:33)
+  │ [sink] kept (line:26)


### PR DESCRIPTION
## Summary

- migrate correlation, CSV, Cull, deferred-dispatch, DLQ, and document-index integration fixtures to `type: sink`
- update Cull explain assertions and the committed snapshot to use the Sink node taxonomy
- preserve Cull's `kept` and `audit` output-port vocabulary unchanged

## Verification

- 14 focused `clinker-exec` integration targets: 80 passed, 0 failed, 2 declared-heavy tests ignored
- `cargo fmt --all --check`
- `git diff --check`

This pull request is stacked on `executor-sink-fixtures-d` and contains only the next executable fixture slice.
