### PR TITLE
Migrate executor terminal fixtures to Sink

### DIFF
--- a/crates/clinker-exec/tests/document_dlq.rs
+++ b/crates/clinker-exec/tests/document_dlq.rs
@@ -56,7 +56,7 @@ nodes:
       cxl: |
         emit id = id
         emit val = value.to_int()
-  - type: output
+  - type: sink
     name: out
     input: validate
     config:
@@ -265,7 +265,7 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: value, type: int }
-  - type: output
+  - type: sink
     name: out
     input: events
     config:
@@ -489,7 +489,7 @@ nodes:
       cxl: |
         emit seg = seg_id
         emit v = e01.to_int()
-  - type: output
+  - type: sink
     name: out
     input: validate
     config:
@@ -600,7 +600,7 @@ nodes:
         - {{ name: seg_id, type: string }}
         - {{ name: set_ref, type: string }}
         - {{ name: e01, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -1149,7 +1149,7 @@ nodes:
       schema:
         - {{ name: seg_id, type: string }}
         - {{ name: {reference_field}, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: msgs
     config:
@@ -1320,7 +1320,7 @@ nodes:
       dlq_granularity: document
       schema:
         - { name: id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: events
     config:
@@ -1360,7 +1360,7 @@ nodes:
       dlq_granularity: document
       schema:
         - { name: id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: events
     config:
@@ -1398,7 +1398,7 @@ nodes:
       schema:
         - { name: account_id, type: string }
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: events
     config:
@@ -1475,7 +1475,7 @@ nodes:
         emit id = id
         emit note = note
         emit val = value.to_int()
-  - type: output
+  - type: sink
     name: out
     input: validate
     config:

--- a/crates/clinker-exec/tests/edifact_pipeline.rs
+++ b/crates/clinker-exec/tests/edifact_pipeline.rs
@@ -151,7 +151,7 @@ nodes:
         emit seg = seg_id
         emit ref = msg_ref
         emit control = $doc.unb.e05
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -199,7 +199,7 @@ nodes:
         - { name: msg_type, type: { nullable: string } }
         - { name: e01, type: { nullable: string } }
         - { name: e02, type: { nullable: string } }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -243,7 +243,7 @@ nodes:
     config:
       cxl: |
         emit seg = seg_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -300,7 +300,7 @@ nodes:
         - { name: msg_type, type: { nullable: string } }
         - { name: e01, type: { nullable: string } }
         - { name: e02, type: { nullable: string } }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -357,7 +357,7 @@ nodes:
         - { name: e01, type: { nullable: string } }
         - { name: e02, type: { nullable: string } }
         - { name: e03, type: { nullable: string } }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -408,7 +408,7 @@ nodes:
     config:
       cxl: |
         emit seg = seg_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -450,7 +450,7 @@ nodes:
       glob: ./*.edi
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -485,7 +485,7 @@ nodes:
       glob: ./*.edi
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -527,7 +527,7 @@ nodes:
       cxl: |
         emit seg = seg_id
         emit first = e01
-  - type: output
+  - type: sink
     name: out
     input: project
     config:
@@ -597,7 +597,7 @@ nodes:
         - { name: e01, type: { nullable: string } }
         - { name: e02, type: { nullable: string } }
         - { name: e03, type: { nullable: string } }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -655,7 +655,7 @@ nodes:
       cxl: |
         emit seg = seg_id
         emit sender = $doc.unb.e02
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -705,7 +705,7 @@ nodes:
       glob: ./*.edi
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -743,7 +743,7 @@ nodes:
       glob: ./*.edi
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -778,7 +778,7 @@ nodes:
       glob: ./*.edi
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:

--- a/crates/clinker-exec/tests/envelope_doc_context_json_test.rs
+++ b/crates/clinker-exec/tests/envelope_doc_context_json_test.rs
@@ -58,7 +58,7 @@ nodes:
         emit amount = amount
         emit batch = batch
         emit declared_total = $doc.Summary.total
-  - type: output
+  - type: sink
     name: out
     input: tag2
     config:

--- a/crates/clinker-exec/tests/envelope_doc_context_test.rs
+++ b/crates/clinker-exec/tests/envelope_doc_context_test.rs
@@ -52,7 +52,7 @@ nodes:
         emit amount = amount
         emit batch = batch
         emit declared_total = $doc.Summary.total
-  - type: output
+  - type: sink
     name: out
     input: tag2
     config:
@@ -180,7 +180,7 @@ nodes:
         emit amount = amount
         emit batch = $doc.BatchInfo.batch_id
         emit declared_total = $doc.Summary.total
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:

--- a/crates/clinker-exec/tests/envelope_node.rs
+++ b/crates/clinker-exec/tests/envelope_node.rs
@@ -252,7 +252,7 @@ nodes:
       cxl: |
         emit id = id
         emit tag = $doc.interchange.tag
-{envelope_node}  - type: output
+{envelope_node}  - type: sink
     name: out
     input: {output_input}
     config:
@@ -652,7 +652,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -764,7 +764,7 @@ nodes:
       cxl: |
         emit id = id
         emit doc_tag = $doc.interchange.tag
-  - type: output
+  - type: sink
     name: out
     input: stamp
     config:
@@ -1220,7 +1220,7 @@ nodes:
     name: framed
     body: tag
     config: { strategy: concat }
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:
@@ -1416,7 +1416,7 @@ nodes:
     body: body
     header: hdr
     config: { strategy: preserve }
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:
@@ -1605,7 +1605,7 @@ nodes:
     body: body
     trailer: tail
     config: { strategy: preserve }
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:
@@ -1688,7 +1688,7 @@ nodes:
       footer:
         interchange:
           {footer_field}
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:

--- a/crates/clinker-exec/tests/explain_arbitration.rs
+++ b/crates/clinker-exec/tests/explain_arbitration.rs
@@ -85,7 +85,7 @@ nodes:
         emit department = department
         emit total = sum(amount)
 
-  - type: output
+  - type: sink
     name: out
     input: dept_totals
     config:
@@ -212,11 +212,11 @@ nodes:
     name: right
     input: shared
     config: { cxl: "emit id = id" }
-  - type: output
+  - type: sink
     name: left_out
     input: left
     config: { name: left_out, type: csv, path: left.csv }
-  - type: output
+  - type: sink
     name: right_out
     input: right
     config: { name: right_out, type: csv, path: right.csv }
@@ -358,7 +358,7 @@ nodes:
       cxl: |
         emit department = department
         emit amount = amount
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -421,7 +421,7 @@ nodes:
         emit amount = orders.amount
         emit name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -588,7 +588,7 @@ nodes:
             set:
               plan_end: "plan_start"
 
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config:

--- a/crates/clinker-exec/tests/format_dispatch.rs
+++ b/crates/clinker-exec/tests/format_dispatch.rs
@@ -106,7 +106,7 @@ nodes:
       - { name: name, type: string }
       - { name: age, type: string }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -150,7 +150,7 @@ nodes:
       - { name: name, type: string }
       - { name: age, type: int }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -197,7 +197,7 @@ nodes:
     schema:
       - { name: name, type: string }
       - { name: age, type: int }
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -250,7 +250,7 @@ nodes:
     schema:
       - { name: name, type: string }
       - { name: age, type: int }
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -313,7 +313,7 @@ nodes:
     schema:
       - { name: name, type: string }
       - { name: age, type: int }
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -374,7 +374,7 @@ nodes:
     schema:
       - { name: name, type: string }
       - { name: age, type: int }
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -444,7 +444,7 @@ nodes:
       - { name: name, type: string }
       - { name: age, type: string }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -492,7 +492,7 @@ nodes:
       - { name: name, type: string }
       - { name: age, type: string }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -548,7 +548,7 @@ nodes:
       - { name: id, type: string }
       - { name: value, type: string }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -593,7 +593,7 @@ nodes:
       - { name: name, type: string }
       - { name: age, type: string }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -635,7 +635,7 @@ nodes:
       - { name: name, type: string, start: 0, width: 10 }
       - { name: age, type: int, start: 10, width: 5 }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -673,7 +673,7 @@ nodes:
       - { name: name, type: string }
       - { name: age, type: string }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:
@@ -737,7 +737,7 @@ nodes:
       - { name: name, type: string }
       - { name: age, type: string }
 
-- type: output
+- type: sink
   name: dest
   input: src
   config:

--- a/crates/clinker-exec/tests/hl7_pipeline.rs
+++ b/crates/clinker-exec/tests/hl7_pipeline.rs
@@ -115,7 +115,7 @@ nodes:
         emit seg = seg_id
         emit ctrl = set_ref
         emit mtype = $doc.transaction_set.f08
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -161,7 +161,7 @@ nodes:
       glob: ./*.hl7
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:
@@ -222,7 +222,7 @@ nodes:
     config:
       cxl: |
         emit seg = seg_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -269,7 +269,7 @@ nodes:
       glob: ./*.hl7
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:
@@ -336,7 +336,7 @@ nodes:
         emit ctrl = set_ref
         emit file_id = $doc.file.f07
         emit batch_id = $doc.batch.f07
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -375,7 +375,7 @@ nodes:
       glob: ./*.hl7
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:
@@ -409,7 +409,7 @@ nodes:
       glob: ./*.hl7
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:
@@ -459,7 +459,7 @@ nodes:
         emit code = f08_c1
         emit trigger = f08_c2
         emit patid = f03_c1
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -510,7 +510,7 @@ nodes:
           - { field: f03, components: 5 }
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:
@@ -557,7 +557,7 @@ nodes:
       cxl: |
         emit seg = seg_id
         emit f3 = f03
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -600,7 +600,7 @@ nodes:
           - { field: f08, components: 2 }
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:
@@ -645,7 +645,7 @@ nodes:
         emit seg = seg_id
         emit mtype = f08_c1
         emit mtrigger = f08_c2
-  - type: output
+  - type: sink
     name: out
     input: project
     config:

--- a/crates/clinker-exec/tests/intra_record_closures.rs
+++ b/crates/clinker-exec/tests/intra_record_closures.rs
@@ -97,7 +97,7 @@ nodes:
       cxl: |
         emit kept = items.filter(it => it["price"] > 5)
         emit prices = items.map(it => it["price"])
-  - type: output
+  - type: sink
     name: out
     input: derive
     config:
@@ -158,7 +158,7 @@ nodes:
           emit sku = it["sku"]
           emit price = it["price"]
         }
-  - type: output
+  - type: sink
     name: out
     input: explode
     config:
@@ -225,7 +225,7 @@ nodes:
             emit val = it
           }
         }
-  - type: output
+  - type: sink
     name: out
     input: explode
     config:
@@ -289,7 +289,7 @@ nodes:
             emit val = it
           }
         }
-  - type: output
+  - type: sink
     name: out
     input: explode
     config:
@@ -345,7 +345,7 @@ nodes:
         emit each it in items {
           emit val = it
         }
-  - type: output
+  - type: sink
     name: out
     input: explode
     config:
@@ -405,7 +405,7 @@ nodes:
         emit enriched = items.map(it => it.set("region", "us-east"))
         emit slim = items.map(it => it.remove_field("internal_id"))
         emit pruned = items.map(it => it.unset("meta.flag"))
-  - type: output
+  - type: sink
     name: out
     input: derive
     config:
@@ -511,7 +511,7 @@ nodes:
         emit best = items.find(it => it["price"] > 15)
         emit any_cheap = items.any(it => it["price"] < 10)
         emit dropped_second = items.remove(1)
-  - type: output
+  - type: sink
     name: out
     input: derive
     config:

--- a/crates/clinker-exec/tests/json_nested_write_e2e.rs
+++ b/crates/clinker-exec/tests/json_nested_write_e2e.rs
@@ -59,7 +59,7 @@ nodes:
         - { name: customer.name, type: string }
         - { name: customer.email, type: string }
         - { name: customer.address.city, type: string }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:

--- a/crates/clinker-exec/tests/long_field_coverage.rs
+++ b/crates/clinker-exec/tests/long_field_coverage.rs
@@ -129,7 +129,7 @@ nodes:
         emit comment_upper = comment.upper()
         emit tagged = ticket_uuid.substring(0, 8).concat("|", comment)
         filter comment.length() > 4
-  - type: output
+  - type: sink
     name: out
     input: derive
     config:
@@ -195,7 +195,7 @@ nodes:
       cxl: |
         emit agent_uuid = agent_uuid
         emit ticket_count = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_agent
     config:
@@ -256,7 +256,7 @@ nodes:
       cxl: |
         emit ticket_uuid = ticket_uuid
         distinct by ticket_uuid
-  - type: output
+  - type: sink
     name: out
     input: dedup
     config:
@@ -346,7 +346,7 @@ nodes:
         emit agent_name = a.agent_name
         emit shipping_address = t.shipping_address
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -424,7 +424,7 @@ nodes:
       conditions:
         keep: "true"
       default: drop
-  - type: output
+  - type: sink
     name: out
     input: fan.keep
     config:
@@ -507,7 +507,7 @@ nodes:
         - { name: ticket_uuid, type: string }
         - { name: shipping_address, type: string }
         - { name: comment, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -556,7 +556,7 @@ nodes:
         - { name: ticket_uuid, type: string }
         - { name: shipping_address, type: string }
         - { name: comment, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/long_unique_column.rs
+++ b/crates/clinker-exec/tests/long_unique_column.rs
@@ -114,7 +114,7 @@ nodes:
       cxl: |
         emit agent_uuid = agent_uuid
         emit ticket_count = count(*)
-  - type: output
+  - type: sink
     name: out
     input: agg
     config:
@@ -192,7 +192,7 @@ nodes:
         emit agent_uuid = t.agent_uuid
         emit agent_name = a.agent_name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -263,7 +263,7 @@ nodes:
       cxl: |
         emit agent_uuid = agent_uuid
         distinct by agent_uuid
-  - type: output
+  - type: sink
     name: out
     input: dedup
     config:
@@ -310,7 +310,7 @@ nodes:
       path: src.csv
       schema:
         - { name: note, type: string, long_unique: true }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_exec_sketches_statistics.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_exec_sketches_statistics.snap
@@ -40,7 +40,7 @@ combine.enriched:
   buffer: materialized
   arbitration: spill_priority=10, can_back_pressure=false, predicted_peak=150K, predicted_freed=150K, predicted_subtree_reclaim=150K
 
-output.out:
+sink.out:
   ordering: <none>
   ordering_provenance: DestroyedByCombine { at_node: "enriched", confidence: Proven }
   partitioning: Single
@@ -58,7 +58,7 @@ edge source.orders -> combine.enriched:
   buffer: node_buffer (slot=0)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=90K, predicted_freed=90K (producer: source)
 
-edge combine.enriched -> output.out:
+edge combine.enriched -> sink.out:
   buffer: node_buffer (slot=2)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=150K, predicted_freed=150K (producer: combine)
 
@@ -105,4 +105,4 @@ Worker threads: 4
   ● [source] products (line:16)
   ● [source] orders (line:7)
   ◈ [combine:grace_hash] enriched drive=orders build=[products] eq=1 range=0 (line:25)
-  │ [output] out (line:39)
+  │ [sink] out (line:39)

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_metadata_driven_grace_hash.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_metadata_driven_grace_hash.snap
@@ -40,7 +40,7 @@ combine.enriched:
   buffer: materialized
   arbitration: spill_priority=10, can_back_pressure=false, predicted_peak=150K, predicted_freed=150K, predicted_subtree_reclaim=150K
 
-output.out:
+sink.out:
   ordering: <none>
   ordering_provenance: DestroyedByCombine { at_node: "enriched", confidence: Proven }
   partitioning: Single
@@ -58,7 +58,7 @@ edge source.orders -> combine.enriched:
   buffer: node_buffer (slot=0)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=90K, predicted_freed=90K (producer: source)
 
-edge combine.enriched -> output.out:
+edge combine.enriched -> sink.out:
   buffer: node_buffer (slot=2)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=150K, predicted_freed=150K (producer: combine)
 
@@ -100,4 +100,4 @@ Worker threads: 4
   ● [source] products (line:16)
   ● [source] orders (line:7)
   ◈ [combine:grace_hash] enriched drive=orders build=[products] eq=1 range=0 (line:25)
-  │ [output] out (line:39)
+  │ [sink] out (line:39)

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output.snap
@@ -32,7 +32,7 @@ aggregation.dept_totals:
   buffer: materialized
   arbitration: spill_priority=30, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.out:
+sink.out:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -46,7 +46,7 @@ edge source.orders -> aggregation.dept_totals:
   buffer: node_buffer (slot=0)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
 
-edge aggregation.dept_totals -> output.out:
+edge aggregation.dept_totals -> sink.out:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: aggregation)
 
@@ -74,4 +74,4 @@ Worker threads: 4
 
   ● [source] orders (line:5)
   ◇ [aggregation:hash] dept_totals (line:15)
-  │ [output] out (line:24)
+  │ [sink] out (line:24)

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output_sized.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output_sized.snap
@@ -32,7 +32,7 @@ aggregation.dept_totals:
   buffer: materialized
   arbitration: spill_priority=30, can_back_pressure=false, predicted_peak=1K, predicted_freed=1K, predicted_subtree_reclaim=1K
 
-output.out:
+sink.out:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -46,7 +46,7 @@ edge source.orders -> aggregation.dept_totals:
   buffer: node_buffer (slot=0)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=1K, predicted_freed=1K (producer: source)
 
-edge aggregation.dept_totals -> output.out:
+edge aggregation.dept_totals -> sink.out:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=1K, predicted_freed=1K (producer: aggregation)
 
@@ -74,4 +74,4 @@ Worker threads: 4
 
   ● [source] orders (line:5)
   ◇ [aggregation:hash] dept_totals (line:15)
-  │ [output] out (line:24)
+  │ [sink] out (line:24)


### PR DESCRIPTION
## Summary

- migrate document, envelope, format-dispatch, and long-field integration fixtures to `type: sink`
- update the four directly consumed arbitration snapshots to use the Sink node taxonomy
- preserve projection and output-domain terminology that does not name the terminal node kind

## Verification

- 14 focused `clinker-exec` integration targets: 125 passed, 0 failed
- `cargo fmt --all --check`
- `git diff --check`

This pull request is stacked on `executor-sink-fixtures-e` and contains only the next executable fixture slice.
