### PR TITLE
Update executor pipelines for Sink syntax

### DIFF
--- a/crates/clinker-exec/tests/memory_backpressure.rs
+++ b/crates/clinker-exec/tests/memory_backpressure.rs
@@ -25,7 +25,7 @@ nodes:
       has_header: true
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: sink
   input: src
   config:

--- a/crates/clinker-exec/tests/merge_interleave.rs
+++ b/crates/clinker-exec/tests/merge_interleave.rs
@@ -79,7 +79,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [src_a, src_b]
-{merge_config_block}  - type: output
+{merge_config_block}  - type: sink
     name: out
     input: merged
     config:
@@ -132,14 +132,14 @@ nodes:
     inputs: [shared, right_only]
     config:
       mode: interleave
-  - type: output
+  - type: sink
     name: left_out
     input: left_merge
     config:
       name: left_out
       type: csv
       path: left_out.csv
-  - type: output
+  - type: sink
     name: right_out
     input: right_merge
     config:
@@ -557,7 +557,7 @@ nodes:
     inputs: [src_a, src_b, src_c, src_d]
     config:
       mode: interleave
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:

--- a/crates/clinker-exec/tests/multi_file_source_test.rs
+++ b/crates/clinker-exec/tests/multi_file_source_test.rs
@@ -35,7 +35,7 @@ nodes:
         emit amount = amount
         emit src_file = $source.file
         emit src_row = $source.row
-  - type: output
+  - type: sink
     name: out
     input: stamp
     config:

--- a/crates/clinker-exec/tests/multi_output.rs
+++ b/crates/clinker-exec/tests/multi_output.rs
@@ -168,7 +168,7 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: value, type: int }
-  - type: output
+  - type: sink
     name: direct
     input: shared
     config:
@@ -178,7 +178,7 @@ nodes:
   - type: merge
     name: joined
     inputs: [shared, sibling]
-  - type: output
+  - type: sink
     name: merged
     input: joined
     config:
@@ -230,7 +230,7 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: label, type: string }
-  - type: output
+  - type: sink
     name: direct
     input: shared
     config:
@@ -253,7 +253,7 @@ nodes:
         emit value = left.value
         emit label = right.label
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: combined
     input: joined
     config:
@@ -296,14 +296,14 @@ fn shared_port_merge_yaml(memory_limit: &str, computational_first: bool) -> Stri
   - type: merge
     name: joined
     inputs: [shared, sibling]
-  - type: output
+  - type: sink
     name: direct
     input: shared
     config: { name: direct, type: csv, path: direct.csv }
 "#
     } else {
         r#"
-  - type: output
+  - type: sink
     name: direct
     input: shared
     config: { name: direct, type: csv, path: direct.csv }
@@ -337,7 +337,7 @@ nodes:
         - {{ name: id, type: string }}
         - {{ name: payload, type: string }}
 {consumers}
-  - type: output
+  - type: sink
     name: merged
     input: joined
     config: {{ name: merged, type: csv, path: merged.csv }}
@@ -370,7 +370,7 @@ nodes:
       schema:
         - {{ name: id, type: string }}
         - {{ name: label, type: string }}
-  - type: output
+  - type: sink
     name: direct
     input: shared
     config: {{ name: direct, type: csv, path: direct.csv }}
@@ -389,7 +389,7 @@ nodes:
         emit payload = left.payload
         emit label = right.label
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: combined
     input: joined
     config: {{ name: combined, type: csv, path: combined.csv }}
@@ -406,14 +406,14 @@ fn shared_port_transform_yaml(memory_limit: &str, computational_first: bool) -> 
     config:
       cxl: |
         emit copied_id = id
-  - type: output
+  - type: sink
     name: direct
     input: shared
     config: { name: direct, type: csv, path: direct.csv }
 "#
     } else {
         r#"
-  - type: output
+  - type: sink
     name: direct
     input: shared
     config: { name: direct, type: csv, path: direct.csv }
@@ -441,7 +441,7 @@ nodes:
         - {{ name: id, type: string }}
         - {{ name: payload, type: string }}
 {consumers}
-  - type: output
+  - type: sink
     name: transformed
     input: copied
     config: {{ name: transformed, type: csv, path: transformed.csv }}
@@ -678,11 +678,11 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: payload, type: string }
-  - type: output
+  - type: sink
     name: interrupting
     input: shared
     config: { name: interrupting, type: csv, path: interrupting.csv }
-  - type: output
+  - type: sink
     name: pending
     input: shared
     config: { name: pending, type: csv, path: pending.csv }
@@ -759,11 +759,11 @@ nodes:
       schema:
         - { name: id, type: string }
         - { name: payload, type: string }
-  - type: output
+  - type: sink
     name: failing
     input: shared
     config: { name: failing, type: csv, path: failing.csv }
-  - type: output
+  - type: sink
     name: pending
     input: shared
     config: { name: pending, type: csv, path: pending.csv }
@@ -818,7 +818,7 @@ fn test_multi_output_two_writers() {
     conditions:
       high: amount_val > 100
     default: low
-- type: output
+- type: sink
   name: high
   input: classify
   config:
@@ -826,7 +826,7 @@ fn test_multi_output_two_writers() {
     path: high.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: low
   input: classify
   config:
@@ -870,7 +870,7 @@ fn test_multi_output_three_writers() {
       high: amount_val > 1000
       medium: amount_val > 100
     default: low
-- type: output
+- type: sink
   name: high
   input: classify
   config:
@@ -878,7 +878,7 @@ fn test_multi_output_three_writers() {
     path: high.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: medium
   input: classify
   config:
@@ -886,7 +886,7 @@ fn test_multi_output_three_writers() {
     path: medium.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: low
   input: classify
   config:
@@ -917,7 +917,7 @@ fn test_multi_output_record_counts() {
     conditions:
       big: amount_val > 50
     default: small
-- type: output
+- type: sink
   name: big
   input: classify
   config:
@@ -925,7 +925,7 @@ fn test_multi_output_record_counts() {
     path: big.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: small
   input: classify
   config:
@@ -961,7 +961,7 @@ fn test_multi_output_order_preserved() {
     conditions:
       big: amount_val > 50
     default: small
-- type: output
+- type: sink
   name: big
   input: classify
   config:
@@ -969,7 +969,7 @@ fn test_multi_output_order_preserved() {
     path: big.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: small
   input: classify
   config:
@@ -1037,7 +1037,7 @@ fn test_multi_output_writer_error_propagated() {
     conditions:
       good: amount_val > 50
     default: bad
-- type: output
+- type: sink
   name: good
   input: classify
   config:
@@ -1045,7 +1045,7 @@ fn test_multi_output_writer_error_propagated() {
     path: good.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: bad
   input: classify
   config:
@@ -1097,7 +1097,7 @@ fn test_multi_output_inclusive_duplicate() {
       report: amount_val > 50
     default: standard
     mode: inclusive
-- type: output
+- type: sink
   name: audit
   input: classify
   config:
@@ -1105,7 +1105,7 @@ fn test_multi_output_inclusive_duplicate() {
     path: audit.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: report
   input: classify
   config:
@@ -1113,7 +1113,7 @@ fn test_multi_output_inclusive_duplicate() {
     path: report.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: standard
   input: classify
   config:
@@ -1171,7 +1171,7 @@ nodes:
     cxl: 'emit val = id
 
       '
-- type: output
+- type: sink
   name: out
   input: passthrough
   config:
@@ -1201,7 +1201,7 @@ fn test_multi_output_empty_route() {
     conditions:
       special: amount_val > 99999
     default: normal
-- type: output
+- type: sink
   name: special
   input: classify
   config:
@@ -1209,7 +1209,7 @@ fn test_multi_output_empty_route() {
     path: special.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: normal
   input: classify
   config:
@@ -1273,7 +1273,7 @@ fn test_multi_output_writer_panic_propagated() {
     conditions:
       good: amount_val > 50
     default: bad
-- type: output
+- type: sink
   name: good
   input: classify
   config:
@@ -1281,7 +1281,7 @@ fn test_multi_output_writer_panic_propagated() {
     path: good.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: bad
   input: classify
   config:
@@ -1368,7 +1368,7 @@ nodes:
     conditions:
       big: amount_val > 50
     default: small
-- type: output
+- type: sink
   name: big
   input: classify
   config:
@@ -1376,7 +1376,7 @@ nodes:
     path: big.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: small
   input: classify
   config:
@@ -1433,7 +1433,7 @@ fn test_multi_output_send_error_disconnected() {
     conditions:
       a: amount_val > 50
     default: b
-- type: output
+- type: sink
   name: a
   input: classify
   config:
@@ -1441,7 +1441,7 @@ fn test_multi_output_send_error_disconnected() {
     path: a.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: b
   input: classify
   config:
@@ -1507,7 +1507,7 @@ fn test_multi_output_multiple_errors_collected() {
     conditions:
       a: amount_val > 50
     default: b
-- type: output
+- type: sink
   name: a
   input: classify
   config:
@@ -1515,7 +1515,7 @@ fn test_multi_output_multiple_errors_collected() {
     path: a.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: b
   input: classify
   config:
@@ -1622,7 +1622,7 @@ nodes:
     conditions:
       high: amount_val > 100
     default: low
-- type: output
+- type: sink
   name: high
   input: classify
   config:
@@ -1630,7 +1630,7 @@ nodes:
     path: high.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: low
   input: classify
   config:
@@ -1693,7 +1693,7 @@ nodes:
     conditions:
       special: amount_val / divisor > 0
     default: normal
-- type: output
+- type: sink
   name: special
   input: calc
   config:
@@ -1701,7 +1701,7 @@ nodes:
     path: special.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: normal
   input: calc
   config:
@@ -1782,7 +1782,7 @@ nodes:
     conditions:
       high: amount_val > 100
     default: low
-- type: output
+- type: sink
   name: high
   input: classify
   config:
@@ -1790,7 +1790,7 @@ nodes:
     path: high.csv
     type: csv
     include_unmapped: true
-- type: output
+- type: sink
   name: low
   input: classify
   config:
@@ -1882,7 +1882,7 @@ nodes:
     cxl: 'emit val = amount.to_int()
 
       '
-- type: output
+- type: sink
   name: out
   input: calc
   config:
@@ -1941,7 +1941,7 @@ nodes:
     cxl: 'emit id_val = id
 
       '
-- type: output
+- type: sink
   name: dest
   input: identity
   config:
@@ -2007,7 +2007,7 @@ nodes:
     cxl: 'emit x_val = x
 
       '
-- type: output
+- type: sink
   name: dest
   input: identity
   config:

--- a/crates/clinker-exec/tests/multi_record_pipeline.rs
+++ b/crates/clinker-exec/tests/multi_record_pipeline.rs
@@ -80,14 +80,14 @@ nodes:
       conditions:
         big: amount > 150
       default: small
-  - type: output
+  - type: sink
     name: out_big
     input: classify.big
     config:
       name: out_big
       type: csv
       path: big.csv
-  - type: output
+  - type: sink
     name: out_small
     input: classify.small
     config:
@@ -217,7 +217,7 @@ nodes:
         records:
 {first}
 {second}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -254,7 +254,7 @@ nodes:
         records:
 {first}
 {second}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -325,7 +325,7 @@ nodes:
       schema:
         - { name: required_alias, source_name: required_wire, type: int, start: 0, width: 3 }
         - { name: nullable_alias, source_name: nullable_wire, type: { nullable: int }, start: 3, width: 3 }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -370,7 +370,7 @@ nodes:
             columns:
               - { name: required_alias, source_name: required_wire, type: int, start: 1, width: 3 }
               - { name: nullable_alias, source_name: nullable_wire, type: { nullable: int }, start: 4, width: 3 }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -418,7 +418,7 @@ nodes:
               - { name: kind, type: string }
               - { name: required_alias, source_name: required_wire, type: int }
               - { name: nullable_alias, source_name: nullable_wire, type: { nullable: int } }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -453,7 +453,7 @@ nodes:
         mode: drop
       schema:
         - { name: logical, source_name: physical, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -664,7 +664,7 @@ nodes:
       cxl: |
         emit kind = record_type
         emit amount = amount
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:

--- a/crates/clinker-exec/tests/multi_source_ingestion.rs
+++ b/crates/clinker-exec/tests/multi_source_ingestion.rs
@@ -80,7 +80,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [src_a, src_b]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -183,7 +183,7 @@ nodes:
         emit id = id
         emit tag = tag
         emit origin = $source.name
-  - type: output
+  - type: sink
     name: out
     input: stamp
     config:
@@ -302,7 +302,7 @@ nodes:
         emit id = id
         emit tag = tag
         emit safe_ratio = if($source.name == "src_b") then (1 / 0) else 1
-  - type: output
+  - type: sink
     name: out
     input: tfm
     config:
@@ -402,14 +402,14 @@ nodes:
       cxl: |
         emit id = id
         emit tag = tag
-  - type: output
+  - type: sink
     name: out_a
     input: tfm_a
     config:
       name: out_a
       type: csv
       path: out_a.csv
-  - type: output
+  - type: sink
     name: out_b
     input: tfm_b
     config:
@@ -519,7 +519,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [tfm_a, tfm_b]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -627,14 +627,14 @@ nodes:
       cxl: |
         emit id = id
         emit tag = tag
-  - type: output
+  - type: sink
     name: out_a
     input: src_a
     config:
       name: out_a
       type: csv
       path: out_a.csv
-  - type: output
+  - type: sink
     name: out_b
     input: stamp_b
     config:
@@ -728,7 +728,7 @@ nodes:
       cxl: |
         emit id = id
         emit origin_file = $source.file
-  - type: output
+  - type: sink
     name: out
     input: stamp_source
     config:

--- a/crates/clinker-exec/tests/multiport_node_buffer.rs
+++ b/crates/clinker-exec/tests/multiport_node_buffer.rs
@@ -112,7 +112,7 @@ nodes:
   - type: merge
     name: recombined
     inputs: [by_region.a, by_region.b]
-  - type: output
+  - type: sink
     name: out
     input: recombined
     config:
@@ -194,7 +194,7 @@ nodes:
         emit dropped_account = dropped.account
         emit dropped_status = dropped.status
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -258,7 +258,7 @@ nodes:
   - type: merge
     name: both
     inputs: [left, right]
-  - type: output
+  - type: sink
     name: out
     input: both
     config:
@@ -319,7 +319,7 @@ nodes:
   - type: merge
     name: recombined
     inputs: [by_value.hi, by_value.big]
-  - type: output
+  - type: sink
     name: out
     input: recombined
     config:
@@ -407,7 +407,7 @@ nodes:
         emit dropped_account = dropped.account
         emit dropped_status = dropped.status
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -483,7 +483,7 @@ nodes:
         emit left_side = l.side
         emit right_side = r.side
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -545,11 +545,11 @@ nodes:
   - type: merge
     name: m2
     inputs: [splitter.big, c]
-  - type: output
+  - type: sink
     name: out1
     input: m1
     config: { name: out1, type: csv, path: o1.csv }
-  - type: output
+  - type: sink
     name: out2
     input: m2
     config: { name: out2, type: csv, path: o2.csv }

--- a/crates/clinker-exec/tests/nested_envelope_test.rs
+++ b/crates/clinker-exec/tests/nested_envelope_test.rs
@@ -173,7 +173,7 @@ nodes:
         emit isa = $doc.interchange.tag
         emit gs = $doc.group.tag
         emit st = $doc.transaction.tag
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:

--- a/crates/clinker-exec/tests/node_buffer_missing_fail_loud.rs
+++ b/crates/clinker-exec/tests/node_buffer_missing_fail_loud.rs
@@ -135,7 +135,7 @@ fn route_pipeline(name: &str, selected_consumer: &str) -> String {
         keep: "status == 'keep'"
       default: drop
 {selected_consumer}
-  - type: output
+  - type: sink
     name: dropped
     input: split.drop
     config:
@@ -161,7 +161,7 @@ fn cull_pipeline(name: &str, main_consumer: &str) -> String {
         - name: remove_bad
           drop_group_when: "sum(if status == 'bad' then 1 else 0) > 0"
 {main_consumer}
-  - type: output
+  - type: sink
     name: removed
     input: gate.removed
     config:
@@ -198,7 +198,7 @@ fn transform_diamond_delivers_source_to_branch_and_combine() {
         emit dept = detail.dept
         emit flag = extra.flag
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -245,7 +245,7 @@ fn aggregate_diamond_delivers_source_to_branch_and_combine() {
         emit dept = detail.dept
         emit n = summary.n
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -290,14 +290,14 @@ nodes:
     config:
       cxl: |
         emit branch = "sibling"
-  - type: output
+  - type: sink
     name: composed_out
     input: composed
     config:
       name: composed_out
       type: csv
       path: composed.csv
-  - type: output
+  - type: sink
     name: sibling_out
     input: sibling
     config:
@@ -384,14 +384,14 @@ fn two_direct_outputs(first: &str, second: &str) -> String {
     config:
       cxl: |
         emit marker = "ready"
-  - type: output
+  - type: sink
     name: {first}
     input: prepared
     config:
       name: {first}
       type: csv
       path: {first}.csv
-  - type: output
+  - type: sink
     name: {second}
     input: prepared
     config:
@@ -413,7 +413,7 @@ fn direct_outputs(outputs: &[(&str, bool)]) -> String {
                 ""
             };
             format!(
-                r#"  - type: output
+                r#"  - type: sink
     name: {name}
     input: prepared
     config:
@@ -536,7 +536,7 @@ fn output_sort_and_aggregate_share_one_materialized_predecessor() {
     config:
       cxl: |
         emit marker = "ready"
-  - type: output
+  - type: sink
     name: direct
     input: prepared
     config:
@@ -553,7 +553,7 @@ fn output_sort_and_aggregate_share_one_materialized_predecessor() {
       rules:
         - name: keep
           when: "true"
-  - type: output
+  - type: sink
     name: sorted
     input: ordered
     config:
@@ -568,7 +568,7 @@ fn output_sort_and_aggregate_share_one_materialized_predecessor() {
       cxl: |
         emit dept = dept
         emit n = count(*)
-  - type: output
+  - type: sink
     name: summarized
     input: summary
     config:
@@ -603,7 +603,7 @@ fn aggregate_sort_and_output_share_one_predecessor_in_reverse_order() {
       cxl: |
         emit dept = dept
         emit n = count(*)
-  - type: output
+  - type: sink
     name: summarized
     input: summary
     config:
@@ -620,14 +620,14 @@ fn aggregate_sort_and_output_share_one_predecessor_in_reverse_order() {
       rules:
         - name: keep
           when: "true"
-  - type: output
+  - type: sink
     name: sorted
     input: ordered
     config:
       name: sorted
       type: csv
       path: sorted.csv
-  - type: output
+  - type: sink
     name: direct
     input: prepared
     config:
@@ -656,7 +656,7 @@ fn route_to_aggregate_delivers_the_selected_branch() {
       cxl: |
         emit dept = dept
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: summarize
     config:
@@ -692,7 +692,7 @@ fn route_to_reshape_delivers_the_selected_branch() {
           mutate:
             set:
               label: "'reshaped'"
-  - type: output
+  - type: sink
     name: out
     input: relabel
     config:
@@ -730,14 +730,14 @@ fn route_to_cull_delivers_the_selected_branch() {
       rules:
         - name: remove_bad
           drop_group_when: "sum(if status == 'bad' then 1 else 0) > 0"
-  - type: output
+  - type: sink
     name: out
     input: filter_kept
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: filtered
     input: filter_kept.removed
     config:
@@ -775,7 +775,7 @@ fn cull_to_aggregate_delivers_main_and_removed_ports() {
       cxl: |
         emit dept = dept
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: summarize
     config:
@@ -811,7 +811,7 @@ fn cull_to_reshape_delivers_main_and_removed_ports() {
           mutate:
             set:
               label: "'reshaped'"
-  - type: output
+  - type: sink
     name: out
     input: relabel
     config:
@@ -849,14 +849,14 @@ fn a_present_empty_materialized_buffer_remains_a_valid_input() {
       rules:
         - name: remove_bad
           drop_group_when: "sum(if status == 'bad' then 1 else 0) > 0"
-  - type: output
+  - type: sink
     name: out
     input: filter_rows
     config:
       name: out
       type: csv
       path: out.csv
-  - type: output
+  - type: sink
     name: removed
     input: filter_rows.removed
     config:
@@ -882,7 +882,7 @@ fn fused_transform_and_streaming_output_control_still_succeeds() {
     config:
       cxl: |
         emit marker = "ready"
-  - type: output
+  - type: sink
     name: out
     input: prepared
     config:

--- a/crates/clinker-exec/tests/observability_isolation.rs
+++ b/crates/clinker-exec/tests/observability_isolation.rs
@@ -202,7 +202,7 @@ nodes:
           when: on_error
           message: "Customer transform failed"
           fields: [customer_id, secret]
-  - type: output
+  - type: sink
     name: output
     input: observe_customers
     config:

--- a/crates/clinker-exec/tests/ordering_contract.rs
+++ b/crates/clinker-exec/tests/ordering_contract.rs
@@ -102,7 +102,7 @@ nodes:
         - {{ name: key, type: int }}
         - {{ name: group, type: string }}
         - {{ name: payload, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:
@@ -137,7 +137,7 @@ nodes:
       type: csv
       glob: ./*.csv
       schema: [{ name: key, type: int }]
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:
@@ -183,7 +183,7 @@ nodes:
       glob: ./*.csv
       dlq_granularity: document
       schema: [{ name: key, type: int }]
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:
@@ -233,7 +233,7 @@ nodes:
     name: merged
     inputs: [left, right]
     config: { mode: concat }
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -395,7 +395,7 @@ nodes:
         - {{ name: key, type: int }}
         - {{ name: group, type: string }}
         - {{ name: payload, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:
@@ -458,7 +458,7 @@ nodes:
       schema:
         - {{ name: key, type: int }}
         - {{ name: payload, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:
@@ -539,7 +539,7 @@ fn writer_boundary_mode_matrix() {
 fn output_pipeline(memory_limit: &str, worker_threads: usize, fanout: bool) -> String {
     let second_output = if fanout {
         r#"
-  - type: output
+  - type: sink
     name: out_b
     input: rows
     config:
@@ -570,7 +570,7 @@ nodes:
       schema:
         - {{ name: key, type: int }}
         - {{ name: payload, type: string }}
-  - type: output
+  - type: sink
     name: out_a
     input: rows
     config:
@@ -735,7 +735,7 @@ pipeline:
         - {{ name: key, type: {{ nullable: int }} }}
         - {{ name: group, type: {{ nullable: int }} }}
         - {{ name: payload, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:
@@ -1076,7 +1076,7 @@ nodes:
     inputs: [left, right]
     config:
       mode: concat
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -1195,7 +1195,7 @@ nodes:
     inputs: [left, right]
     config:
       mode: {mode}
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -1273,7 +1273,7 @@ nodes:
     inputs: [left, right]
     config:
       mode: interleave
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -1352,7 +1352,7 @@ nodes:
       cxl: |
         emit sku = products.sku
         emit bracket_id = brackets.bracket_id
-  - type: output
+  - type: sink
     name: out
     input: assign_bracket
     config:
@@ -1409,7 +1409,7 @@ nodes:
       cxl: |
         emit key = key
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: totals
     config:
@@ -1499,7 +1499,7 @@ nodes:
         emit did = drivers.did
         emit tid = builds.tid
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -1687,7 +1687,7 @@ nodes:
         emit did = drivers.id
         emit tid = builds.id
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: banded
     config:
@@ -2014,7 +2014,7 @@ nodes:
       schema:
         - { name: key, type: int }
       sort_order: [key]
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:
@@ -2077,7 +2077,7 @@ nodes:
     inputs: [left, right]
     config:
       mode: interleave
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -2121,7 +2121,7 @@ nodes:
       schema:
         - { name: key, type: int }
         - { name: payload, type: string }
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:

--- a/crates/clinker-exec/tests/output_envelope_seam.rs
+++ b/crates/clinker-exec/tests/output_envelope_seam.rs
@@ -57,7 +57,7 @@ nodes:
       cxl: |
         emit amount = amount
         emit batch = $doc.BatchInfo.batch_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -176,7 +176,7 @@ nodes:
       cxl: |
         emit amount = amount
         emit batch = $doc.BatchInfo.batch_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -307,7 +307,7 @@ nodes:
       glob: ./*.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -340,7 +340,7 @@ nodes:
       dlq_granularity: document
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -372,7 +372,7 @@ nodes:
       correlation_key: order_id
       schema:
         - { name: order_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -413,7 +413,7 @@ nodes:
               batch_id: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -462,7 +462,7 @@ nodes:
               checksum: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -517,7 +517,7 @@ nodes:
               checksum: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -579,7 +579,7 @@ nodes:
               checksum: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -695,7 +695,7 @@ nodes:
       propagate_ck: driver
       cxl: |
         emit id = a.id
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:
@@ -740,7 +740,7 @@ nodes:
       group_by: []
       cxl: |
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: totals
     config:
@@ -802,7 +802,7 @@ nodes:
               id: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out_a
     input: src_a
     config:
@@ -813,7 +813,7 @@ nodes:
       options:
         envelope:
           header_from_doc: HeadB
-  - type: output
+  - type: sink
     name: out_b
     input: src_b
     config:
@@ -856,7 +856,7 @@ nodes:
               batch_id: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -902,7 +902,7 @@ nodes:
               batch_id: string
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:
@@ -993,7 +993,7 @@ nodes:
     inputs: [a, b]
     config:
       mode: concat
-  - type: output
+  - type: sink
     name: out
     input: both
     config:
@@ -1024,7 +1024,7 @@ nodes:
       paths: [a.csv, b.csv]
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -1065,7 +1065,7 @@ nodes:
     inputs: [a, b]
     config:
       mode: concat
-  - type: output
+  - type: sink
     name: out
     input: both
     config:
@@ -1110,7 +1110,7 @@ nodes:
     body: both
     config:
       strategy: concat
-  - type: output
+  - type: sink
     name: out
     input: one_doc
     config:
@@ -1155,7 +1155,7 @@ nodes:
     body: both
     config:
       strategy: preserve
-  - type: output
+  - type: sink
     name: out
     input: passthrough
     config:
@@ -1217,7 +1217,7 @@ nodes:
     body: joined
     config:
       strategy: concat
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:
@@ -1277,7 +1277,7 @@ nodes:
     body: joined
     config:
       strategy: preserve
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:
@@ -1358,7 +1358,7 @@ nodes:
     inputs: [joined, framed]
     config:
       mode: concat
-  - type: output
+  - type: sink
     name: out
     input: both
     config:
@@ -1395,7 +1395,7 @@ nodes:
       paths: [a.csv, b.csv]
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/output_policy.rs
+++ b/crates/clinker-exec/tests/output_policy.rs
@@ -192,7 +192,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [a, b]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -232,7 +232,7 @@ nodes:
       options: { has_header: true }
       schema:
         - { name: x, type: string }
-  - type: output
+  - type: sink
     name: out
     input: a
     config:
@@ -268,7 +268,7 @@ nodes:
       options: { has_header: true }
       schema:
         - { name: x, type: string }
-  - type: output
+  - type: sink
     name: out
     input: customers
     config:

--- a/examples/pipelines/order_fulfillment.yaml
+++ b/examples/pipelines/order_fulfillment.yaml
@@ -87,7 +87,7 @@ nodes:
         emit handling_fee = if priority_level == "urgent" then $vars.express_surcharge else 0.0
         emit region = $vars.region
 
-  - type: output
+  - type: sink
     name: fulfilled_orders
     input: route_priority
     config:
@@ -96,7 +96,7 @@ nodes:
       path: ./output/fulfilled_orders.csv
       include_unmapped: false
 
-  - type: output
+  - type: sink
     name: priority_report
     input: route_priority
     config:


### PR DESCRIPTION
## Summary

- migrate multi-source, multi-output, ordering, observability, and output-policy integration fixtures to `type: sink`
- update the directly executed order-fulfillment example to the current terminal syntax
- preserve the intentional retired-syntax diagnostic fixture and all output-domain terminology

## Verification

- 14 focused `clinker-exec` integration targets: 202 passed, 0 failed
- `cargo fmt --all --check`
- `git diff --check`

This pull request is stacked on `executor-sink-fixtures-f` and contains only the next executable fixture slice.
