### PR TITLE
Migrate lineage and window fixtures to Sink

### DIFF
--- a/crates/clinker-exec/tests/partition_lineage_test.rs
+++ b/crates/clinker-exec/tests/partition_lineage_test.rs
@@ -39,7 +39,7 @@ nodes:
       path: data/orders.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -71,7 +71,7 @@ nodes:
       glob: data/orders_*.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -110,7 +110,7 @@ nodes:
       regex: '^.*\.csv$'
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -142,7 +142,7 @@ nodes:
         - data/feb.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -183,7 +183,7 @@ nodes:
   - type: merge
     name: m
     inputs: [a, b]
-  - type: output
+  - type: sink
     name: out
     input: m
     config:
@@ -248,7 +248,7 @@ nodes:
         emit id = orders.id
         emit dept_id = orders.dept_id
         emit dept_name = depts.dept_name
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -289,7 +289,7 @@ nodes:
       glob: data/*.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/path_a_parity.rs
+++ b/crates/clinker-exec/tests/path_a_parity.rs
@@ -209,7 +209,7 @@ nodes:
       cxl: |
         emit id = id
 
-  - type: output
+  - type: sink
     name: out
     input: passthrough
     config:
@@ -416,14 +416,14 @@ nodes:
     config:
       cxl: |
         emit id = id
-  - type: output
+  - type: sink
     name: out_a
     input: passthrough_a
     config:
       name: out_a
       type: csv
       path: out_a.csv
-  - type: output
+  - type: sink
     name: out_b
     input: passthrough_b
     config:

--- a/crates/clinker-exec/tests/per_source_dlq_counts.rs
+++ b/crates/clinker-exec/tests/per_source_dlq_counts.rs
@@ -76,7 +76,7 @@ nodes:
       cxl: |
         emit id = id
         emit ratio = if($source.name == "src_bad") then (1 / 0) else amt
-  - type: output
+  - type: sink
     name: out
     input: tfm
     config:

--- a/crates/clinker-exec/tests/per_source_merged_dlq.rs
+++ b/crates/clinker-exec/tests/per_source_merged_dlq.rs
@@ -85,7 +85,7 @@ nodes:
       cxl: |
         emit category = category
         emit ratio = total / (total - total)
-  - type: output
+  - type: sink
     name: out
     input: post
     config:

--- a/crates/clinker-exec/tests/per_source_record_counts.rs
+++ b/crates/clinker-exec/tests/per_source_record_counts.rs
@@ -65,7 +65,7 @@ nodes:
   - type: merge
     name: m
     inputs: [src_a, src_b]
-  - type: output
+  - type: sink
     name: out
     input: m
     config:
@@ -147,7 +147,7 @@ nodes:
     inputs: [src_a, src_b]
     config:
       mode: interleave
-  - type: output
+  - type: sink
     name: out
     input: m
     config:
@@ -219,7 +219,7 @@ nodes:
       path: only.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: only
     config:
@@ -273,7 +273,7 @@ nodes:
       path: empty.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: empty_src
     config:
@@ -334,7 +334,7 @@ nodes:
     config:
       cxl: |
         emit id = id
-  - type: output
+  - type: sink
     name: out
     input: shape
     config:

--- a/crates/clinker-exec/tests/per_source_rollback.rs
+++ b/crates/clinker-exec/tests/per_source_rollback.rs
@@ -91,7 +91,7 @@ nodes:
       cxl: |
         emit id = id
         emit ratio = if($source.name == "src_b") then (1 / 0) else amt
-  - type: output
+  - type: sink
     name: out
     input: tfm
     config:
@@ -188,7 +188,7 @@ nodes:
       cxl: |
         emit id = id
         emit ratio = if(tag == "bad") then (1 / 0) else amt
-  - type: output
+  - type: sink
     name: out
     input: tfm
     config:
@@ -299,7 +299,7 @@ nodes:
         emit amt = d.amt
         emit dept = b.dept
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -418,7 +418,7 @@ nodes:
         emit id = d.id
         emit ratio = d.amt / b.factor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -624,7 +624,7 @@ nodes:
         emit x = b.x
         emit ratio = d.amt / b.factor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -719,7 +719,7 @@ nodes:
         emit id = d.id
         emit ratio = d.amt / b.factor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:
@@ -803,7 +803,7 @@ nodes:
         emit k = src_drv.k
         emit ratio = src_drv.amt / src_bld.factor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: enriched
     config:

--- a/crates/clinker-exec/tests/per_source_watermarks.rs
+++ b/crates/clinker-exec/tests/per_source_watermarks.rs
@@ -93,7 +93,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [src_a, src_b]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -178,7 +178,7 @@ nodes:
       schema:
         - { name: id, type: int }
         - { name: event_time, type: date_time }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -247,7 +247,7 @@ nodes:
       schema:
         - { name: id, type: int }
         - { name: event_time, type: date_time }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -314,7 +314,7 @@ nodes:
   - type: merge
     name: merged
     inputs: [src_a, src_b]
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -377,7 +377,7 @@ nodes:
       schema:
         - { name: id, type: int }
         - { name: tag, type: string }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -426,7 +426,7 @@ nodes:
       schema:
         - { name: id, type: int }
         - { name: event_time, type: date_time }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -478,7 +478,7 @@ nodes:
       schema:
         - { name: id, type: int }
         - { name: event_time, type: date_time }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/post_aggregate_any_all.rs
+++ b/crates/clinker-exec/tests/post_aggregate_any_all.rs
@@ -49,7 +49,7 @@ nodes:
       sort_by:
         - field: region
           order: asc
-- type: output
+- type: sink
   name: out
   input: predicates
   config:

--- a/crates/clinker-exec/tests/post_aggregate_lag_lead.rs
+++ b/crates/clinker-exec/tests/post_aggregate_lag_lead.rs
@@ -54,7 +54,7 @@ nodes:
       sort_by:
         - field: region
           order: asc
-- type: output
+- type: sink
   name: out
   input: lagged
   config:

--- a/crates/clinker-exec/tests/post_aggregate_recompute_determinism.rs
+++ b/crates/clinker-exec/tests/post_aggregate_recompute_determinism.rs
@@ -51,7 +51,7 @@ nodes:
       emit ratio = 1 / (total - 60)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:

--- a/crates/clinker-exec/tests/post_aggregate_window.rs
+++ b/crates/clinker-exec/tests/post_aggregate_window.rs
@@ -114,7 +114,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:
@@ -205,7 +205,7 @@ nodes:
       sort_by:
         - field: region
           order: asc
-- type: output
+- type: sink
   name: out
   input: dept_sums
   config:
@@ -346,7 +346,7 @@ nodes:
       sort_by:
         - field: region
           order: asc
-- type: output
+- type: sink
   name: out
   input: dept_running
   config:
@@ -459,7 +459,7 @@ nodes:
       emit ratio = 1 / (total - 60)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: ratio
   config:
@@ -542,7 +542,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [missing_field]
-- type: output
+- type: sink
   name: out
   input: bad
   config:
@@ -601,7 +601,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:
@@ -687,7 +687,7 @@ nodes:
       emit running_total = $window.sum(amount)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: windowed
   config:

--- a/crates/clinker-exec/tests/post_aggregate_window_ranking.rs
+++ b/crates/clinker-exec/tests/post_aggregate_window_ranking.rs
@@ -47,7 +47,7 @@ nodes:
       sort_by:
         - field: score
           order: asc
-- type: output
+- type: sink
   name: out
   input: ranked
   config:
@@ -225,7 +225,7 @@ nodes:
       emit none_neg = $window.not_exists(score < 0)
     analytic_window:
       group_by: [dept]
-- type: output
+- type: sink
   name: out
   input: predicates
   config:

--- a/crates/clinker-exec/tests/post_aggregate_window_spilled.rs
+++ b/crates/clinker-exec/tests/post_aggregate_window_spilled.rs
@@ -59,7 +59,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:

--- a/crates/clinker-exec/tests/post_combine_array_field.rs
+++ b/crates/clinker-exec/tests/post_combine_array_field.rs
@@ -54,7 +54,7 @@ nodes:
       emit products_array = products
     analytic_window:
       group_by: [products]
-- type: output
+- type: sink
   name: out
   input: aggregate_window
   config:

--- a/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_aggregate_windowed.snap
+++ b/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_aggregate_windowed.snap
@@ -5,4 +5,4 @@ expression: shape
 [source] sales
 [transform] active_only <- sales
 [aggregation] by_dept <- active_only
-[output] dept_totals <- by_dept
+[sink] dept_totals <- by_dept

--- a/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_combine_two_input_equi.snap
+++ b/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_combine_two_input_equi.snap
@@ -5,4 +5,4 @@ expression: shape
 [source] products
 [source] orders
 [combine] enriched <- orders, products
-[output] enriched_out <- enriched
+[sink] enriched_out <- enriched

--- a/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_combine_two_input_mixed.snap
+++ b/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_combine_two_input_mixed.snap
@@ -5,4 +5,4 @@ expression: shape
 [source] products
 [source] orders
 [combine] qualified <- orders, products
-[output] qualified_out <- qualified
+[sink] qualified_out <- qualified

--- a/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_csv_transform_sink.snap
+++ b/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_csv_transform_sink.snap
@@ -4,4 +4,4 @@ expression: shape
 ---
 [source] employees
 [transform] tier_flag <- employees
-[output] results <- tier_flag
+[sink] results <- tier_flag

--- a/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_route_fanout.snap
+++ b/crates/clinker-exec/tests/snapshots/path_a_parity__canonical_dag_route_fanout.snap
@@ -5,5 +5,5 @@ expression: shape
 [source] orders
 [transform] classify <- orders
 [route] classify_route <- classify
-[output] low <- classify_route
-[output] high <- classify_route
+[sink] low <- classify_route
+[sink] high <- classify_route

--- a/examples/pipelines/tests/baseline/aggregate_windowed.yaml
+++ b/examples/pipelines/tests/baseline/aggregate_windowed.yaml
@@ -37,7 +37,7 @@ nodes:
         emit total = sum(amount.to_int())
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: dept_totals
     input: by_dept
     config:

--- a/examples/pipelines/tests/baseline/csv_transform_sink.yaml
+++ b/examples/pipelines/tests/baseline/csv_transform_sink.yaml
@@ -25,7 +25,7 @@ nodes:
         emit salary = salary
         emit tier = if salary.to_int() >= 90000 then "senior" else "junior"
 
-  - type: output
+  - type: sink
     name: results
     input: tier_flag
     config:

--- a/examples/pipelines/tests/baseline/route_fanout.yaml
+++ b/examples/pipelines/tests/baseline/route_fanout.yaml
@@ -31,7 +31,7 @@ nodes:
         high: "amount.to_int() > 100"
       default: low
 
-  - type: output
+  - type: sink
     name: high
     input: classify_route.high
     config:
@@ -39,7 +39,7 @@ nodes:
       type: csv
       path: ./output/high.csv
 
-  - type: output
+  - type: sink
     name: low
     input: classify_route.low
     config:


### PR DESCRIPTION
## Summary

- migrate per-source, lineage, aggregate-window, and post-combine integration fixtures to `type: sink`
- update the directly executed canonical baseline pipelines to the current terminal syntax
- update canonical DAG snapshots to render the Sink node taxonomy while preserving node and port identities

## Verification

- 14 focused `clinker-exec` integration targets: 53 passed, 0 failed
- `cargo fmt --all --check`
- `git diff --check`

This pull request is stacked on `executor-sink-fixtures-g` and contains only the next executable fixture slice.
