### PR TITLE
Compile explicit body Source resource activation

### DIFF
--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -4593,7 +4593,17 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         }
     }
 
-    for input in config.source_configs() {
+    for body in config.source_bodies() {
+        let input = &body.source;
+        // `resource:` replaces file discovery only for a Source authored in a
+        // composition body. Pipeline parsing cannot know that enclosing scope,
+        // so defer every resource-bearing Source to the contextual bind walk:
+        // it rejects the top-level form and validates the body slot/binding.
+        // In particular, do not let E211 mask the resource-specific diagnostic
+        // merely because the direct matcher is intentionally absent.
+        if body.resource.is_some() {
+            continue;
+        }
         // Matcher-exclusivity, gated on transport. A file transport
         // resolves its file set through the discovery layer's
         // `path`/`glob`/`regex`/`paths` matchers, so exactly one must be

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -1228,6 +1228,15 @@ impl PipelineNode {
 /// [`crate::config::PipelineConfig::compile`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SourceBody {
+    /// Composition resource slot that supplies this Source's external target.
+    ///
+    /// This field is valid only on a Source authored inside a composition
+    /// body. The enclosing `_compose.resources_schema` must declare the slot,
+    /// and each call site must bind it through `resources:`. Top-level Sources
+    /// continue to use exactly one direct file matcher until they gain a
+    /// separately designed binding surface.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource: Option<crate::yaml::Spanned<String>>,
     /// The source's unified schema. Required — missing this field is a
     /// serde parse error routed to E201 via the diagnostic layer. A
     /// [`SourceSchema`](clinker_format::SourceSchema) carrying the declared

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -42,6 +42,9 @@ use crate::plan::combine::{
     CombineInput, DecomposedPredicate, decompose_predicate, select_driving_input,
 };
 use crate::plan::composition_body::{BoundBody, CompositionBodyId};
+use crate::plan::execution::{
+    CompiledResourceRequirement, CompiledSourceInstance, CompiledSourceInstanceId,
+};
 use crate::plan::types::JoinSide;
 use crate::plan::{EntityRef, PlanNodeId};
 use crate::resources::WorkspaceCatalog;
@@ -1067,6 +1070,15 @@ fn span_for_node(spanned: &Spanned<PipelineNode>) -> Span {
         Span::line_only(line)
     } else {
         Span::SYNTHETIC
+    }
+}
+
+fn authored_value_span<T>(spanned: &Spanned<T>, fallback: Span) -> Span {
+    let line = spanned.referenced.line() as u32;
+    if line > 0 {
+        Span::line_only(line)
+    } else {
+        fallback
     }
 }
 
@@ -2557,6 +2569,27 @@ fn bind_schema_inner(
 
         match node {
             PipelineNode::Source { config, .. } => {
+                if bind_ctx.depth == 0
+                    && let Some(resource) = config.resource.as_ref()
+                {
+                    diags.push(
+                        Diagnostic::error(
+                            "E103",
+                            format!(
+                                "top-level source {name:?} declares `resource: {}` but top-level resource binding is not available",
+                                resource.value
+                            ),
+                            LabeledSpan::primary(
+                                authored_value_span(resource, span),
+                                "resource slots are composition-body scoped",
+                            ),
+                        )
+                        .with_help(
+                            "remove `resource:` and set exactly one of `path`, `glob`, `regex`, or `paths`; use a composition body plus `_compose.resources_schema` and call-site `resources:` for a catalog-backed Source",
+                        ),
+                    );
+                    continue;
+                }
                 // Resolve the unified `schema:` (single-record column list,
                 // multi-record superset, external file, or engine-generated)
                 // to the effective column list this source seeds its row from.
@@ -3323,7 +3356,24 @@ fn bind_composition(
         }
     }
 
-    // 7b. Body nodes never flow through top-level config validation
+    // 7b. Resolve every authored body Source through one explicit resource
+    // slot before the ordinary body bind. Synthetic input-port Sources are
+    // introduced later and deliberately do not appear in this inventory:
+    // they receive parent records and do not open an external dataset.
+    let pending_source_requirements = match compile_body_source_requirements(
+        &body_file.nodes,
+        signature,
+        call_resources,
+        bind_ctx.resource_catalog,
+        node_name,
+        &resolved_path,
+        diags,
+    ) {
+        Some(requirements) => requirements,
+        None => return,
+    };
+
+    // 7c. Body nodes never flow through top-level config validation
     // (`validate_config` sees only the call-site pipeline's own nodes),
     // so run the shared node-scoped checks here. Without this pass a
     // body Envelope with a wired `trailer:` — or a Transform with a
@@ -3353,7 +3403,7 @@ fn bind_composition(
         }
     }
 
-    // 7c. A body Source/Output CSV `delimiter` / `quote_char` is only ever
+    // 7d. A body Source/Output CSV `delimiter` / `quote_char` is only ever
     // rejected at runtime by the writer's single-byte lowering guard, because
     // top-level `validate_config` (which runs the same check) sees only the
     // call-site pipeline's own nodes. Run the shared byte-option check here so
@@ -3423,7 +3473,7 @@ fn bind_composition(
         }
     }
 
-    // 7d. Resolve external `.schema.yaml` (`SourceSchema::File`) references on
+    // 7e. Resolve external `.schema.yaml` (`SourceSchema::File`) references on
     // body Source and Output nodes to their inline column form, each path
     // resolved relative to the composition file's own directory. Top-level
     // nodes have their externals resolved at parse time by
@@ -3486,7 +3536,7 @@ fn bind_composition(
         }
     }
 
-    // 7e. The multi-value gates (E358 / E359 / E360 / E361) and the E363
+    // 7f. The multi-value gates (E358 / E359 / E360 / E361) and the E363
     // `record_path` grammar gate, which the call-site pipeline runs over its
     // OWN `nodes:` — a list that never contains a body's nodes. Without this
     // pass a body source declaring the retired `array_paths:`, a `multiple:
@@ -3693,6 +3743,18 @@ fn bind_composition(
             .entry(port_name.clone())
             .or_insert_with(|| artifacts.fresh_node_id());
     }
+
+    let source_instances = pending_source_requirements
+        .into_iter()
+        .map(|(source_name, resource)| CompiledSourceInstance {
+            id: CompiledSourceInstanceId {
+                body_scope: body_id.into(),
+                source_node: body_node_ids[&source_name],
+            },
+            source_name,
+            resource,
+        })
+        .collect();
 
     // Recursive bind_schema on body nodes.
     bind_schema_inner(
@@ -4084,6 +4146,7 @@ fn bind_composition(
     // binds, not the body the file spelled.
     bound_body.semantic_digest = body_file.semantic_digest();
     bound_body.resource_bindings = call_resources.clone();
+    bound_body.source_instances = source_instances;
     bound_body.graph = body_graph;
     bound_body.topo_order = body_topo;
     bound_body.name_to_idx = body_name_to_idx;
@@ -4112,6 +4175,162 @@ fn bind_composition(
 }
 
 // ─── Validation helpers ─────────────────────────────────────────────
+
+fn compile_body_source_requirements(
+    nodes: &[Spanned<PipelineNode>],
+    signature: &CompositionSignature,
+    call_resources: &IndexMap<String, ResourceBinding>,
+    catalog: &WorkspaceCatalog,
+    call_name: &str,
+    body_path: &Path,
+    diags: &mut Vec<Diagnostic>,
+) -> Option<Vec<(String, CompiledResourceRequirement)>> {
+    let mut requirements = Vec::new();
+    let mut valid = true;
+
+    for spanned in nodes {
+        let PipelineNode::Source { config, .. } = &spanned.value else {
+            continue;
+        };
+        let source_name = config.source.name.as_str();
+        let node_span = span_for_node(spanned);
+        let Some(authored_slot) = config.resource.as_ref() else {
+            diags.push(
+                Diagnostic::error(
+                    "E103",
+                    format!(
+                        "composition node {call_name:?}: body file {}: source {source_name:?} declares no resource slot; authored body Sources cannot use an inert direct file target",
+                        body_path.display()
+                    ),
+                    LabeledSpan::primary(node_span, "missing body Source resource slot"),
+                )
+                .with_help(
+                    "add `resource: <slot>` to this Source, declare that slot under `_compose.resources_schema`, and bind it at the composition call; if rows arrive from the caller, remove this Source and consume the declared `_compose.inputs` port directly",
+                ),
+            );
+            valid = false;
+            continue;
+        };
+        let slot = authored_slot.value.as_str();
+        let resource_span = authored_value_span(authored_slot, node_span);
+        let matchers: Vec<&str> = [
+            ("path", config.source.path.is_some()),
+            ("glob", config.source.glob.is_some()),
+            ("regex", config.source.regex.is_some()),
+            ("paths", config.source.paths.is_some()),
+        ]
+        .into_iter()
+        .filter_map(|(name, present)| present.then_some(name))
+        .collect();
+        if !matchers.is_empty() {
+            let remove = matchers
+                .iter()
+                .map(|matcher| format!("`{matcher}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            diags.push(
+                Diagnostic::error(
+                    "E103",
+                    format!(
+                        "composition node {call_name:?}: body file {}: source {source_name:?} declares `resource: {slot}` together with direct matcher(s) {}; a resource-backed Source has exactly one external target",
+                        body_path.display(),
+                        matchers.join(", ")
+                    ),
+                    LabeledSpan::primary(resource_span, "resource conflicts with direct matcher"),
+                )
+                .with_help(format!(
+                    "remove {remove}; the catalog resource bound through `resource: {slot}` supplies the Source target"
+                )),
+            );
+            valid = false;
+            continue;
+        }
+        if !config.source.transport.is_file() {
+            diags.push(
+                Diagnostic::error(
+                    "E103",
+                    format!(
+                        "composition node {call_name:?}: body file {}: source {source_name:?} binds file resource slot {slot:?} but declares `{}` transport",
+                        body_path.display(),
+                        config.source.transport.transport_name()
+                    ),
+                    LabeledSpan::primary(resource_span, "file resource requires file transport"),
+                )
+                .with_help("remove `transport:` so the Source uses the default file transport"),
+            );
+            valid = false;
+            continue;
+        }
+        let Some(declaration) = signature.resources_schema.get(slot) else {
+            diags.push(
+                Diagnostic::error(
+                    "E103",
+                    format!(
+                        "composition node {call_name:?}: body file {}: source {source_name:?} names resource slot {slot:?}, but `_compose.resources_schema` does not declare it",
+                        body_path.display()
+                    ),
+                    LabeledSpan::primary(resource_span, "undeclared body Source resource slot"),
+                )
+                .with_help(format!(
+                    "add `{slot}: {{ kind: file, required: true }}` under `_compose.resources_schema`"
+                )),
+            );
+            valid = false;
+            continue;
+        };
+        let Some(binding) = call_resources.get(slot) else {
+            diags.push(
+                Diagnostic::error(
+                    "E103",
+                    format!(
+                        "composition node {call_name:?}: body source {source_name:?} uses resource slot {slot:?}, but this call does not bind it"
+                    ),
+                    LabeledSpan::primary(resource_span, "unbound body Source resource slot"),
+                )
+                .with_help(format!(
+                    "add `resources: {{ {slot}: <catalog-resource-id> }}` to composition node {call_name:?}"
+                )),
+            );
+            valid = false;
+            continue;
+        };
+        let resource = match catalog.resolve_resource(binding.logical_id()) {
+            Ok(resource) => resource,
+            Err(error) => {
+                diags.push(
+                    Diagnostic::error(
+                        "E103",
+                        format!(
+                            "composition node {call_name:?}: body source {source_name:?} cannot resolve resource slot {slot:?}: {error}"
+                        ),
+                        LabeledSpan::primary(resource_span, "unresolved body Source resource"),
+                    )
+                    .with_help("bind the slot to an existing compatible catalog resource"),
+                );
+                valid = false;
+                continue;
+            }
+        };
+        requirements.push((
+            source_name.to_owned(),
+            CompiledResourceRequirement {
+                slot: slot.to_owned(),
+                binding: binding.clone(),
+                kind: declaration.kind,
+                required_capabilities: declaration
+                    .kind
+                    .required_capabilities()
+                    .to_vec()
+                    .into_boxed_slice(),
+                opener: declaration.kind.opener_kind(),
+                lifetime: declaration.kind.lifetime(),
+                dataset_identity: resource.dataset_identity(),
+            },
+        ));
+    }
+
+    valid.then_some(requirements)
+}
 
 /// Validate call-site `inputs:` against the signature's declared input ports.
 /// Returns `true` if validation passes (no errors emitted).

--- a/crates/clinker-plan/src/plan/composition_body.rs
+++ b/crates/clinker-plan/src/plan/composition_body.rs
@@ -11,7 +11,7 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use crate::config::composition::ResourceBinding;
 
 use super::deferred_region::{DeferredRegion, ParentContinuation};
-use super::execution::{PlanEdge, PlanNode};
+use super::execution::{CompiledSourceInstance, PlanEdge, PlanNode};
 
 /// Opaque handle into `CompileArtifacts.composition_bodies`. Each
 /// `PipelineNode::Composition` in `CompiledPlan` carries one of these
@@ -122,6 +122,14 @@ pub struct BoundBody {
     /// explain tooling can report how the body was configured without
     /// retaining a descriptor, credential choice, or opened handle.
     pub resource_bindings: IndexMap<String, ResourceBinding>,
+
+    /// Scoped activation contracts for Sources authored in this body.
+    ///
+    /// Synthetic input-port roots are not entries: their records arrive from
+    /// the parent body rather than from an external resource. Entries contain
+    /// only logical, typed requirements and never physical locators, secrets,
+    /// credentials, opened handles, or runtime state.
+    pub source_instances: Vec<CompiledSourceInstance>,
 
     /// Body's mini-DAG of lowered `PlanNode`s. NodeIndices here live
     /// in their own space — they do not collide with NodeIndices in
@@ -255,6 +263,7 @@ impl BoundBody {
             semantic_name: String::new(),
             semantic_digest: [0; 32],
             resource_bindings: IndexMap::new(),
+            source_instances: Vec::new(),
             graph: DiGraph::new(),
             topo_order: Vec::new(),
             name_to_idx: HashMap::new(),

--- a/crates/clinker-plan/src/plan/execution/activation.rs
+++ b/crates/clinker-plan/src/plan/execution/activation.rs
@@ -1,0 +1,68 @@
+//! Plan-time composition Source activation contracts.
+//!
+//! These values describe which typed, logical resource a body Source will
+//! require once runtime activation is implemented. They deliberately contain
+//! no physical path, credential selection, secret, opened handle, I/O state,
+//! or thread state. One instance is scoped to one bound body call, so two
+//! calls to the same composition never share mutable source identity.
+
+use crate::config::{
+    ResourceBinding, ResourceCapability, ResourceKind, ResourceLifetime, ResourceOpenerKind,
+};
+use crate::plan::PlanNodeId;
+use crate::plan::composition_body::BodyScopeId;
+use crate::resources::ResourceDatasetIdentity;
+
+/// Stable identity of one Source authored in one bound composition body.
+///
+/// `body_scope` distinguishes separate call sites, while `source_node`
+/// distinguishes Sources within that body. Both values are minted in stable
+/// declaration order, so compiling identical input twice yields identical
+/// identities without relying on an author-chosen name.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub struct CompiledSourceInstanceId {
+    /// Call-site-local body scope.
+    pub body_scope: BodyScopeId,
+    /// Stable node identity of the authored body Source.
+    pub source_node: PlanNodeId,
+}
+
+/// Secret-free typed resource requirement for one body Source.
+///
+/// The binding retains the logical catalog identity and complete overlay
+/// provenance. The catalog's physical descriptor remains outside
+/// [`crate::plan::CompiledPlan`]; only its kind, capabilities, opener family,
+/// lifetime, and stable logical dataset identity cross this boundary.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledResourceRequirement {
+    /// Authored slot in the enclosing `_compose.resources_schema`.
+    pub slot: String,
+    /// Winning logical identity plus attempted/winning overlay provenance.
+    pub binding: ResourceBinding,
+    /// Required descriptor kind.
+    pub kind: ResourceKind,
+    /// Complete finite capability request for this kind.
+    pub required_capabilities: Box<[ResourceCapability]>,
+    /// Provider-neutral opener family required later at activation.
+    pub opener: ResourceOpenerKind,
+    /// Maximum lifetime of the future opened resource.
+    pub lifetime: ResourceLifetime,
+    /// Stable logical dataset identity, independent of physical location.
+    pub dataset_identity: ResourceDatasetIdentity,
+}
+
+/// One plan-time body Source instance and its exact resource dependency.
+///
+/// The value is fixed, configuration-derived state. It performs no execution
+/// work and retains a constant amount of data per authored Source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CompiledSourceInstance {
+    /// Scope-qualified source identity.
+    pub id: CompiledSourceInstanceId,
+    /// Author-facing source name, retained for diagnostics only.
+    pub source_name: String,
+    /// Typed, secret-free resource requirement.
+    pub resource: CompiledResourceRequirement,
+}

--- a/crates/clinker-plan/src/plan/execution/dag.rs
+++ b/crates/clinker-plan/src/plan/execution/dag.rs
@@ -855,6 +855,7 @@ mod port_tag_guard_tests {
             semantic_name: "test".to_string(),
             semantic_digest: [0; 32],
             resource_bindings: indexmap::IndexMap::new(),
+            source_instances: Vec::new(),
             graph: body_graph,
             topo_order: Vec::new(),
             name_to_idx: HashMap::new(),

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -7,6 +7,7 @@
 // (PlanNode, PlanEdge, ExecutionPlanDag) and re-exports each submodule's
 // surface so `crate::plan::execution::*` paths resolve unchanged.
 
+mod activation;
 mod composition;
 mod consumer_registry;
 mod dag;
@@ -16,6 +17,7 @@ mod graph_util;
 mod scheduling;
 mod streaming_class;
 
+pub use activation::*;
 pub use composition::*;
 pub use consumer_registry::*;
 pub use dag::*;

--- a/crates/clinker-plan/src/plan/semantic_identity.rs
+++ b/crates/clinker-plan/src/plan/semantic_identity.rs
@@ -442,6 +442,18 @@ nodes:
         let pipelines = workspace.path().join("pipelines");
         std::fs::create_dir_all(&compositions).expect("create compositions");
         std::fs::create_dir_all(&pipelines).expect("create pipelines");
+        std::fs::create_dir_all(workspace.path().join("data")).expect("create data");
+        std::fs::write(workspace.path().join("data/reference.csv"), "code\nA\n")
+            .expect("write resource data");
+        std::fs::write(
+            workspace.path().join("clinker.toml"),
+            r#"[catalog.resources.body_reference]
+kind = "file"
+path = "data/reference.csv"
+access = "read"
+"#,
+        )
+        .expect("write resource catalog");
         std::fs::write(
             compositions.join("enrich.comp.yaml"),
             r#"_compose:
@@ -450,13 +462,15 @@ nodes:
     driver:
       schema: [{ name: x, type: int }]
   outputs: { out: shape }
+  resources_schema:
+    reference: { kind: file, required: true }
 nodes:
   - type: source
     name: ref
     config:
       name: ref
       type: csv
-      path: ref.csv
+      resource: reference
       schema: [{ name: code, type: string }]
   - type: transform
     name: shape
@@ -481,6 +495,7 @@ nodes:
     input: drv
     use: ../compositions/enrich.comp.yaml
     inputs: { driver: drv }
+    resources: { reference: body_reference }
   - type: output
     name: out
     input: enrich

--- a/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
@@ -29,6 +29,20 @@ use crate::plan::execution::PlanNode;
 
 use super::deferred_region::{body_id_for, compile_with_dir_full};
 
+fn write_body_source_catalog(workspace: &std::path::Path) {
+    std::fs::create_dir_all(workspace.join("data")).expect("mkdir data");
+    std::fs::write(workspace.join("data/reference.csv"), "code\nA\n").expect("write resource data");
+    std::fs::write(
+        workspace.join("clinker.toml"),
+        r#"[catalog.resources.body_reference]
+kind = "file"
+path = "data/reference.csv"
+access = "read"
+"#,
+    )
+    .expect("write resource catalog");
+}
+
 /// Write a `.comp.yaml` body and a pipeline invoking it, and return the
 /// compile-ready pieces. The body's `nodes:` section is caller-supplied
 /// so each test exercises a different body-node violation.
@@ -299,6 +313,7 @@ fn body_output_valid_csv_delimiter_compiles() {
 #[test]
 fn body_source_bad_csv_quote_char_rejected_at_compile() {
     let workspace = tempfile::tempdir().expect("tempdir");
+    write_body_source_catalog(workspace.path());
     let comp_dir = workspace.path().join("compositions");
     std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
     std::fs::write(
@@ -312,6 +327,8 @@ fn body_source_bad_csv_quote_char_rejected_at_compile() {
   outputs:
     out: shape
   config_schema: {}
+  resources_schema:
+    reference: { kind: file, required: true }
 
 nodes:
   - type: source
@@ -319,7 +336,7 @@ nodes:
     config:
       name: body_src
       type: csv
-      path: body_src.csv
+      resource: reference
       schema:
         - { name: code, type: string }
       options:
@@ -355,6 +372,7 @@ nodes:
     use: ../compositions/src_body.comp.yaml
     inputs:
       driver: drv
+    resources: { reference: body_reference }
   - type: output
     name: out
     input: enrich
@@ -384,6 +402,7 @@ nodes:
 /// contains it.
 fn compile_body_source(source_node: &str) -> Vec<clinker_core_types::Diagnostic> {
     let workspace = tempfile::tempdir().expect("tempdir");
+    write_body_source_catalog(workspace.path());
     let comp_dir = workspace.path().join("compositions");
     std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
     std::fs::write(
@@ -398,6 +417,8 @@ fn compile_body_source(source_node: &str) -> Vec<clinker_core_types::Diagnostic>
   outputs:
     out: shape
   config_schema: {{}}
+  resources_schema:
+    reference: {{ kind: file, required: true }}
 
 nodes:
 {source_node}
@@ -433,6 +454,7 @@ nodes:
     use: ../compositions/mv_body.comp.yaml
     inputs:
       driver: drv
+    resources: { reference: body_reference }
   - type: output
     name: out
     input: enrich
@@ -460,7 +482,7 @@ fn body_source_retired_array_paths_rejected_with_e360() {
     config:
       name: body_src
       type: xml
-      path: body_src.xml
+      resource: reference
       array_paths:
         - path: Item
           mode: explode
@@ -490,7 +512,7 @@ fn body_source_nested_split_to_rows_rejected_with_e358() {
     config:
       name: body_src
       type: xml
-      path: body_src.xml
+      resource: reference
       split_to_rows:
         - Item
         - Item.part
@@ -517,7 +539,7 @@ fn body_source_unproducible_multi_value_column_rejected_with_e361() {
     config:
       name: body_src
       type: csv
-      path: body_src.csv
+      resource: reference
       schema:
         - { name: sku, type: string, multiple: true }"#,
     );
@@ -544,7 +566,7 @@ fn body_source_jsonpath_record_path_rejected_with_e363() {
     config:
       name: body_src
       type: json
-      path: body_src.json
+      resource: reference
       options:
         record_path: "$.data"
       schema:
@@ -688,6 +710,7 @@ nodes:
 #[test]
 fn body_source_external_schema_resolves_relative_to_comp_dir() {
     let workspace = tempfile::tempdir().expect("tempdir");
+    write_body_source_catalog(workspace.path());
     let comp_dir = workspace.path().join("compositions");
     std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
     std::fs::write(
@@ -706,6 +729,8 @@ fn body_source_external_schema_resolves_relative_to_comp_dir() {
   outputs:
     out: shape
   config_schema: {}
+  resources_schema:
+    reference: { kind: file, required: true }
 
 nodes:
   - type: source
@@ -713,7 +738,7 @@ nodes:
     config:
       name: body_src
       type: csv
-      path: body_src.csv
+      resource: reference
       schema: ref.schema.yaml
   - type: transform
     name: shape
@@ -746,6 +771,7 @@ nodes:
     use: ../compositions/src_ref_body.comp.yaml
     inputs:
       driver: drv
+    resources: { reference: body_reference }
   - type: output
     name: out
     input: enrich

--- a/crates/clinker-plan/src/plan/tests/composition_source_patch.rs
+++ b/crates/clinker-plan/src/plan/tests/composition_source_patch.rs
@@ -17,6 +17,20 @@ use indexmap::IndexMap;
 
 use crate::config::{CompileContext, PipelineConfig, SourceConfigPatch, apply_source_patches};
 
+fn write_body_source_catalog(workspace: &std::path::Path) {
+    std::fs::create_dir_all(workspace.join("data")).expect("mkdir data");
+    std::fs::write(workspace.join("data/reference.csv"), "code\nA\n").expect("write resource data");
+    std::fs::write(
+        workspace.join("clinker.toml"),
+        r#"[catalog.resources.body_reference]
+kind = "file"
+path = "data/reference.csv"
+access = "read"
+"#,
+    )
+    .expect("write resource catalog");
+}
+
 /// Build a workspace with a composition body that declares its own source
 /// `ref` and a transform reading it (`emit label = code`), plus the invoking
 /// pipeline whose composition node is named `enrich`. `ref_schema` is the body
@@ -24,6 +38,7 @@ use crate::config::{CompileContext, PipelineConfig, SourceConfigPatch, apply_sou
 /// fix it. Returns the temp workspace and the parsed pipeline config.
 fn workspace_with_body_source(ref_schema: &str) -> (tempfile::TempDir, PipelineConfig) {
     let workspace = tempfile::tempdir().expect("tempdir");
+    write_body_source_catalog(workspace.path());
     let comp_dir = workspace.path().join("compositions");
     std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
     std::fs::write(
@@ -38,6 +53,8 @@ fn workspace_with_body_source(ref_schema: &str) -> (tempfile::TempDir, PipelineC
   outputs:
     out: shape
   config_schema: {{}}
+  resources_schema:
+    reference: {{ kind: file, required: true }}
 
 nodes:
   - type: source
@@ -45,7 +62,7 @@ nodes:
     config:
       name: ref
       type: csv
-      path: ref.csv
+      resource: reference
       schema:
 {ref_schema}
   - type: transform
@@ -80,6 +97,7 @@ nodes:
     use: ../compositions/with_ref.comp.yaml
     inputs:
       driver: drv
+    resources: { reference: body_reference }
   - type: output
     name: out
     input: enrich
@@ -174,6 +192,7 @@ fn unknown_inner_source_fails_at_bind_with_e230() {
 /// `enrich` body, never the same-named nested node inside `wrap`'s body.
 fn workspace_with_shadowed_nested_enrich() -> (tempfile::TempDir, PipelineConfig) {
     let workspace = tempfile::tempdir().expect("tempdir");
+    write_body_source_catalog(workspace.path());
     let comp_dir = workspace.path().join("compositions");
     std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
 
@@ -191,6 +210,8 @@ fn workspace_with_shadowed_nested_enrich() -> (tempfile::TempDir, PipelineConfig
   outputs:
     out: shape
   config_schema: {}
+  resources_schema:
+    reference: { kind: file, required: true }
 
 nodes:
   - type: source
@@ -198,7 +219,7 @@ nodes:
     config:
       name: ref
       type: csv
-      path: ref.csv
+      resource: reference
       schema:
         - { name: raw, type: string }
   - type: transform
@@ -288,6 +309,7 @@ nodes:
     use: ../compositions/with_ref.comp.yaml
     inputs:
       driver: drv
+    resources: { reference: body_reference }
   - type: composition
     name: wrap
     input: drv

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -26,5 +26,6 @@ mod predicate_support;
 mod record_path_validation;
 mod reshape_validation;
 mod route_ports;
+mod source_activation;
 mod typed_scoped_key;
 mod watermark_validation;

--- a/crates/clinker-plan/src/plan/tests/source_activation.rs
+++ b/crates/clinker-plan/src/plan/tests/source_activation.rs
@@ -120,7 +120,7 @@ fn tracer() {
     assert_eq!(requirement.binding.logical_id().as_str(), "shared_orders");
     assert_eq!(requirement.kind.label(), "file");
     assert_eq!(
-        requirement.required_capabilities,
+        requirement.required_capabilities.as_ref(),
         requirement.kind.required_capabilities()
     );
     assert_eq!(requirement.opener, requirement.kind.opener_kind());
@@ -210,6 +210,29 @@ fn body_source_resource_must_name_a_declared_slot() {
 }
 
 #[test]
+fn body_source_resource_must_be_bound_at_the_call_site() {
+    let body = BODY.replace("required: true", "required: false");
+    let workspace = write_workspace(&body);
+    let yaml = pipeline().replace("    resources: { orders: shared_orders }\n", "");
+    let diagnostics = parse_config(&yaml)
+        .expect("pipeline parses")
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace.path(),
+            PathBuf::from("pipelines"),
+        ))
+        .expect_err("a Source cannot use an unbound optional slot");
+    assert!(
+        diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "E103"
+                && diagnostic.message.contains("body source \"read\"")
+                && diagnostic.message.contains("orders")
+                && diagnostic.message.contains("does not bind")
+        }),
+        "{diagnostics:?}"
+    );
+}
+
+#[test]
 fn authored_body_source_requires_an_explicit_resource() {
     let body = BODY.replace("      resource: orders", "      path: private.csv");
     let workspace = write_workspace(&body);
@@ -220,12 +243,19 @@ fn authored_body_source_requires_an_explicit_resource() {
             PathBuf::from("pipelines"),
         ))
         .expect_err("inert direct-path body source must fail");
-    assert!(diagnostics.iter().any(|diagnostic| {
-        diagnostic.code == "E103"
-            && diagnostic.message.contains("read")
-            && diagnostic.message.contains("resource: <slot>")
-            && diagnostic.primary.span.synthetic_line_number().is_some()
-    }));
+    assert!(
+        diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "E103"
+                && diagnostic.message.contains("read")
+                && diagnostic.message.contains("resource slot")
+                && diagnostic
+                    .help
+                    .as_deref()
+                    .is_some_and(|help| help.contains("resource: <slot>"))
+                && diagnostic.primary.span.synthetic_line_number().is_some()
+        }),
+        "{diagnostics:?}"
+    );
 }
 
 #[test]

--- a/crates/clinker-plan/src/plan/tests/source_activation.rs
+++ b/crates/clinker-plan/src/plan/tests/source_activation.rs
@@ -1,0 +1,257 @@
+use std::num::NonZeroU32;
+use std::path::{Path, PathBuf};
+
+use clinker_core_types::span::FileId;
+
+use crate::config::composition::CompositionFile;
+use crate::config::{CompileContext, PipelineConfig, PipelineNode, parse_config};
+use crate::plan::CompiledPlan;
+use crate::plan::execution::PlanNode;
+
+const BODY: &str = r#"_compose:
+  name: catalog_reader
+  inputs: {}
+  outputs: { out: read }
+  config_schema: {}
+  resources_schema:
+    orders:
+      kind: file
+      required: true
+
+nodes:
+  - type: source
+    name: read
+    config:
+      name: read
+      type: csv
+      resource: orders
+      schema: [{ name: id, type: string }]
+"#;
+
+fn write_workspace(body: &str) -> tempfile::TempDir {
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::create_dir_all(workspace.path().join("compositions")).expect("composition dir");
+    std::fs::create_dir_all(workspace.path().join("pipelines")).expect("pipeline dir");
+    std::fs::create_dir_all(workspace.path().join("data")).expect("data dir");
+    std::fs::write(workspace.path().join("data/orders.csv"), "id\n1\n").expect("orders data");
+    std::fs::write(
+        workspace
+            .path()
+            .join("compositions/catalog_reader.comp.yaml"),
+        body,
+    )
+    .expect("composition body");
+    std::fs::write(
+        workspace.path().join("clinker.toml"),
+        r#"[catalog.resources.shared_orders]
+kind = "file"
+path = "data/orders.csv"
+access = "read"
+"#,
+    )
+    .expect("workspace catalog");
+    workspace
+}
+
+fn pipeline() -> &'static str {
+    r#"pipeline: { name: source_activation }
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      path: driver.csv
+      schema: [{ name: id, type: string }]
+  - type: composition
+    name: first
+    input: driver
+    use: ../compositions/catalog_reader.comp.yaml
+    inputs: {}
+    resources: { orders: shared_orders }
+  - type: composition
+    name: second
+    input: driver
+    use: ../compositions/catalog_reader.comp.yaml
+    inputs: {}
+    resources: { orders: shared_orders }
+"#
+}
+
+fn compile(workspace: &Path) -> CompiledPlan {
+    parse_config(pipeline())
+        .expect("pipeline parses")
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace,
+            PathBuf::from("pipelines"),
+        ))
+        .unwrap_or_else(|diagnostics| panic!("pipeline compiles: {diagnostics:?}"))
+}
+
+fn body_source_instances(
+    plan: &CompiledPlan,
+) -> Vec<&crate::plan::execution::CompiledSourceInstance> {
+    plan.dag()
+        .graph
+        .node_weights()
+        .filter_map(|node| match node {
+            PlanNode::Composition { body, .. } => plan.body_of(*body),
+            _ => None,
+        })
+        .flat_map(|body| body.source_instances.iter())
+        .collect()
+}
+
+#[test]
+fn tracer() {
+    let workspace = write_workspace(BODY);
+    let first_plan = compile(workspace.path());
+    let first_instances = body_source_instances(&first_plan);
+    assert_eq!(first_instances.len(), 2);
+    assert_ne!(first_instances[0].id, first_instances[1].id);
+    assert_ne!(
+        first_instances[0].id.body_scope,
+        first_instances[1].id.body_scope
+    );
+    assert_eq!(first_instances[0].source_name, "read");
+
+    let requirement = &first_instances[0].resource;
+    assert_eq!(requirement.slot, "orders");
+    assert_eq!(requirement.binding.logical_id().as_str(), "shared_orders");
+    assert_eq!(requirement.kind.label(), "file");
+    assert_eq!(
+        requirement.required_capabilities,
+        requirement.kind.required_capabilities()
+    );
+    assert_eq!(requirement.opener, requirement.kind.opener_kind());
+    assert_eq!(requirement.lifetime, requirement.kind.lifetime());
+    assert_eq!(
+        requirement.dataset_identity.namespace,
+        "clinker-resource:file"
+    );
+    assert_eq!(requirement.dataset_identity.name, "shared_orders");
+    assert!(requirement.binding.provenance().winning_layer().is_some());
+    let rendered = format!("{first_instances:?}");
+    assert!(!rendered.contains("orders.csv"));
+    assert!(!rendered.contains("credential"));
+    assert!(!rendered.contains("token"));
+
+    let second_plan = compile(workspace.path());
+    let second_ids: Vec<_> = body_source_instances(&second_plan)
+        .iter()
+        .map(|instance| instance.id)
+        .collect();
+    let first_ids: Vec<_> = first_instances.iter().map(|instance| instance.id).collect();
+    assert_eq!(first_ids, second_ids);
+}
+
+#[test]
+fn resource_slot_parses_on_a_body_source() {
+    let body = CompositionFile::parse(
+        BODY,
+        FileId::new(NonZeroU32::new(1).expect("non-zero file id")),
+        PathBuf::from("compositions/catalog_reader.comp.yaml"),
+    )
+    .expect("composition parses");
+    let PipelineNode::Source { config, .. } = &body.nodes[0].value else {
+        panic!("expected body Source");
+    };
+    assert_eq!(
+        config.resource.as_ref().expect("resource slot").value,
+        "orders"
+    );
+}
+
+#[test]
+fn resource_backed_body_source_rejects_a_direct_matcher() {
+    let body = BODY.replace(
+        "      resource: orders",
+        "      resource: orders\n      path: private.csv",
+    );
+    let workspace = write_workspace(&body);
+    let diagnostics = parse_config(pipeline())
+        .expect("pipeline parses")
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace.path(),
+            PathBuf::from("pipelines"),
+        ))
+        .expect_err("resource plus path must fail");
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "E103")
+        .unwrap_or_else(|| panic!("expected E103: {diagnostics:?}"));
+    assert!(diagnostic.message.contains("resource"));
+    assert!(diagnostic.message.contains("path"));
+    assert!(diagnostic.primary.span.synthetic_line_number().is_some());
+    assert!(
+        diagnostic
+            .help
+            .as_deref()
+            .is_some_and(|help| help.contains("remove `path`"))
+    );
+}
+
+#[test]
+fn body_source_resource_must_name_a_declared_slot() {
+    let body = BODY.replace("resource: orders", "resource: missing");
+    let workspace = write_workspace(&body);
+    let diagnostics = parse_config(pipeline())
+        .expect("pipeline parses")
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace.path(),
+            PathBuf::from("pipelines"),
+        ))
+        .expect_err("undeclared source slot must fail");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "E103"
+            && diagnostic.message.contains("missing")
+            && diagnostic.message.contains("resources_schema")
+    }));
+}
+
+#[test]
+fn authored_body_source_requires_an_explicit_resource() {
+    let body = BODY.replace("      resource: orders", "      path: private.csv");
+    let workspace = write_workspace(&body);
+    let diagnostics = parse_config(pipeline())
+        .expect("pipeline parses")
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace.path(),
+            PathBuf::from("pipelines"),
+        ))
+        .expect_err("inert direct-path body source must fail");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "E103"
+            && diagnostic.message.contains("read")
+            && diagnostic.message.contains("resource: <slot>")
+            && diagnostic.primary.span.synthetic_line_number().is_some()
+    }));
+}
+
+#[test]
+fn top_level_resource_is_rejected_until_it_has_a_binding_surface() {
+    let workspace = write_workspace(BODY);
+    let yaml = r#"pipeline: { name: top_level_resource }
+nodes:
+  - type: source
+    name: source
+    config:
+      name: source
+      type: csv
+      resource: orders
+      schema: [{ name: id, type: string }]
+"#;
+    let config: PipelineConfig = parse_config(yaml).expect("resource syntax parses");
+    let diagnostics = config
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace.path(),
+            PathBuf::from("pipelines"),
+        ))
+        .expect_err("top-level resource must fail closed");
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "E103"
+            && diagnostic.message.contains("top-level")
+            && diagnostic.message.contains("resource")
+            && diagnostic.primary.span.synthetic_line_number().is_some()
+    }));
+}

--- a/docs/engine/src/extension-seams.md
+++ b/docs/engine/src/extension-seams.md
@@ -108,26 +108,35 @@ shutdown, and cleanup rules instead of creating an independent resource model.
 
 ## Composition resource slots
 
-The current composition surface is only partly wired. `_compose.resources_schema`
-parses resource declarations, and the declaration model currently has one
-`file` kind. Ordinary composition call sites also parse `resources:` as
-untyped JSON. Binding currently accepts every call-site resource because
-`validate_resources` is a stub, and the executor does not consume those values.
-Accepted input at this seam must not be mistaken for working runtime behavior.
+`_compose.resources_schema` declares typed slots; the bounded workspace
+catalog currently admits the `file` kind. A composition call binds a slot to
+one logical catalog identity through strict scalar `resources:` values.
+Binding rejects missing and undeclared slots, unknown identities, kind or
+capability mismatches, inline descriptors, credential selectors, and the
+ordinary call-site `outputs` and `alias` fields. Each winning logical binding
+retains its complete attempted-versus-winning overlay provenance.
 
-D-12 through D-15 assign the replacement to AUTH-01: a bounded typed
-kind registry, concrete named catalog, declared typed slots, fail-closed
-call-site and overlay binding, attempted-versus-winning provenance, and
-secret-safe preflight handles. Reusable content and compiled plans may retain
-only non-secret semantics and secret references; credentials and live handles
-are run-local and must be closed on failure. D-16 also requires rejection of
-ordinary composition call-site `outputs` and `alias`, which currently
-parse without providing the promised remapping or namespace. `_compose.outputs`,
-the composition node name, and the distinct overlay insertion alias remain
-valid concepts.
+An authored body Source names its slot explicitly with `resource: <slot>` in
+the Source config. The binder never infers a slot from a Source name or path.
+It rejects a body Source that combines `resource:` with `path`, `glob`,
+`regex`, or `paths`, and it rejects an authored body Source with no resource
+link. Input ports remain separate synthetic Source roots seeded by the caller;
+they do not receive activation entries. Top-level direct file Sources keep
+their existing matcher surface and reject `resource:` because no top-level
+catalog-binding surface exists.
 
-These are locked downstream contracts, not usable extension APIs today. See
-the [composition resources and call-site surface contract](https://github.com/rustpunk/clinker/blob/main/docs/ai/15_PRODUCTION_CONTRACTS.md#composition-resources-and-call-site-surface).
+Each bound call compiles its body Sources into scope-qualified
+`CompiledSourceInstance` values. The retained requirement contains the slot,
+logical binding and provenance, kind, finite capabilities, opener family,
+run-local lifetime, and stable logical dataset identity. It deliberately drops
+the catalog's physical path and cannot contain a credential choice, secret,
+live handle, I/O state, or thread state. Separate calls to the same composition
+therefore share immutable logical descriptor semantics but have distinct
+Source identities for later activation.
+
+Runtime credential resolution and opening are still future preflight work; a
+compiled activation requirement is not an opened Source. See the
+[composition resources and call-site surface contract](https://github.com/rustpunk/clinker/blob/main/docs/ai/15_PRODUCTION_CONTRACTS.md#composition-resources-and-call-site-surface).
 
 ## Approved transitional exceptions
 

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -753,10 +753,12 @@ file). A plain unqualified key still targets a top-level source, and a name that
 matches no top-level source still fails with E230 — now hinting at the qualified
 form when the pipeline has compositions.
 
-> **Note:** a body-declared source binds (its schema seeds the body) but is not
-> yet fed at runtime — the engine ingests only top-level sources — so a channel
-> patch to a body source is applied and observable at compile (`--explain`),
-> while a data run through a body source awaits body-source runtime support.
+> **Note:** an authored body Source must link to one declared composition
+> resource slot with `resource: <slot>`; a direct `path`, `glob`, `regex`, or
+> `paths` matcher is rejected. The source patch above changes schema/reader
+> configuration but does not select the resource. Planning binds the slot and
+> compiles a call-scoped Source instance, while a data run through that Source
+> still awaits runtime credential resolution and resource opening.
 
 When a patch changes the effective source config, the run's pipeline identity
 differs from the base and from other patched variants, so their outputs and

--- a/docs/user/src/pipelines/compositions.md
+++ b/docs/user/src/pipelines/compositions.md
@@ -178,13 +178,35 @@ _compose:
   name: order_lookup
   inputs:
     input: { schema: [{ name: order_id, type: string }] }
-  outputs: { out: shape }
+  outputs: { out: order_reference }
   config_schema: {}
   resources_schema:
     orders:
       kind: file
       required: true
+
+nodes:
+  - type: source
+    name: order_reference
+    config:
+      name: order_reference
+      type: csv
+      resource: orders
+      schema: [{ name: order_id, type: string }]
 ```
+
+`resource:` is an explicit body-Source-to-slot link. The slot must be declared
+by the enclosing `_compose.resources_schema`; the Source name and its format do
+not select a resource implicitly. A resource-backed body Source must not also
+declare `path`, `glob`, `regex`, or `paths`, because the bound catalog resource
+is its only external target. Every authored body Source must declare
+`resource:`. Composition input ports are separate synthetic roots: to consume
+caller-provided rows, declare `_compose.inputs.<port>` and set a downstream
+node's `input: <port>` instead of authoring a Source node for that port.
+
+Top-level Sources are unchanged: they continue to require exactly one direct
+matcher. `resource:` on a top-level Source is rejected until a separate
+top-level binding surface is designed.
 
 The workspace supplies a concrete, secret-free descriptor under a logical
 identity in `clinker.toml`:
@@ -216,9 +238,12 @@ descriptor-byte limits.
 
 Planning retains the winning logical identity and every attempted overlay
 layer for each binding. That identity also participates in the semantic plan
-fingerprint. Runtime credential resolution and handle activation are separate
-future preflight work; this surface neither selects credentials nor opens the
-file.
+fingerprint. For each authored body Source, planning compiles a distinct
+call-site-scoped instance carrying only the slot, logical identity, resource
+kind, required capabilities, opener family, run lifetime, provenance, and
+stable logical dataset identity. It does not retain the catalog's physical
+path. Runtime credential resolution and handle activation are separate future
+preflight work; this surface neither selects credentials nor opens the file.
 
 Ordinary composition calls do not have `outputs:` or `alias:` fields. Either
 key fails with E377 at its authored location. Use `_compose.outputs` for the


### PR DESCRIPTION
## Summary

- add an explicit `resource: <slot>` link for Sources authored inside compositions
- reject implicit or conflicting body-Source targets and reject top-level `resource:` until that surface is designed
- compile each body Source into a stable call-scoped identity with a secret-free typed resource requirement and logical dataset identity
- migrate the affected planner fixtures to catalog-backed resources and document the authoring contract

The compiled requirement contains no physical path, credential choice, secret, opened handle, I/O state, or thread state. Runtime admission and opening will consume this contract in a separate pull request.

## Verification

- focused Source activation tests: 7 passed
- exact activation tracer: 1 passed
- full `clinker-plan` test suite: 957 unit tests, all integration tests, and 2 doctests passed
- warning-denied all-target `clinker-plan` Clippy
- `cargo fmt --all --check`
- user and engine documentation builds
- `git diff --check`

## Runtime obligations

- Lineage: the compiled requirement retains the stable logical dataset identity needed by later activation; this change does not alter row values or routing.
- Telemetry: exempt because this is plan-time configuration-derived state and performs no execution work.
- Memory: the retained state is bounded by the admitted configuration and does not grow with input records, so it does not register as a runtime memory consumer.

This pull request is stacked on `credential-lifecycle-telemetry`.
