### PR TITLE
Migrate executor identity and streaming fixtures to Sink

### DIFF
--- a/crates/clinker-exec/tests/fixtures/pipelines/channel_target_pipeline.yaml
+++ b/crates/clinker-exec/tests/fixtures/pipelines/channel_target_pipeline.yaml
@@ -23,7 +23,7 @@ nodes:
       fuzzy_threshold: 0.8
       lookup_table: "default-lookup.csv"
 
-  - type: output
+  - type: sink
     name: sink
     input: enrich1
     config:

--- a/crates/clinker-exec/tests/post_combine_synthetic_ck.rs
+++ b/crates/clinker-exec/tests/post_combine_synthetic_ck.rs
@@ -74,7 +74,7 @@ nodes:
       emit running_total = $window.sum(total)
     analytic_window:
       group_by: [department, '$ck.aggregate.dept_totals']
-- type: output
+- type: sink
   name: out
   input: running
   config:

--- a/crates/clinker-exec/tests/post_combine_window_strategies.rs
+++ b/crates/clinker-exec/tests/post_combine_window_strategies.rs
@@ -77,7 +77,7 @@ nodes:
       emit dept_total = $window.sum(matched_amount)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:
@@ -198,7 +198,7 @@ nodes:
       emit dept_total = $window.sum(matched_amount)
     analytic_window:
       group_by: [department]
-- type: output
+- type: sink
   name: out
   input: running
   config:

--- a/crates/clinker-exec/tests/pre_lift_baselines.rs
+++ b/crates/clinker-exec/tests/pre_lift_baselines.rs
@@ -643,7 +643,7 @@ nodes:
     inputs:
       data: src
 
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/record_source_transport.rs
+++ b/crates/clinker-exec/tests/record_source_transport.rs
@@ -85,7 +85,7 @@ nodes:
         emit amount = amount
         emit src_file = $source.file
         emit src_name = $source.name
-  - type: output
+  - type: sink
     name: out
     input: stamp
     config:

--- a/crates/clinker-exec/tests/reshape_pipeline.rs
+++ b/crates/clinker-exec/tests/reshape_pipeline.rs
@@ -111,7 +111,7 @@ nodes:
             copy_from: trigger
             overrides:
               status: "'synthesized'"
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config:
@@ -152,7 +152,7 @@ nodes:
           mutate:
             set:
               label: "'large'"
-  - type: output
+  - type: sink
     name: out
     input: relabel
     config:
@@ -290,7 +290,7 @@ nodes:
           mutate:
             set:
               tier: "'big'"
-  - type: output
+  - type: sink
     name: out
     input: classify
     config:
@@ -372,7 +372,7 @@ nodes:
           mutate:
             set:
               note: "'was_base'"
-  - type: output
+  - type: sink
     name: out
     input: classify
     config:
@@ -426,7 +426,7 @@ nodes:
               id: "id"
               amount: "amount * 2"
               label: "'synthetic-summary'"
-  - type: output
+  - type: sink
     name: out
     input: emit_summary
     config:
@@ -531,7 +531,7 @@ nodes:
               plan_start: "plan_start"
               plan_end: "plan_start"
               status: "'synthesized'"
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config:
@@ -578,7 +578,7 @@ nodes:
           mutate:
             set:
               plan_end: "plan_start"
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config:
@@ -767,7 +767,7 @@ nodes:
           mutate:
             set:
               tag: "tag"
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config:

--- a/crates/clinker-exec/tests/retraction_explain_snapshot.rs
+++ b/crates/clinker-exec/tests/retraction_explain_snapshot.rs
@@ -71,7 +71,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -116,7 +116,7 @@ nodes:
       emit total = sum(amount)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:

--- a/crates/clinker-exec/tests/retraction_metrics_test.rs
+++ b/crates/clinker-exec/tests/retraction_metrics_test.rs
@@ -84,7 +84,7 @@ nodes:
       emit n = count(*)
 
       '
-- type: output
+- type: sink
   name: out
   input: dept_totals
   config:
@@ -119,7 +119,7 @@ nodes:
       emit amount_int = amount.to_int()
 
       '
-- type: output
+- type: sink
   name: out
   input: validate
   config:

--- a/crates/clinker-exec/tests/route_fanout_soft_spill.rs
+++ b/crates/clinker-exec/tests/route_fanout_soft_spill.rs
@@ -58,21 +58,21 @@ nodes:
         a: "region == \"a\""
         b: "region == \"b\""
       default: c
-  - type: output
+  - type: sink
     name: out_a
     input: by_region.a
     config:
       name: out_a
       type: csv
       path: out_a.csv
-  - type: output
+  - type: sink
     name: out_b
     input: by_region.b
     config:
       name: out_b
       type: csv
       path: out_b.csv
-  - type: output
+  - type: sink
     name: out_c
     input: by_region.c
     config:

--- a/crates/clinker-exec/tests/scheduling_determinism.rs
+++ b/crates/clinker-exec/tests/scheduling_determinism.rs
@@ -79,7 +79,7 @@ nodes:
       cxl: |
         emit k = k
         emit total = sum(v)
-  - type: output
+  - type: sink
     name: out_small
     input: agg_small
     config:
@@ -87,7 +87,7 @@ nodes:
       type: csv
       path: out_small.csv
       include_unmapped: true
-  - type: output
+  - type: sink
     name: out_large
     input: agg_large
     config:

--- a/crates/clinker-exec/tests/scheduling_heavy_first_peak.rs
+++ b/crates/clinker-exec/tests/scheduling_heavy_first_peak.rs
@@ -110,7 +110,7 @@ nodes:
         emit heavy_total = h.total
         emit light_items = l.items
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_aggregate_windowed.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_aggregate_windowed.snap
@@ -45,7 +45,7 @@ aggregation.by_dept:
   buffer: streaming
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.dept_totals:
+sink.dept_totals:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -81,4 +81,4 @@ Worker threads: 4
   ● [source] sales (line:5)
   │ [transform] active_only (line:19)
   ◇ [aggregation:streaming] by_dept (line:31)
-  │ [output] dept_totals (line:40)
+  │ [sink] dept_totals (line:40)

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_channel_target_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_channel_target_pipeline.snap
@@ -32,7 +32,7 @@ composition.enrich1:
   buffer: materialized
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.sink:
+sink.sink:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -46,7 +46,7 @@ edge source.ingest_src -> composition.enrich1:
   buffer: node_buffer (slot=0)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
 
-edge composition.enrich1 -> output.sink:
+edge composition.enrich1 -> sink.sink:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: composition)
 
@@ -64,4 +64,4 @@ Worker threads: 4
 
   ● [source] ingest_src (line:5)
   │ [composition:body=<ID>] enrich1 (line:16)
-  │ [output] sink (line:26)
+  │ [sink] sink (line:26)

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_composition_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_composition_pipeline.snap
@@ -48,7 +48,7 @@ composition.enrich1:
   buffer: materialized
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.enriched_out:
+sink.enriched_out:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -70,7 +70,7 @@ edge source.customers_src -> composition.enrich1:
   buffer: node_buffer (slot=0)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
 
-edge composition.enrich1 -> output.enriched_out:
+edge composition.enrich1 -> sink.enriched_out:
   buffer: node_buffer (slot=2)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: composition)
 
@@ -90,4 +90,4 @@ Worker threads: 4
   │ [composition:body=<ID>] addr_norm (line:38)
   ● [source] customers_src (line:5)
   │ [composition:body=<ID>] enrich1 (line:27)
-  │ [output] enriched_out (line:47)
+  │ [sink] enriched_out (line:47)

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_csv_transform_sink.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_csv_transform_sink.snap
@@ -37,7 +37,7 @@ transform.tier_flag:
   buffer: streaming
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.results:
+sink.results:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -66,4 +66,4 @@ Worker threads: 4
 
   ● [source] employees (line:5)
   │ [transform] tier_flag (line:18)
-  │ [output] results (line:28)
+  │ [sink] results (line:28)

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_nested_composition_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_nested_composition_pipeline.snap
@@ -32,7 +32,7 @@ composition.nested_process:
   buffer: materialized
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.final_out:
+sink.final_out:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -46,7 +46,7 @@ edge source.raw_src -> composition.nested_process:
   buffer: node_buffer (slot=0)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
 
-edge composition.nested_process -> output.final_out:
+edge composition.nested_process -> sink.final_out:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: composition)
 
@@ -64,4 +64,4 @@ Worker threads: 4
 
   ● [source] raw_src (line:5)
   │ [composition:body=<ID>] nested_process (line:18)
-  │ [output] final_out (line:27)
+  │ [sink] final_out (line:27)

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_route_fanout.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_route_fanout.snap
@@ -45,7 +45,7 @@ route.classify_route:
   buffer: materialized
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.low:
+sink.low:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -53,7 +53,7 @@ output.low:
   buffer: streaming
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.high:
+sink.high:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -67,17 +67,17 @@ edge transform.classify -> route.classify_route:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: transform)
 
-edge route.classify_route -> output.low:
+edge route.classify_route -> sink.low:
   buffer: node_buffer (slot=2, port=low)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: route)
 
-edge route.classify_route -> output.high:
+edge route.classify_route -> sink.high:
   buffer: node_buffer (slot=2, port=high)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: route)
 
 Route 'classify_route' (mode: exclusive):
-  Branch 'high' → output.high
-  Default: 'low' → output.low
+  Branch 'high' → sink.high
+  Default: 'low' → sink.low
 
 === CXL Expressions ===
 
@@ -103,5 +103,5 @@ Worker threads: 4
   ◆ FORK [route:exclusive] 'classify_route' (line:25)
   ├──> high → high
   ├──> default → low
-  │ [output] low (line:42)
-  │ [output] high (line:34)
+  │ [sink] low (line:42)
+  │ [sink] high (line:34)

--- a/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
+++ b/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
@@ -66,7 +66,7 @@ aggregation.dept_totals:
   buffer: materialized
   arbitration: spill_priority=30, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
-output.out:
+sink.out:
   ordering: <none>
   ordering_provenance: NoOrdering
   partitioning: Single
@@ -88,7 +88,7 @@ edge transform.windowed -> aggregation.dept_totals:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: transform)
 
-edge aggregation.dept_totals -> output.out:
+edge aggregation.dept_totals -> sink.out:
   buffer: node_buffer (slot=2)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: aggregation)
 
@@ -143,5 +143,5 @@ Worker threads: 4
   │ [sort] __correlation_sort_orders
   │ [transform] windowed (line:19)
   ◇ [aggregation:hash] dept_totals (line:34)
-  │ [output] out (line:48)
+  │ [sink] out (line:48)
   │ [correlation_commit] __correlation_commit_terminal key=[order_id]

--- a/crates/clinker-exec/tests/source_order_verification.rs
+++ b/crates/clinker-exec/tests/source_order_verification.rs
@@ -32,7 +32,7 @@ nodes:
       schema:
         - {{ name: key, type: int }}
         - {{ name: payload, type: string }}
-{sort_order}{policy}  - type: output
+{sort_order}{policy}  - type: sink
     name: out
     input: rows
     config:
@@ -80,7 +80,7 @@ nodes:
         - {{ name: payload, type: string }}
       sort_order: [key]
       on_unsorted: {on_unsorted}
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:
@@ -199,7 +199,7 @@ nodes:
       cxl: |
         emit key = key
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: totals
     config:
@@ -435,7 +435,7 @@ nodes:
         - { name: value, type: string }
       sort_order: [tag]
       on_unsorted: error
-  - type: output
+  - type: sink
     name: out
     input: rows
     config:

--- a/crates/clinker-exec/tests/source_row_identity_handoffs.rs
+++ b/crates/clinker-exec/tests/source_row_identity_handoffs.rs
@@ -115,7 +115,7 @@ nodes:
     input: merged
     config:
       cxl: "emit failure = 1 / 0"
-  - type: output
+  - type: sink
     name: out
     input: observe_identity
     config:
@@ -179,14 +179,14 @@ nodes:
     input: duplicate.right
     config:
       cxl: "emit failure = 1 / 0"
-  - type: output
+  - type: sink
     name: left_out
     input: fail_left
     config:
       name: left_out
       type: csv
       path: left.csv
-  - type: output
+  - type: sink
     name: right_out
     input: fail_right
     config:
@@ -244,14 +244,14 @@ nodes:
     input: cull.removed
     config:
       cxl: "emit failure = 1 / 0"
-  - type: output
+  - type: sink
     name: kept_out
     input: fail_kept
     config:
       name: kept_out
       type: csv
       path: kept.csv
-  - type: output
+  - type: sink
     name: removed_out
     input: fail_removed
     config:
@@ -355,7 +355,7 @@ nodes:
     input: selected.yes
     config:
       cxl: "emit failure = 1 / 0"
-  - type: output
+  - type: sink
     name: out
     input: observe_identity
     config:
@@ -531,7 +531,7 @@ nodes:
     input: merged
     config:
       cxl: "emit failure = 1 / 0"
-  - type: output
+  - type: sink
     name: out
     input: observe_identity
     config:

--- a/crates/clinker-exec/tests/source_row_identity_retraction.rs
+++ b/crates/clinker-exec/tests/source_row_identity_retraction.rs
@@ -53,7 +53,7 @@ nodes:
     config:
       cxl: |
         emit parsed = value.to_int()
-  - type: output
+  - type: sink
     name: out
     input: validate
     config:
@@ -324,7 +324,7 @@ nodes:
         emit total = total
         emit n = n
         emit ratio = 1 / (total - {failing_total})
-  - type: output
+  - type: sink
     name: out
     input: post_check
     config:

--- a/crates/clinker-exec/tests/source_row_identity_structural.rs
+++ b/crates/clinker-exec/tests/source_row_identity_structural.rs
@@ -95,7 +95,7 @@ nodes:
     input: one_document
     config:
       cxl: "emit failure = 1 / 0"
-  - type: output
+  - type: sink
     name: out
     input: observe_identity
     config:
@@ -161,7 +161,7 @@ nodes:
     name: one_document
     body: interchange
     config: { strategy: concat }
-  - type: output
+  - type: sink
     name: out
     input: one_document
     config:
@@ -261,7 +261,7 @@ nodes:
     input: backfill
     config:
       cxl: "emit failure = 1 / 0"
-  - type: output
+  - type: sink
     name: out
     input: observe_identity
     config:

--- a/crates/clinker-exec/tests/source_type_errors.rs
+++ b/crates/clinker-exec/tests/source_type_errors.rs
@@ -149,7 +149,7 @@ nodes:
       schema:
 {schema}
 {source_options}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -723,7 +723,7 @@ nodes:
       cxl: |
         emit id = id
         emit quantity = quantity
-  - type: output
+  - type: sink
     name: out
     input: projected
     config:
@@ -781,7 +781,7 @@ nodes:
     inputs: [src_a, src_b]
     config:
       mode: interleave
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:
@@ -837,7 +837,7 @@ nodes:
       on_unmapped:
         mode: reject
       sort_order: [id]
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -896,7 +896,7 @@ nodes:
         - { name: id, type: int }
         - { name: payload, type: string }
       sort_order: [id]
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/state_node_diagnostics.rs
+++ b/crates/clinker-exec/tests/state_node_diagnostics.rs
@@ -83,7 +83,7 @@ nodes:
       cxl: |
         emit a = a
         emit b = $pipeline.x
-  - type: output
+  - type: sink
     name: out
     input: runtime_reader
     config:
@@ -133,7 +133,7 @@ nodes:
       cxl: |
         emit a = a
         emit $pipeline.x = a + 1
-  - type: output
+  - type: sink
     name: out
     input: w2
     config:
@@ -175,7 +175,7 @@ nodes:
       cxl: |
         emit a = a
         emit b = $pipeline.x
-  - type: output
+  - type: sink
     name: out
     input: sibling_reader
     config:
@@ -231,7 +231,7 @@ nodes:
       cxl: |
         emit id = id
         emit t = $source.tag
-  - type: output
+  - type: sink
     name: out
     input: reader
     config:
@@ -277,7 +277,7 @@ nodes:
     use: ../compositions/declares_undeclared.comp.yaml
     inputs:
       data: parent_writer
-  - type: output
+  - type: sink
     name: out
     input: body
     config:
@@ -318,7 +318,7 @@ nodes:
     use: ../compositions/declares_type_mismatch.comp.yaml
     inputs:
       inp: parent_writer
-  - type: output
+  - type: sink
     name: out
     input: body
     config:
@@ -372,7 +372,7 @@ nodes:
       cxl: |
         emit b = b
         emit $pipeline.init_v = b + $pipeline.runtime_v
-  - type: output
+  - type: sink
     name: out
     input: runtime_w
     config:

--- a/crates/clinker-exec/tests/state_node_integration.rs
+++ b/crates/clinker-exec/tests/state_node_integration.rs
@@ -129,7 +129,7 @@ nodes:
       cxl: |
         emit id = id
         emit pipeline_last = $pipeline.last_amount
-  - type: output
+  - type: sink
     name: out
     input: read_back
     config:
@@ -191,7 +191,7 @@ nodes:
       cxl: |
         emit id = id
         emit src_label = $source.batch_label
-  - type: output
+  - type: sink
     name: out
     input: read_back
     config:
@@ -249,7 +249,7 @@ nodes:
       cxl: |
         emit id = id
         emit derived = $record.doubled
-  - type: output
+  - type: sink
     name: out
     input: read_back
     config:
@@ -309,7 +309,7 @@ nodes:
     use: ../compositions/declares_used.comp.yaml
     inputs:
       inp: parent_writer
-  - type: output
+  - type: sink
     name: out
     input: body
     config:
@@ -407,7 +407,7 @@ nodes:
         emit id = id
         emit lt = $source.tag_left.left_label
         emit rt = $source.tag_right.right_label
-  - type: output
+  - type: sink
     name: out
     input: read_back
     config:
@@ -497,7 +497,7 @@ nodes:
       cxl: |
         emit id = id
         emit cap = $pipeline.max_amount
-  - type: output
+  - type: sink
     name: out
     input: read_back
     config:
@@ -562,7 +562,7 @@ nodes:
       cxl: |
         emit id = id
         emit label = $source.file_label
-  - type: output
+  - type: sink
     name: out
     input: read_back
     config:
@@ -640,7 +640,7 @@ nodes:
         emit id = id
         emit tier = $vars.label
         emit threshold = $vars.cutoff
-  - type: output
+  - type: sink
     name: out
     input: filter_and_tag
     config:
@@ -711,7 +711,7 @@ nodes:
         emit id = id
         emit tier = $vars.label
         emit threshold = $vars.cutoff
-  - type: output
+  - type: sink
     name: out
     input: filter_and_tag
     config:

--- a/crates/clinker-exec/tests/storage_spill_dir.rs
+++ b/crates/clinker-exec/tests/storage_spill_dir.rs
@@ -45,14 +45,14 @@ nodes:
       conditions:
         a: "region == \"a\""
       default: b
-  - type: output
+  - type: sink
     name: out_a
     input: by_region.a
     config:
       name: out_a
       type: csv
       path: out_a.csv
-  - type: output
+  - type: sink
     name: out_b
     input: by_region.b
     config:

--- a/crates/clinker-exec/tests/streaming_arms.rs
+++ b/crates/clinker-exec/tests/streaming_arms.rs
@@ -151,7 +151,7 @@ nodes:
       conditions:
         all: "true"
       default: all
-  - type: output
+  - type: sink
     name: out
     input: r.all
     config:
@@ -254,7 +254,7 @@ nodes:
       conditions:
         all: "true"
       default: all
-  - type: output
+  - type: sink
     name: out
     input: r.all
     config:
@@ -349,7 +349,7 @@ nodes:
         emit order_id = orders.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: c
     config:
@@ -444,7 +444,7 @@ nodes:
       cxl: |
         emit total = sum(amount.to_int())
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: totals
     config:
@@ -546,7 +546,7 @@ nodes:
     inputs: [ta, tb]
     config:
       mode: concat
-  - type: output
+  - type: sink
     name: out
     input: m
     config:
@@ -665,7 +665,7 @@ nodes:
     inputs: [ta, tb]
     config:
       mode: concat
-  - type: output
+  - type: sink
     name: out
     input: m
     config:
@@ -786,7 +786,7 @@ nodes:
         emit dept = dept
         emit total = sum(amount.to_int())
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: totals
     config:
@@ -899,7 +899,7 @@ nodes:
       cxl: |
         emit total = sum(amount.to_int())
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: totals
     config:
@@ -1001,7 +1001,7 @@ nodes:
       cxl: |
         emit total = sum(amount.to_int())
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: totals
     config:
@@ -1102,7 +1102,7 @@ nodes:
         emit order_id = norm.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: c
     config:
@@ -1228,7 +1228,7 @@ nodes:
         emit order_id = m.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: c
     config:
@@ -1346,7 +1346,7 @@ nodes:
         emit order_id = norm.order_id
         emit product_name = products.name
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: c
     config:
@@ -1455,7 +1455,7 @@ nodes:
         emit order_id = norm.order_id
         emit ratio = norm.qty / products.divisor
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: c
     config:

--- a/crates/clinker-exec/tests/streaming_ingest_fixes.rs
+++ b/crates/clinker-exec/tests/streaming_ingest_fixes.rs
@@ -153,7 +153,7 @@ nodes:
       cxl: |
         emit category = category
         emit ratio = sum(100 / divisor)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -260,7 +260,7 @@ nodes:
       cxl: |
         emit total = sum(amount)
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: total
     config:
@@ -301,7 +301,7 @@ nodes:
       cxl: |
         emit amount = amount
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: total
     config:
@@ -533,7 +533,7 @@ nodes:
       cxl: |
         emit category = category
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: by_category
     config:
@@ -623,7 +623,7 @@ nodes:
       cxl: |
         emit total = sum(amount)
         emit n = count(*)
-  - type: output
+  - type: sink
     name: out
     input: total
     config:

--- a/crates/clinker-exec/tests/streaming_output.rs
+++ b/crates/clinker-exec/tests/streaming_output.rs
@@ -86,7 +86,7 @@ nodes:
     inputs: [src_a, src_b]
     config:
       mode: interleave
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:

--- a/crates/clinker-exec/tests/strict_pipeline_zero_overhead.rs
+++ b/crates/clinker-exec/tests/strict_pipeline_zero_overhead.rs
@@ -47,7 +47,7 @@ nodes:
       emit order_id = order_id
       emit department = department
       emit total = sum(amount)
-- type: output
+- type: sink
   name: out
   input: order_totals
   config:

--- a/crates/clinker-exec/tests/structured_output_multidoc.rs
+++ b/crates/clinker-exec/tests/structured_output_multidoc.rs
@@ -59,7 +59,7 @@ nodes:
       schema:
         - {{ name: id, type: int }}
         - {{ name: tag, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: body
     config:
@@ -122,7 +122,7 @@ nodes:
     inputs: [left, right]
     config:
       mode: interleave
-  - type: output
+  - type: sink
     name: out
     input: merged
     config:

--- a/crates/clinker-exec/tests/swift_pipeline.rs
+++ b/crates/clinker-exec/tests/swift_pipeline.rs
@@ -132,7 +132,7 @@ nodes:
         emit app = $doc.app.body
         emit user = $doc.user.body
         emit tlr = $doc.tlr.body
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -200,7 +200,7 @@ nodes:
         emit block = block
         emit tag = tag
         emit value = value
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -256,7 +256,7 @@ nodes:
         - { name: block, type: string }
         - { name: tag, type: string }
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: out
     input: message
     config:
@@ -289,7 +289,7 @@ nodes:
         - { name: block, type: string }
         - { name: tag, type: string }
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: out
     input: message
     config:
@@ -324,7 +324,7 @@ nodes:
         - { name: block, type: string }
         - { name: tag, type: string }
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: out
     input: message
     config:
@@ -372,7 +372,7 @@ nodes:
         - {{ name: block, type: string }}
         - {{ name: tag, type: string }}
         - {{ name: value, type: string }}
-  - type: output
+  - type: sink
     name: out
     input: message
     config:
@@ -408,7 +408,7 @@ nodes:
         - { name: block, type: string }
         - { name: tag, type: string }
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: out
     input: message
     config:
@@ -623,7 +623,7 @@ nodes:
         - { name: block, type: string }
         - { name: tag, type: string }
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: out
     input: message
     config:
@@ -662,7 +662,7 @@ nodes:
         - { name: block, type: string }
         - { name: tag, type: string }
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: out
     input: message
     config:

--- a/crates/clinker-exec/tests/telemetry_composition_scope.rs
+++ b/crates/clinker-exec/tests/telemetry_composition_scope.rs
@@ -103,7 +103,7 @@ nodes:
     use: ../compositions/exec_transform_check.comp.yaml
     inputs:
       inp: doubler
-  - type: output
+  - type: sink
     name: eu_out
     input: enrich_eu
     config:
@@ -125,7 +125,7 @@ nodes:
     use: ../compositions/exec_transform_check.comp.yaml
     inputs:
       inp: us_orders
-  - type: output
+  - type: sink
     name: us_out
     input: enrich_us
     config:

--- a/crates/clinker-exec/tests/time_window_aggregate.rs
+++ b/crates/clinker-exec/tests/time_window_aggregate.rs
@@ -152,7 +152,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: hourly
   config:
@@ -228,7 +228,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: hourly
   config:
@@ -315,7 +315,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: hourly
   config:
@@ -409,7 +409,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: hourly
   config:
@@ -483,7 +483,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: totals
   config:
@@ -536,7 +536,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: sliding
   config:
@@ -593,7 +593,7 @@ nodes:
     cxl: |
       emit user_id = user_id
       emit n = count(*)
-- type: output
+- type: sink
   name: out
   input: sessions
   config:

--- a/crates/clinker-exec/tests/transform_signals_across_a_converge.rs
+++ b/crates/clinker-exec/tests/transform_signals_across_a_converge.rs
@@ -63,7 +63,7 @@ nodes:
         every: 1
         message: seen
         fields: [total]
-- type: output
+- type: sink
   name: out
   input: ratio
   config:

--- a/examples/pipelines/scd_type2.yaml
+++ b/examples/pipelines/scd_type2.yaml
@@ -56,7 +56,7 @@ nodes:
               plan_end: "plan_end"
               status: "'synthesized'"
 
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config:


### PR DESCRIPTION
## Summary

- migrate executable identity, scheduling, state, streaming, and telemetry fixtures to the canonical `type: sink` terminal syntax
- update the directly associated explain snapshots to render Sink node taxonomy and topology
- preserve semantic output-port vocabulary and the deliberate retired-syntax diagnostic case

## Validation

- all 28 affected integration targets passed: 164 passed, 0 failed, 0 ignored
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

- This changes executable fixtures and expected taxonomy only; runtime value derivation, row movement, dataset identity, signal emission, and retained memory are unchanged.
- Lineage, telemetry, and memory-budget behavior therefore remain covered by the implementations exercised by these tests rather than requiring new runtime instrumentation.
