### PR TITLE
Migrate transform and format fixtures to Sink

### DIFF
--- a/crates/clinker-exec/tests/transform_stream_fusion.rs
+++ b/crates/clinker-exec/tests/transform_stream_fusion.rs
@@ -103,7 +103,7 @@ nodes:
       cxl: |
         emit id = id
         emit label = tag
-  - type: output
+  - type: sink
     name: out
     input: rename
     config:
@@ -208,7 +208,7 @@ nodes:
         emit amount = amount
         emit batch = $doc.BatchInfo.batch_id
         emit declared_total = $doc.Summary.total
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -303,7 +303,7 @@ nodes:
         emit grp = grp
         emit amt = amt
         emit running = $window.sum(amt)
-  - type: output
+  - type: sink
     name: out
     input: enrich
     config:
@@ -431,14 +431,14 @@ nodes:
       cxl: |
         emit id = id
         emit tag = tag
-  - type: output
+  - type: sink
     name: out_a
     input: t_a
     config:
       name: out_a
       type: csv
       path: out_a.csv
-  - type: output
+  - type: sink
     name: out_b
     input: t_b
     config:
@@ -579,7 +579,7 @@ nodes:
       cxl: |
         emit id = id
         emit label = tag
-  - type: output
+  - type: sink
     name: out
     input: rename
     config:
@@ -671,7 +671,7 @@ nodes:
       cxl: |
         emit amount = amount
         emit batch = $doc.BatchInfo.batch_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -814,7 +814,7 @@ nodes:
       cxl: |
         emit id = id
         emit label = tag
-  - type: output
+  - type: sink
     name: out
     input: rename
     config:

--- a/crates/clinker-exec/tests/transport_validation.rs
+++ b/crates/clinker-exec/tests/transport_validation.rs
@@ -21,7 +21,7 @@ nodes:
 {source_body}
       schema:
         - {{ name: id, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: src
     config:

--- a/crates/clinker-exec/tests/two_source_aggregate_retract.rs
+++ b/crates/clinker-exec/tests/two_source_aggregate_retract.rs
@@ -107,7 +107,7 @@ nodes:
         emit total = total
         emit n = n
         emit ratio = 1 / (total - 60)
-  - type: output
+  - type: sink
     name: out
     input: post_check
     config:

--- a/crates/clinker-exec/tests/volume_estimates.rs
+++ b/crates/clinker-exec/tests/volume_estimates.rs
@@ -63,7 +63,7 @@ nodes:
       cxl: |
         emit department = department
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: dept_totals
     config:
@@ -161,7 +161,7 @@ nodes:
       schema:
         - {{ name: department, type: string }}
         - {{ name: amount, type: int }}
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -222,7 +222,7 @@ nodes:
       schema:
         - { name: department, type: string }
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: header_name
     config:
@@ -281,7 +281,7 @@ nodes:
       schema:
         - { name: department, type: string }
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -321,7 +321,7 @@ nodes:
       schema:
         - { name: department, type: string }
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -362,7 +362,7 @@ nodes:
       schema:
         - { name: department, type: string }
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -423,7 +423,7 @@ nodes:
       cxl: |
         emit department = department
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: dept_totals
     config:
@@ -551,7 +551,7 @@ nodes:
         emit ht = h.total
         emit lt = l.total
       propagate_ck: driver
-  - type: output
+  - type: sink
     name: out
     input: joined
     config:

--- a/crates/clinker-exec/tests/window_recompute_correctness.rs
+++ b/crates/clinker-exec/tests/window_recompute_correctness.rs
@@ -161,7 +161,7 @@ nodes:
       emit region = region
       emit total = total
       emit running_total = running_total + 1 / (if region == "north" then 0 else 1)
-- type: output
+- type: sink
   name: out
   input: gate
   config:

--- a/crates/clinker-exec/tests/x12_pipeline.rs
+++ b/crates/clinker-exec/tests/x12_pipeline.rs
@@ -136,7 +136,7 @@ nodes:
         emit isa13 = $doc.interchange.e13
         emit gs06 = $doc.functional_group.e06
         emit st02 = $doc.transaction_set.e02
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -208,7 +208,7 @@ nodes:
         emit gs_id = $doc.grp.e01
         emit gs_ctrl = $doc.grp.e06
         emit st_id = $doc.txn.e01
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -266,7 +266,7 @@ nodes:
         - { name: e02, type: { nullable: string } }
         - { name: e03, type: { nullable: string } }
         - { name: e04, type: { nullable: string } }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -320,7 +320,7 @@ nodes:
     config:
       cxl: |
         emit seg = seg_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -381,7 +381,7 @@ nodes:
         - { name: e03, type: { nullable: string } }
         - { name: e04, type: { nullable: string } }
         - { name: e05, type: { nullable: string } }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -440,7 +440,7 @@ nodes:
       cxl: |
         emit seg = seg_id
         emit ref = set_ref
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -510,7 +510,7 @@ nodes:
         emit e02 = e02
         emit e03 = e03
         emit e04 = e04
-  - type: output
+  - type: sink
     name: out
     input: regroup
     config:
@@ -562,7 +562,7 @@ nodes:
     config:
       cxl: |
         emit seg = seg_id
-  - type: output
+  - type: sink
     name: out
     input: tag
     config:
@@ -601,7 +601,7 @@ nodes:
       glob: ./*.x12
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -639,7 +639,7 @@ nodes:
       glob: ./*.x12
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -703,7 +703,7 @@ nodes:
         - { name: set_type, type: string }
         - { name: e01, type: string }
         - { name: e02, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -743,7 +743,7 @@ nodes:
       glob: ./*.x12
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:
@@ -783,7 +783,7 @@ nodes:
         encoding: shift_jis
       schema:
         - { name: seg_id, type: string }
-  - type: output
+  - type: sink
     name: out
     input: interchange
     config:

--- a/crates/clinker-exec/tests/xml_multi_value_e2e.rs
+++ b/crates/clinker-exec/tests/xml_multi_value_e2e.rs
@@ -66,7 +66,7 @@ nodes:
       schema:
         - { name: order_id, type: string }
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:
@@ -99,7 +99,7 @@ nodes:
       schema:
         - { name: order_id, type: string }
         - { name: tags, type: string, multiple: true }
-  - type: output
+  - type: sink
     name: out
     input: orders
     config:


### PR DESCRIPTION
## Summary

- migrate the remaining transform, transport, retraction, volume, window, X12, and XML executable fixtures to `type: sink`
- preserve semantic output names, paths, datasets, and assertions
- leave already-current lineage and REST owners unchanged

## Validation

- all seven affected integration targets passed: 41 passed, 0 failed, 0 ignored
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

- This is an executable fixture-only syntax migration. Runtime value derivation, row movement, dataset identity, telemetry, and retained memory are unchanged.
