### PR TITLE
Migrate planner and CLI fixtures to Sink

### DIFF
--- a/crates/clinker-plan/tests/e200_split_diagnostics.rs
+++ b/crates/clinker-plan/tests/e200_split_diagnostics.rs
@@ -32,7 +32,7 @@ nodes:
     input: src
     config:
       cxl: "{cxl}"
-  - type: output
+  - type: sink
     name: out
     input: t
     config:

--- a/crates/clinker-plan/tests/envelope_doc_validation.rs
+++ b/crates/clinker-plan/tests/envelope_doc_validation.rs
@@ -65,7 +65,7 @@ nodes:
     name: framed
     body: enrich
     config: {{ strategy: concat }}
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:

--- a/crates/clinker-plan/tests/observability_config.rs
+++ b/crates/clinker-plan/tests/observability_config.rs
@@ -15,7 +15,7 @@ nodes:
       path: input.csv
       type: csv
       schema: [{ name: id, type: int }]
-  - type: output
+  - type: sink
     name: out
     input: src
     config: { name: out, path: output.csv, type: csv }

--- a/crates/clinker-plan/tests/output_path_collisions.rs
+++ b/crates/clinker-plan/tests/output_path_collisions.rs
@@ -40,14 +40,14 @@ nodes:
       path: a.csv
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: direct
     input: src_a
     config:
       name: direct
       type: csv
       path: out/data.csv
-  - type: output
+  - type: sink
     name: through_pending
     input: src_a
     config:

--- a/crates/clinker-plan/tests/route_condition_diagnostics.rs
+++ b/crates/clinker-plan/tests/route_condition_diagnostics.rs
@@ -51,14 +51,14 @@ nodes:
       conditions:
         big: '{condition}'
       default: small
-  - type: output
+  - type: sink
     name: big_out
     input: split.big
     config:
       name: big_out
       type: csv
       path: big.csv
-  - type: output
+  - type: sink
     name: small_out
     input: split.small
     config:
@@ -105,14 +105,14 @@ nodes:
       conditions:
         big: '{condition}'
       default: small
-  - type: output
+  - type: sink
     name: big_out
     input: split.big
     config:
       name: big_out
       type: csv
       path: big.csv
-  - type: output
+  - type: sink
     name: small_out
     input: split.small
     config:

--- a/crates/clinker-plan/tests/transform_observability.rs
+++ b/crates/clinker-plan/tests/transform_observability.rs
@@ -28,7 +28,7 @@ pipeline:
         emit customer_id = customer_id
         emit amount = amount
       log:
-{directives}  - type: output
+{directives}  - type: sink
     name: output
     input: observe
     config:
@@ -482,7 +482,7 @@ nodes:
         emit doubled = amount * 2
       log:
         - {{ name: transform.seen, level: info, when: per_record, every: 1, message: seen, condition: "{condition}" }}
-  - type: output
+  - type: sink
     name: output
     input: observe
     config:
@@ -583,7 +583,7 @@ nodes:
         emit doubled = amount * 2
       log:
         - {{ name: transform.seen, level: info, when: per_record, every: 1, message: seen, fields: [{field}] }}
-  - type: output
+  - type: sink
     name: output
     input: observe
     config:

--- a/crates/clinker-schema/tests/canonical_parity.rs
+++ b/crates/clinker-schema/tests/canonical_parity.rs
@@ -11,7 +11,7 @@ use clinker_schema::{
 fn write_pipeline(root: &Path, schema_path: &Path) -> PathBuf {
     fs::write(root.join("input.csv"), "id\n1\n").unwrap();
     let pipeline = format!(
-        "pipeline:\n  name: parity\nnodes:\n  - type: source\n    name: src\n    config:\n      name: src\n      type: csv\n      path: input.csv\n      schema: '{}'\n  - type: output\n    name: out\n    input: src\n    config:\n      name: out\n      type: csv\n      path: output.csv\n",
+        "pipeline:\n  name: parity\nnodes:\n  - type: source\n    name: src\n    config:\n      name: src\n      type: csv\n      path: input.csv\n      schema: '{}'\n  - type: sink\n    name: out\n    input: src\n    config:\n      name: out\n      type: csv\n      path: output.csv\n",
         schema_path.display()
     );
     let path = root.join("pipeline.yaml");

--- a/crates/clinker/src/capability.rs
+++ b/crates/clinker/src/capability.rs
@@ -140,7 +140,7 @@ nodes:
         timeout_secs: 5
       schema:
         - { name: id, type: int }
-  - type: output
+  - type: sink
     name: out
     input: api
     config:
@@ -192,7 +192,7 @@ nodes:
             "the suggestion was not found in the message: {error}"
         );
         let corrected = format!(
-            "pipeline:\n  name: capability_test\nnodes:\n{suggestion}\n  - type: output\n    \
+            "pipeline:\n  name: capability_test\nnodes:\n{suggestion}\n  - type: sink\n    \
              name: out\n    input: api\n    config:\n      name: out\n      type: csv\n      \
              path: out.csv\n"
         );

--- a/crates/clinker/src/refactor/tests.rs
+++ b/crates/clinker/src/refactor/tests.rs
@@ -272,7 +272,7 @@ fn logical_overlay_target_matches_only_the_catalog_scope() {
 #[test]
 fn base_node_names_reads_pipelines_and_compositions() {
     let p = dom(
-        "pipeline:\n  name: p\nnodes:\n  - { type: source, name: a, config: {name: a, type: csv, path: x} }\n  - { type: output, name: b, input: a, config: {name: b, type: csv, path: y} }",
+        "pipeline:\n  name: p\nnodes:\n  - { type: source, name: a, config: {name: a, type: csv, path: x} }\n  - { type: sink, name: b, input: a, config: {name: b, type: csv, path: y} }",
     );
     let names = base_node_names(&p).unwrap();
     assert!(names.contains("a") && names.contains("b"));
@@ -313,7 +313,7 @@ fn write_fixture(root: &std::path::Path) {
 
     w(
         "pipeline/order.yaml",
-        "pipeline:\n  name: order\nnodes:\n  - type: source\n    name: orders\n    config:\n      name: orders\n      type: csv\n      path: ./orders.csv\n      schema:\n        - { name: id, type: string }\n        - { name: amt, type: float }\n  - type: source\n    name: events\n    config:\n      name: events\n      type: csv\n      path: ./events.csv\n      schema:\n        - { name: id, type: string }\n  - type: combine\n    name: joined\n    input:\n      orders: orders\n      events: events\n    config:\n      where: \"orders.id == events.id\"\n      match: first\n      on_miss: skip\n      propagate_ck: driver\n      cxl: |\n        emit id = orders.id\n        emit amt = orders.amt\n  - type: output\n    name: out\n    input: joined\n    config:\n      name: out\n      type: csv\n      path: ./out.csv\n",
+        "pipeline:\n  name: order\nnodes:\n  - type: source\n    name: orders\n    config:\n      name: orders\n      type: csv\n      path: ./orders.csv\n      schema:\n        - { name: id, type: string }\n        - { name: amt, type: float }\n  - type: source\n    name: events\n    config:\n      name: events\n      type: csv\n      path: ./events.csv\n      schema:\n        - { name: id, type: string }\n  - type: combine\n    name: joined\n    input:\n      orders: orders\n      events: events\n    config:\n      where: \"orders.id == events.id\"\n      match: first\n      on_miss: skip\n      propagate_ck: driver\n      cxl: |\n        emit id = orders.id\n        emit amt = orders.amt\n  - type: sink\n    name: out\n    input: joined\n    config:\n      name: out\n      type: csv\n      path: ./out.csv\n",
     );
 
     // Group: a structural op targeting the renamed source.
@@ -340,7 +340,7 @@ fn write_fixture(root: &std::path::Path) {
     // (per-target scoping keyed on the overlay's target).
     w(
         "pipeline/other.yaml",
-        "pipeline:\n  name: other\nnodes:\n  - type: source\n    name: orders\n    config:\n      name: orders\n      type: csv\n      path: ./orders.csv\n      schema:\n        - { name: id, type: string }\n  - type: output\n    name: sink\n    input: orders\n    config:\n      name: sink\n      type: csv\n      path: ./sink.csv\n",
+        "pipeline:\n  name: other\nnodes:\n  - type: source\n    name: orders\n    config:\n      name: orders\n      type: csv\n      path: ./orders.csv\n      schema:\n        - { name: id, type: string }\n  - type: sink\n    name: sink\n    input: orders\n    config:\n      name: sink\n      type: csv\n      path: ./sink.csv\n",
     );
     w(
         "channel/beta/channel.cfg.yaml",

--- a/crates/clinker/tests/allow_absolute_paths_cli.rs
+++ b/crates/clinker/tests/allow_absolute_paths_cli.rs
@@ -48,7 +48,7 @@ nodes:
     schema:
       - {{ name: id, type: int }}
       - {{ name: name, type: string }}
-- type: output
+- type: sink
   name: out
   input: src
   config:

--- a/crates/clinker/tests/atomic_output_test.rs
+++ b/crates/clinker/tests/atomic_output_test.rs
@@ -58,7 +58,7 @@ nodes:
     schema:
       - { name: id, type: int }
       - { name: name, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -143,7 +143,7 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -206,7 +206,7 @@ nodes:
     cxl: |
       emit id = id
       emit boom = id / 0
-- type: output
+- type: sink
   name: out
   input: divzero
   config:
@@ -265,7 +265,7 @@ nodes:
   config:
     cxl: |
       emit boom = id / 0
-- type: output
+- type: sink
   name: out
   input: fail
   config:
@@ -312,7 +312,7 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -372,7 +372,7 @@ nodes:
     schema:
       - { name: id, type: int }
       - { name: group, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -425,7 +425,7 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -497,7 +497,7 @@ nodes:
   config:
     cxl: |
       emit boom = id / 0
-- type: output
+- type: sink
   name: out
   input: fail
   config:
@@ -543,7 +543,7 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -599,7 +599,7 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -663,14 +663,14 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: fan
   input: src
   config:
     name: fan
     path: literal-{{source_file}}-{source_file}.csv
     type: csv
-- type: output
+- type: sink
   name: merged
   input: src
   config:
@@ -723,7 +723,7 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -789,7 +789,7 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -839,7 +839,7 @@ nodes:
     schema:
       - { name: id, type: int }
       - { name: group, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -903,7 +903,7 @@ nodes:
     cxl: |
       emit id = id
       emit value = 1 / amount
-- type: output
+- type: sink
   name: out
   input: fail_one
   config:
@@ -962,7 +962,7 @@ nodes:
     schema:
       - { name: id, type: int }
       - { name: name, type: string }
-- type: output
+- type: sink
   name: out
   input: src
   config:

--- a/crates/clinker/tests/attempt_operations.rs
+++ b/crates/clinker/tests/attempt_operations.rs
@@ -23,7 +23,7 @@ nodes:
       path: input.csv
       schema:
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: result
     input: source
     config:
@@ -290,7 +290,7 @@ nodes:
       path: input.csv
       schema:
         - {{ name: value, type: string }}
-  - type: output
+  - type: sink
     name: result
     input: source
     config:
@@ -681,7 +681,7 @@ nodes:
       glob: input-*.csv
       schema:
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: result
     input: source
     config:
@@ -743,7 +743,7 @@ nodes:
       glob: input-*.csv
       schema:
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: result
     input: source
     config:
@@ -800,7 +800,7 @@ nodes:
       glob: inputs/original/*.csv
       schema:
         - { name: value, type: string }
-  - type: output
+  - type: sink
     name: result
     input: source
     config:
@@ -947,7 +947,7 @@ nodes:
       cxl: |
         emit id = id
         emit value = 10 / amount
-  - type: output
+  - type: sink
     name: primary
     input: checked
     config:
@@ -955,14 +955,14 @@ nodes:
       type: csv
       path: output/primary.csv
       write_meta: true
-  - type: output
+  - type: sink
     name: fan
     input: source
     config:
       name: fan
       type: csv
       path: output/fan_{source_file}.csv
-  - type: output
+  - type: sink
     name: split
     input: checked
     config:

--- a/crates/clinker/tests/attempt_publication.rs
+++ b/crates/clinker/tests/attempt_publication.rs
@@ -127,7 +127,7 @@ nodes:
       type: csv
       path: input.csv
       schema: [{{ name: id, type: int }}]
-  - type: output
+  - type: sink
     name: out
     input: src
     config:


### PR DESCRIPTION
## Summary

- migrate embedded planner, schema, capability, refactor, and CLI fixtures to the canonical `type: sink` syntax
- preserve semantic output names, paths, artifacts, diagnostics, and test behavior
- leave the already-current command entry point unchanged

## Validation

- 151 focused tests across planner, schema, capability, refactor, and CLI targets
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

- This is an executable fixture-only syntax migration. Runtime lineage, telemetry, row behavior, and retained memory are unchanged.
