### PR TITLE
Seal deterministic source activation groups

### DIFF
--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -452,11 +452,6 @@ impl PipelineConfig {
             };
             LabeledSpan::primary(s, String::new())
         };
-        // (a) Whole-DAG diagnostic: stage-3 cycle detection emits one
-        // diagnostic that covers the entire pipeline graph, with no
-        // single node to anchor on.
-        let synth = || LabeledSpan::primary(Span::SYNTHETIC, String::new());
-
         // ── Stage 1: duplicate names ────────────────────────────────
         // Names are case-sensitive (matches Unix FS, Airflow, Beam).
         // Exact duplicates → E001 error. Case-only duplicates → W002.
@@ -518,10 +513,17 @@ impl PipelineConfig {
         }
         if let Some(cycle) = graph.detect_cycle() {
             let path = cycle.join(" → ");
+            let cycle_span = cycle
+                .first()
+                .and_then(|name| self.nodes.iter().find(|node| node.value.name() == name))
+                .map_or_else(
+                    || LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+                    span_for,
+                );
             diags.push(Diagnostic::error(
                 "E003",
                 format!("cycle detected: {path} → {}", cycle[0]),
-                synth(),
+                cycle_span,
             ));
         }
 
@@ -2369,6 +2371,19 @@ impl PipelineConfig {
                 "E003",
                 format!("order-contract finalization failed: {error}"),
                 LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+            ));
+            return Err(diags);
+        }
+
+        // Seal the complete recursive Source activation inventory at the same
+        // finalized-plan boundary. This reads only compiled topology and
+        // secret-free logical resource requirements; runtime handles and
+        // credential profiles remain outside `CompiledPlan`.
+        if let Err(error) = dag.seal_source_activation(&artifacts.composition_bodies) {
+            diags.push(Diagnostic::error(
+                "E003",
+                format!("source activation finalization failed: {}", error.message),
+                LabeledSpan::primary(error.span, String::new()),
             ));
             return Err(diags);
         }

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -42,9 +42,7 @@ use crate::plan::combine::{
     CombineInput, DecomposedPredicate, decompose_predicate, select_driving_input,
 };
 use crate::plan::composition_body::{BoundBody, CompositionBodyId};
-use crate::plan::execution::{
-    CompiledResourceRequirement, CompiledSourceInstance, CompiledSourceInstanceId,
-};
+use crate::plan::execution::{CompiledResourceRequirement, CompiledSourceInstance};
 use crate::plan::types::JoinSide;
 use crate::plan::{EntityRef, PlanNodeId};
 use crate::resources::WorkspaceCatalog;
@@ -3746,13 +3744,13 @@ fn bind_composition(
 
     let source_instances = pending_source_requirements
         .into_iter()
-        .map(|(source_name, resource)| CompiledSourceInstance {
-            id: CompiledSourceInstanceId {
-                body_scope: body_id.into(),
-                source_node: body_node_ids[&source_name],
-            },
-            source_name,
-            resource,
+        .map(|(source_name, resource)| {
+            CompiledSourceInstance::composition_body(
+                body_id.into(),
+                body_node_ids[&source_name],
+                source_name,
+                resource,
+            )
         })
         .collect();
 

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -3085,6 +3085,7 @@ mod tests {
         let mut plan = ExecutionPlanDag {
             consumer_registry: Default::default(),
             order_contract: Default::default(),
+            source_activation: Default::default(),
             graph,
             topo_order: Vec::new(),
             source_dag: Vec::new(),
@@ -3435,6 +3436,7 @@ mod tests {
         let mut plan = ExecutionPlanDag {
             consumer_registry: Default::default(),
             order_contract: Default::default(),
+            source_activation: Default::default(),
             graph,
             topo_order: Vec::new(),
             source_dag: Vec::new(),

--- a/crates/clinker-plan/src/plan/execution/activation.rs
+++ b/crates/clinker-plan/src/plan/execution/activation.rs
@@ -1,31 +1,49 @@
-//! Plan-time composition Source activation contracts.
+//! Plan-time Source activation inventory and dependency groups.
 //!
-//! These values describe which typed, logical resource a body Source will
+//! These values describe which typed, logical resources a compiled plan will
 //! require once runtime activation is implemented. They deliberately contain
 //! no physical path, credential selection, secret, opened handle, I/O state,
-//! or thread state. One instance is scoped to one bound body call, so two
-//! calls to the same composition never share mutable source identity.
+//! or thread state. The inventory is sealed only after every top-level and
+//! recursively bound body graph has reached its final topology.
 
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fmt;
+
+use clinker_core_types::span::Span;
+use petgraph::graph::NodeIndex;
+use petgraph::visit::EdgeRef;
+
+use super::{
+    ExecutionPlanDag, PlanEdge, PlanNode, PlanNodeId, SourceActivationFusionKind,
+    derive_source_activation_fusions, stable_topological_order,
+};
 use crate::config::{
     ResourceBinding, ResourceCapability, ResourceKind, ResourceLifetime, ResourceOpenerKind,
 };
-use crate::plan::PlanNodeId;
-use crate::plan::composition_body::BodyScopeId;
+use crate::credentials::CredentialRequirementName;
+use crate::plan::composition_body::{BodyScopeId, BoundBody, CompositionBodies, CompositionBodyId};
 use crate::resources::ResourceDatasetIdentity;
 
-/// Stable identity of one Source authored in one bound composition body.
-///
-/// `body_scope` distinguishes separate call sites, while `source_node`
-/// distinguishes Sources within that body. Both values are minted in stable
-/// declaration order, so compiling identical input twice yields identical
-/// identities without relying on an author-chosen name.
+/// Scope that owns one compiled external Source.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum CompiledSourceScope {
+    /// A Source authored directly in the pipeline.
+    TopLevel,
+    /// A Source authored in one call-site-scoped composition body.
+    CompositionBody(BodyScopeId),
+}
+
+/// Stable identity of one external Source in one compiled scope.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct CompiledSourceInstanceId {
-    /// Call-site-local body scope.
-    pub body_scope: BodyScopeId,
-    /// Stable node identity of the authored body Source.
+    /// Top-level or call-site-local body scope.
+    pub scope: CompiledSourceScope,
+    /// Stable node identity of the authored Source.
     pub source_node: PlanNodeId,
 }
 
@@ -53,16 +71,869 @@ pub struct CompiledResourceRequirement {
     pub dataset_identity: ResourceDatasetIdentity,
 }
 
-/// One plan-time body Source instance and its exact resource dependency.
+/// Origin-specific contract for one external Source.
+#[derive(Debug, Clone, PartialEq)]
+enum CompiledSourceOrigin {
+    TopLevel,
+    CompositionBody(CompiledResourceRequirement),
+}
+
+/// One plan-time external Source instance and its activation requirement.
 ///
 /// The value is fixed, configuration-derived state. It performs no execution
 /// work and retains a constant amount of data per authored Source.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct CompiledSourceInstance {
-    /// Scope-qualified source identity.
-    pub id: CompiledSourceInstanceId,
-    /// Author-facing source name, retained for diagnostics only.
-    pub source_name: String,
-    /// Typed, secret-free resource requirement.
-    pub resource: CompiledResourceRequirement,
+    id: CompiledSourceInstanceId,
+    source_name: String,
+    origin: CompiledSourceOrigin,
+    credential_requirement_ids: Box<[CredentialRequirementName]>,
+    credential_handle_units: u32,
+}
+
+impl fmt::Debug for CompiledSourceInstance {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CompiledSourceInstance")
+            .field("id", &self.id)
+            .field("source_name", &self.source_name)
+            .field("resource", &self.resource())
+            .finish()
+    }
+}
+
+impl CompiledSourceInstance {
+    pub(crate) fn top_level(source_node: PlanNodeId, source_name: String) -> Self {
+        Self {
+            id: CompiledSourceInstanceId {
+                scope: CompiledSourceScope::TopLevel,
+                source_node,
+            },
+            source_name,
+            origin: CompiledSourceOrigin::TopLevel,
+            credential_requirement_ids: Box::new([]),
+            credential_handle_units: 0,
+        }
+    }
+
+    pub(crate) fn composition_body(
+        body_scope: BodyScopeId,
+        source_node: PlanNodeId,
+        source_name: String,
+        resource: CompiledResourceRequirement,
+    ) -> Self {
+        Self {
+            id: CompiledSourceInstanceId {
+                scope: CompiledSourceScope::CompositionBody(body_scope),
+                source_node,
+            },
+            source_name,
+            origin: CompiledSourceOrigin::CompositionBody(resource),
+            credential_requirement_ids: Box::new([]),
+            credential_handle_units: 0,
+        }
+    }
+
+    /// Return the stable scope-qualified Source identity.
+    pub fn id(&self) -> CompiledSourceInstanceId {
+        self.id
+    }
+
+    /// Return the author-facing Source name retained for diagnostics.
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    /// Return the typed logical resource requirement for a body Source.
+    ///
+    /// Top-level Sources return `None` because the top-level catalog binding
+    /// surface has not been designed; they retain their existing direct-file
+    /// source contract.
+    pub fn resource(&self) -> Option<&CompiledResourceRequirement> {
+        match &self.origin {
+            CompiledSourceOrigin::TopLevel => None,
+            CompiledSourceOrigin::CompositionBody(resource) => Some(resource),
+        }
+    }
+
+    fn capacity(&self) -> SourceActivationCapacity {
+        SourceActivationCapacity::new(1, 1, self.credential_handle_units)
+    }
+}
+
+/// One root of a compiled scope, with synthetic input ports distinguished from
+/// external Sources that require activation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompiledSourceRoot {
+    /// External Source represented by exactly one activation group member.
+    External {
+        /// Stable external Source identity.
+        instance: CompiledSourceInstanceId,
+    },
+    /// Synthetic body input fed by its parent scope without opening a resource.
+    InputPort {
+        /// Body scope that owns the synthetic root.
+        body_scope: BodyScopeId,
+        /// Stable identity of the synthetic Source node.
+        source_node: PlanNodeId,
+        /// Authored composition input-port name.
+        port_name: Box<str>,
+        /// Parent activation groups that can feed this port.
+        dependency_groups: Box<[SourceActivationGroupId]>,
+    },
+}
+
+/// Dense stable identity of one activation group.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub struct SourceActivationGroupId(u32);
+
+impl SourceActivationGroupId {
+    /// Return the dense zero-based group index.
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
+/// Topology proof that determines which Source instances activate together.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceActivationGroupKind {
+    /// One ordinary Source with no proven shared live-consumer boundary.
+    Ordinary,
+    /// Multiple exclusive Sources selected live by one unseeded interleave.
+    LiveInterleave {
+        /// Stable compiled consumer path that proves the grouping.
+        consumer_path: Box<[PlanNodeId]>,
+    },
+    /// One exclusive Source fused into its immediate streaming Transform.
+    FusedStreaming {
+        /// Stable compiled consumer path that proves the grouping.
+        consumer_path: Box<[PlanNodeId]>,
+    },
+}
+
+/// Checked resource capacity required to activate one group atomically.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+pub struct SourceActivationCapacity {
+    resource_units: u32,
+    opener_units: u32,
+    credential_handle_units: u32,
+}
+
+impl SourceActivationCapacity {
+    /// Construct an exact three-axis capacity requirement.
+    pub const fn new(resource_units: u32, opener_units: u32, credential_handle_units: u32) -> Self {
+        Self {
+            resource_units,
+            opener_units,
+            credential_handle_units,
+        }
+    }
+
+    /// Add two requirements, returning `None` rather than wrapping any axis.
+    pub fn checked_add(self, other: Self) -> Option<Self> {
+        Some(Self {
+            resource_units: self.resource_units.checked_add(other.resource_units)?,
+            opener_units: self.opener_units.checked_add(other.opener_units)?,
+            credential_handle_units: self
+                .credential_handle_units
+                .checked_add(other.credential_handle_units)?,
+        })
+    }
+
+    /// Number of independently opened resource sessions.
+    pub fn resource_units(self) -> u32 {
+        self.resource_units
+    }
+
+    /// Number of provider-neutral openers held concurrently.
+    pub fn opener_units(self) -> u32 {
+        self.opener_units
+    }
+
+    /// Number of credential handles held concurrently.
+    pub fn credential_handle_units(self) -> u32 {
+        self.credential_handle_units
+    }
+}
+
+/// One deterministic, dependency-aware Source activation group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceActivationGroup {
+    id: SourceActivationGroupId,
+    kind: SourceActivationGroupKind,
+    members: Box<[CompiledSourceInstanceId]>,
+    dependencies: Box<[SourceActivationGroupId]>,
+    credential_requirement_ids: Box<[CredentialRequirementName]>,
+    capacity: SourceActivationCapacity,
+}
+
+impl SourceActivationGroup {
+    /// Return this group's dense stable identity.
+    pub fn id(&self) -> SourceActivationGroupId {
+        self.id
+    }
+
+    /// Return the topology proof for this group.
+    pub fn kind(&self) -> &SourceActivationGroupKind {
+        &self.kind
+    }
+
+    /// Return external Sources that must activate atomically.
+    pub fn members(&self) -> &[CompiledSourceInstanceId] {
+        &self.members
+    }
+
+    /// Return groups that must activate before this one.
+    pub fn dependencies(&self) -> &[SourceActivationGroupId] {
+        &self.dependencies
+    }
+
+    /// Return the complete deduplicated logical credential requirements.
+    pub fn credential_requirement_ids(&self) -> &[CredentialRequirementName] {
+        &self.credential_requirement_ids
+    }
+
+    /// Return checked aggregate activation capacity.
+    pub fn capacity(&self) -> SourceActivationCapacity {
+        self.capacity
+    }
+}
+
+/// Sealed recursive Source activation inventory retained by `CompiledPlan`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SourceActivationPlan {
+    sealed: bool,
+    instances: Box<[CompiledSourceInstance]>,
+    roots: Box<[CompiledSourceRoot]>,
+    groups: Box<[SourceActivationGroup]>,
+    credential_requirement_ids: Box<[CredentialRequirementName]>,
+}
+
+impl SourceActivationPlan {
+    /// Whether the inventory covers the finalized top-level and body DAGs.
+    pub fn is_sealed(&self) -> bool {
+        self.sealed
+    }
+
+    /// Return every external Source in deterministic recursive order.
+    pub fn instances(&self) -> &[CompiledSourceInstance] {
+        &self.instances
+    }
+
+    /// Return external and synthetic input-port roots.
+    pub fn roots(&self) -> &[CompiledSourceRoot] {
+        &self.roots
+    }
+
+    /// Return activation groups in stable dependency order.
+    pub fn groups(&self) -> &[SourceActivationGroup] {
+        &self.groups
+    }
+
+    /// Return the plan-wide complete logical credential requirement set.
+    pub fn credential_requirement_ids(&self) -> &[CredentialRequirementName] {
+        &self.credential_requirement_ids
+    }
+
+    /// Produce a fixed-cardinality, data-free explain projection.
+    pub fn summary(&self) -> SourceActivationSummary {
+        SourceActivationSummary {
+            sealed: self.sealed,
+            instance_count: self.instances.len(),
+            input_port_root_count: self
+                .roots
+                .iter()
+                .filter(|root| matches!(root, CompiledSourceRoot::InputPort { .. }))
+                .count(),
+            group_count: self.groups.len(),
+            max_simultaneous_width: self
+                .groups
+                .iter()
+                .map(|group| group.members.len())
+                .max()
+                .unwrap_or(0),
+            credential_requirement_count: self.credential_requirement_ids.len(),
+            max_group_resource_units: self
+                .groups
+                .iter()
+                .map(|group| group.capacity.resource_units)
+                .max()
+                .unwrap_or(0),
+            max_group_opener_units: self
+                .groups
+                .iter()
+                .map(|group| group.capacity.opener_units)
+                .max()
+                .unwrap_or(0),
+            max_group_credential_handle_units: self
+                .groups
+                .iter()
+                .map(|group| group.capacity.credential_handle_units)
+                .max()
+                .unwrap_or(0),
+        }
+    }
+}
+
+/// Fixed-cardinality explain projection for Source activation planning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub struct SourceActivationSummary {
+    /// Whether recursive inventory sealing completed.
+    pub sealed: bool,
+    /// External Source count across every scope.
+    pub instance_count: usize,
+    /// Synthetic body input-port root count.
+    pub input_port_root_count: usize,
+    /// Activation group count.
+    pub group_count: usize,
+    /// Largest atomic Source group.
+    pub max_simultaneous_width: usize,
+    /// Distinct logical credential requirement count.
+    pub credential_requirement_count: usize,
+    /// Largest per-group resource-session requirement.
+    pub max_group_resource_units: u32,
+    /// Largest per-group opener requirement.
+    pub max_group_opener_units: u32,
+    /// Largest per-group credential-handle requirement.
+    pub max_group_credential_handle_units: u32,
+}
+
+/// Failure to seal the finalized recursive activation inventory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceActivationPlanError {
+    pub span: Span,
+    pub message: String,
+}
+
+#[derive(Debug)]
+struct DraftGroup {
+    kind: SourceActivationGroupKind,
+    members: Vec<CompiledSourceInstanceId>,
+    dependencies: BTreeSet<usize>,
+    credential_requirement_ids: BTreeSet<CredentialRequirementName>,
+    capacity: SourceActivationCapacity,
+    rank: usize,
+    span: Span,
+}
+
+#[derive(Debug)]
+enum DraftRoot {
+    External(CompiledSourceInstanceId),
+    InputPort {
+        body_scope: BodyScopeId,
+        source_node: PlanNodeId,
+        port_name: Box<str>,
+        dependency_groups: BTreeSet<usize>,
+    },
+}
+
+#[derive(Debug, Default)]
+struct ActivationBuilder {
+    instances: Vec<CompiledSourceInstance>,
+    roots: Vec<DraftRoot>,
+    groups: Vec<DraftGroup>,
+    visited_bodies: BTreeSet<CompositionBodyId>,
+}
+
+impl ActivationBuilder {
+    fn compile_scope(
+        &mut self,
+        plan: &ExecutionPlanDag,
+        body: Option<(CompositionBodyId, &BoundBody)>,
+        bodies: &CompositionBodies,
+        input_dependencies: &BTreeMap<String, BTreeSet<usize>>,
+    ) -> Result<Vec<usize>, SourceActivationPlanError> {
+        let supplied_instances = match body {
+            Some((body_id, bound)) => {
+                if !self.visited_bodies.insert(body_id) {
+                    return Err(SourceActivationPlanError {
+                        span: Span::SYNTHETIC,
+                        message: format!(
+                            "composition body {} is reachable from more than one compiled call site",
+                            body_id.0
+                        ),
+                    });
+                }
+                bound.source_instances.clone()
+            }
+            None => stable_topological_order(&plan.graph)
+                .map_err(|idx| self.topology_error(plan, idx))?
+                .into_iter()
+                .filter_map(|idx| match &plan.graph[idx] {
+                    PlanNode::Source { id, name, .. } => {
+                        Some(CompiledSourceInstance::top_level(*id, name.clone()))
+                    }
+                    _ => None,
+                })
+                .collect(),
+        };
+
+        let base_dependencies: BTreeSet<_> = input_dependencies
+            .values()
+            .flat_map(|dependencies| dependencies.iter().copied())
+            .collect();
+        let (source_groups, scope_groups) =
+            self.add_scope_groups(plan, supplied_instances, &base_dependencies)?;
+
+        if body.is_none() {
+            self.apply_top_level_source_tiers(plan, &source_groups)?;
+        }
+
+        let mut port_groups_by_node = HashMap::new();
+        if let Some((_, bound)) = body {
+            for (port_name, node_idx) in &bound.port_name_to_node_idx {
+                let node = &bound.graph[*node_idx];
+                let dependencies = input_dependencies
+                    .get(port_name)
+                    .cloned()
+                    .unwrap_or_default();
+                port_groups_by_node.insert(node.id(), dependencies.clone());
+                self.roots.push(DraftRoot::InputPort {
+                    body_scope: bound.body_scope,
+                    source_node: node.id(),
+                    port_name: port_name.clone().into_boxed_str(),
+                    dependency_groups: dependencies,
+                });
+            }
+            self.reject_unclassified_body_sources(bound, &source_groups, &port_groups_by_node)?;
+        }
+
+        let stable_topo =
+            stable_topological_order(&plan.graph).map_err(|idx| self.topology_error(plan, idx))?;
+        let mut composition_groups: HashMap<PlanNodeId, Vec<usize>> = HashMap::new();
+        let mut recursive_groups = scope_groups.clone();
+        for idx in stable_topo {
+            let PlanNode::Composition {
+                id,
+                body: child_body_id,
+                ..
+            } = plan.graph[idx]
+            else {
+                continue;
+            };
+            let child_body =
+                bodies
+                    .get(&child_body_id)
+                    .ok_or_else(|| SourceActivationPlanError {
+                        span: plan.graph[idx].span(),
+                        message: format!(
+                            "composition {:?} references undeclared bound body {}",
+                            plan.graph[idx].name(),
+                            child_body_id.0
+                        ),
+                    })?;
+            let mut child_inputs: BTreeMap<String, BTreeSet<usize>> = BTreeMap::new();
+            for edge in plan
+                .graph
+                .edges_directed(idx, petgraph::Direction::Incoming)
+            {
+                let Some(port) = edge.weight().port.as_ref() else {
+                    return Err(SourceActivationPlanError {
+                        span: plan.graph[idx].span(),
+                        message: format!(
+                            "composition {:?} has an undeclared untagged input dependency",
+                            plan.graph[idx].name()
+                        ),
+                    });
+                };
+                let dependencies = collect_upstream_groups(
+                    &plan.graph,
+                    edge.source(),
+                    &source_groups,
+                    &port_groups_by_node,
+                    &composition_groups,
+                );
+                child_inputs
+                    .entry(port.clone())
+                    .or_default()
+                    .extend(dependencies);
+            }
+            for port_name in child_inputs.keys() {
+                if !child_body.input_port_rows.contains_key(port_name) {
+                    return Err(SourceActivationPlanError {
+                        span: plan.graph[idx].span(),
+                        message: format!(
+                            "composition {:?} depends on undeclared input port {port_name:?}",
+                            plan.graph[idx].name()
+                        ),
+                    });
+                }
+            }
+
+            let child_plan = ExecutionPlanDag::from_body(child_body);
+            let child_groups = self.compile_scope(
+                &child_plan,
+                Some((child_body_id, child_body)),
+                bodies,
+                &child_inputs,
+            )?;
+            composition_groups.insert(id, child_groups.clone());
+            recursive_groups.extend(child_groups);
+        }
+
+        Ok(recursive_groups)
+    }
+
+    fn add_scope_groups(
+        &mut self,
+        plan: &ExecutionPlanDag,
+        supplied_instances: Vec<CompiledSourceInstance>,
+        base_dependencies: &BTreeSet<usize>,
+    ) -> Result<(HashMap<PlanNodeId, usize>, Vec<usize>), SourceActivationPlanError> {
+        let supplied_by_node: HashMap<_, _> = supplied_instances
+            .into_iter()
+            .map(|instance| (instance.id.source_node, instance))
+            .collect();
+        let external_source_ids: HashSet<_> = supplied_by_node.keys().copied().collect();
+        let fusions = derive_source_activation_fusions(plan, &external_source_ids)
+            .map_err(|idx| self.topology_error(plan, idx))?;
+        let fusion_by_source: HashMap<_, _> = fusions
+            .iter()
+            .enumerate()
+            .flat_map(|(fusion_idx, fusion)| {
+                fusion
+                    .sources
+                    .iter()
+                    .copied()
+                    .map(move |source| (source, fusion_idx))
+            })
+            .collect();
+        let stable_topo =
+            stable_topological_order(&plan.graph).map_err(|idx| self.topology_error(plan, idx))?;
+        let mut source_groups = HashMap::new();
+        let mut scope_groups = Vec::new();
+        let mut emitted_fusions = HashSet::new();
+
+        for idx in stable_topo {
+            let node_id = plan.graph[idx].id();
+            if !external_source_ids.contains(&node_id) {
+                continue;
+            }
+            let (kind, source_ids) = if let Some(&fusion_idx) = fusion_by_source.get(&node_id) {
+                if !emitted_fusions.insert(fusion_idx) {
+                    continue;
+                }
+                let fusion = &fusions[fusion_idx];
+                let kind = match fusion.kind {
+                    SourceActivationFusionKind::LiveInterleave => {
+                        SourceActivationGroupKind::LiveInterleave {
+                            consumer_path: fusion.consumer_path.clone(),
+                        }
+                    }
+                    SourceActivationFusionKind::FusedStreaming => {
+                        SourceActivationGroupKind::FusedStreaming {
+                            consumer_path: fusion.consumer_path.clone(),
+                        }
+                    }
+                };
+                (kind, fusion.sources.to_vec())
+            } else {
+                (SourceActivationGroupKind::Ordinary, vec![node_id])
+            };
+
+            let mut members = Vec::with_capacity(source_ids.len());
+            let mut credentials = BTreeSet::new();
+            let mut capacity = SourceActivationCapacity::default();
+            let rank = self.instances.len();
+            for source_id in &source_ids {
+                let instance =
+                    supplied_by_node
+                        .get(source_id)
+                        .ok_or_else(|| SourceActivationPlanError {
+                            span: plan.graph[idx].span(),
+                            message: format!(
+                                "activation group references undeclared Source identity {:?}",
+                                source_id
+                            ),
+                        })?;
+                capacity = capacity.checked_add(instance.capacity()).ok_or_else(|| {
+                    SourceActivationPlanError {
+                        span: plan.graph[idx].span(),
+                        message: "Source activation capacity exceeds the supported u32 bound"
+                            .to_string(),
+                    }
+                })?;
+                credentials.extend(instance.credential_requirement_ids.iter().cloned());
+                members.push(instance.id());
+                self.instances.push(instance.clone());
+                self.roots.push(DraftRoot::External(instance.id()));
+            }
+            let group_idx = self.groups.len();
+            self.groups.push(DraftGroup {
+                kind,
+                members,
+                dependencies: base_dependencies.clone(),
+                credential_requirement_ids: credentials,
+                capacity,
+                rank,
+                span: plan.graph[idx].span(),
+            });
+            for source_id in source_ids {
+                source_groups.insert(source_id, group_idx);
+            }
+            scope_groups.push(group_idx);
+        }
+
+        if source_groups.len() != supplied_by_node.len() {
+            let missing = supplied_by_node
+                .keys()
+                .find(|source_id| !source_groups.contains_key(source_id))
+                .copied();
+            return Err(SourceActivationPlanError {
+                span: Span::SYNTHETIC,
+                message: format!(
+                    "compiled Source activation inventory omitted Source identity {missing:?}"
+                ),
+            });
+        }
+        Ok((source_groups, scope_groups))
+    }
+
+    fn reject_unclassified_body_sources(
+        &self,
+        body: &BoundBody,
+        external_groups: &HashMap<PlanNodeId, usize>,
+        port_groups: &HashMap<PlanNodeId, BTreeSet<usize>>,
+    ) -> Result<(), SourceActivationPlanError> {
+        for node in body.graph.node_weights() {
+            if matches!(node, PlanNode::Source { .. })
+                && !external_groups.contains_key(&node.id())
+                && !port_groups.contains_key(&node.id())
+            {
+                return Err(SourceActivationPlanError {
+                    span: node.span(),
+                    message: format!(
+                        "body Source {:?} is neither an external resource nor an input-port root",
+                        node.name()
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_top_level_source_tiers(
+        &mut self,
+        plan: &ExecutionPlanDag,
+        source_groups: &HashMap<PlanNodeId, usize>,
+    ) -> Result<(), SourceActivationPlanError> {
+        let source_id_by_name: HashMap<_, _> = plan
+            .graph
+            .node_weights()
+            .filter_map(|node| match node {
+                PlanNode::Source { name, id, .. } => Some((name.as_str(), *id)),
+                _ => None,
+            })
+            .collect();
+        let mut previous_tier = BTreeSet::new();
+        for tier in &plan.source_dag {
+            let current: BTreeSet<_> = tier
+                .sources
+                .iter()
+                .filter_map(|name| source_id_by_name.get(name.as_str()))
+                .filter_map(|source_id| source_groups.get(source_id))
+                .copied()
+                .collect();
+            for &group in &current {
+                if previous_tier.contains(&group) {
+                    return Err(SourceActivationPlanError {
+                        span: self.groups[group].span,
+                        message: "one simultaneous Source group spans dependent source tiers"
+                            .to_string(),
+                    });
+                }
+                self.groups[group]
+                    .dependencies
+                    .extend(previous_tier.iter().copied());
+            }
+            previous_tier = current;
+        }
+        Ok(())
+    }
+
+    fn topology_error(&self, plan: &ExecutionPlanDag, idx: NodeIndex) -> SourceActivationPlanError {
+        SourceActivationPlanError {
+            span: plan
+                .graph
+                .node_weight(idx)
+                .map(PlanNode::span)
+                .unwrap_or(Span::SYNTHETIC),
+            message: "cycle detected while sealing Source activation topology".to_string(),
+        }
+    }
+
+    fn finish(self) -> Result<SourceActivationPlan, SourceActivationPlanError> {
+        let mut indegrees: Vec<_> = self
+            .groups
+            .iter()
+            .map(|group| group.dependencies.len())
+            .collect();
+        let mut dependents = vec![Vec::new(); self.groups.len()];
+        for (group_idx, group) in self.groups.iter().enumerate() {
+            for &dependency in &group.dependencies {
+                if dependency == group_idx {
+                    return Err(SourceActivationPlanError {
+                        span: group.span,
+                        message: "Source activation group depends on itself".to_string(),
+                    });
+                }
+                dependents[dependency].push(group_idx);
+            }
+        }
+        let mut ready: BTreeSet<_> = self
+            .groups
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, group)| (indegrees[idx] == 0).then_some((group.rank, idx)))
+            .collect();
+        let mut order = Vec::with_capacity(self.groups.len());
+        while let Some(&(rank, idx)) = ready.first() {
+            ready.remove(&(rank, idx));
+            order.push(idx);
+            for &dependent in &dependents[idx] {
+                indegrees[dependent] -= 1;
+                if indegrees[dependent] == 0 {
+                    ready.insert((self.groups[dependent].rank, dependent));
+                }
+            }
+        }
+        if order.len() != self.groups.len() {
+            let idx = indegrees
+                .iter()
+                .position(|&indegree| indegree > 0)
+                .unwrap_or(0);
+            return Err(SourceActivationPlanError {
+                span: self.groups[idx].span,
+                message: "cycle detected between Source activation groups".to_string(),
+            });
+        }
+
+        let mut remap = vec![SourceActivationGroupId(0); self.groups.len()];
+        for (new_idx, &old_idx) in order.iter().enumerate() {
+            let dense = u32::try_from(new_idx).map_err(|_| SourceActivationPlanError {
+                span: self.groups[old_idx].span,
+                message: "Source activation group count exceeds the supported u32 bound"
+                    .to_string(),
+            })?;
+            remap[old_idx] = SourceActivationGroupId(dense);
+        }
+        let groups: Vec<_> = order
+            .into_iter()
+            .map(|old_idx| {
+                let group = &self.groups[old_idx];
+                let mut dependencies: Vec<_> = group
+                    .dependencies
+                    .iter()
+                    .map(|&dependency| remap[dependency])
+                    .collect();
+                dependencies.sort_unstable();
+                SourceActivationGroup {
+                    id: remap[old_idx],
+                    kind: group.kind.clone(),
+                    members: group.members.clone().into_boxed_slice(),
+                    dependencies: dependencies.into_boxed_slice(),
+                    credential_requirement_ids: group
+                        .credential_requirement_ids
+                        .iter()
+                        .cloned()
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                    capacity: group.capacity,
+                }
+            })
+            .collect();
+        let roots = self
+            .roots
+            .into_iter()
+            .map(|root| match root {
+                DraftRoot::External(instance) => CompiledSourceRoot::External { instance },
+                DraftRoot::InputPort {
+                    body_scope,
+                    source_node,
+                    port_name,
+                    dependency_groups,
+                } => CompiledSourceRoot::InputPort {
+                    body_scope,
+                    source_node,
+                    port_name,
+                    dependency_groups: dependency_groups
+                        .into_iter()
+                        .map(|dependency| remap[dependency])
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                },
+            })
+            .collect::<Vec<_>>();
+        let credential_requirement_ids: BTreeSet<_> = groups
+            .iter()
+            .flat_map(|group| group.credential_requirement_ids.iter().cloned())
+            .collect();
+        Ok(SourceActivationPlan {
+            sealed: true,
+            instances: self.instances.into_boxed_slice(),
+            roots: roots.into_boxed_slice(),
+            groups: groups.into_boxed_slice(),
+            credential_requirement_ids: credential_requirement_ids
+                .into_iter()
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        })
+    }
+}
+
+fn collect_upstream_groups(
+    graph: &petgraph::graph::DiGraph<PlanNode, PlanEdge>,
+    start: NodeIndex,
+    source_groups: &HashMap<PlanNodeId, usize>,
+    port_groups: &HashMap<PlanNodeId, BTreeSet<usize>>,
+    composition_groups: &HashMap<PlanNodeId, Vec<usize>>,
+) -> BTreeSet<usize> {
+    let mut pending = vec![start];
+    let mut visited = HashSet::new();
+    let mut groups = BTreeSet::new();
+    while let Some(idx) = pending.pop() {
+        if !visited.insert(idx) {
+            continue;
+        }
+        let node_id = graph[idx].id();
+        if let Some(&group) = source_groups.get(&node_id) {
+            groups.insert(group);
+            continue;
+        }
+        if let Some(dependencies) = port_groups.get(&node_id) {
+            groups.extend(dependencies.iter().copied());
+            continue;
+        }
+        if let Some(dependencies) = composition_groups.get(&node_id) {
+            groups.extend(dependencies.iter().copied());
+            continue;
+        }
+        pending.extend(graph.neighbors_directed(idx, petgraph::Direction::Incoming));
+    }
+    groups
+}
+
+pub(crate) fn compile_source_activation_plan(
+    plan: &ExecutionPlanDag,
+    bodies: &CompositionBodies,
+) -> Result<SourceActivationPlan, SourceActivationPlanError> {
+    let mut builder = ActivationBuilder::default();
+    builder.compile_scope(plan, None, bodies, &BTreeMap::new())?;
+    if builder.visited_bodies.len() != bodies.len() {
+        let missing = bodies
+            .keys()
+            .find(|body_id| !builder.visited_bodies.contains(body_id))
+            .copied()
+            .unwrap_or(CompositionBodyId::SENTINEL);
+        return Err(SourceActivationPlanError {
+            span: Span::SYNTHETIC,
+            message: format!(
+                "bound composition body {} is absent from the recursive activation inventory",
+                missing.0
+            ),
+        });
+    }
+    builder.finish()
 }

--- a/crates/clinker-plan/src/plan/execution/dag.rs
+++ b/crates/clinker-plan/src/plan/execution/dag.rs
@@ -54,6 +54,7 @@ impl ExecutionPlanDag {
         let mut dag = Self {
             consumer_registry: CompiledConsumerRegistry::compile(&graph),
             order_contract: ExecutionOrderContract::default(),
+            source_activation: SourceActivationPlan::default(),
             graph,
             topo_order,
             source_dag,
@@ -86,6 +87,7 @@ impl ExecutionPlanDag {
         Self {
             consumer_registry: CompiledConsumerRegistry::compile(&body.graph),
             order_contract: ExecutionOrderContract::default(),
+            source_activation: SourceActivationPlan::default(),
             graph: body.graph.clone(),
             topo_order: body.topo_order.clone(),
             source_dag: Vec::new(),
@@ -191,6 +193,22 @@ impl ExecutionPlanDag {
     /// Whether any node requires arena allocation (window functions).
     pub fn required_arena(&self) -> bool {
         !self.indices_to_build.is_empty()
+    }
+
+    /// Return the recursively sealed external Source activation inventory.
+    pub fn source_activation(&self) -> &SourceActivationPlan {
+        &self.source_activation
+    }
+
+    /// Seal Source activation after the top-level DAG and every body mini-DAG
+    /// have reached their final compiled topology.
+    pub(crate) fn seal_source_activation(
+        &mut self,
+        bodies: &crate::plan::composition_body::CompositionBodies,
+    ) -> Result<(), SourceActivationPlanError> {
+        let compiled = compile_source_activation_plan(self, bodies)?;
+        self.source_activation = compiled;
+        Ok(())
     }
 
     /// Coarse plan-time estimate, in bytes, of the disk volume the run could
@@ -738,6 +756,7 @@ mod port_tag_guard_tests {
         ExecutionPlanDag {
             consumer_registry: CompiledConsumerRegistry::default(),
             order_contract: ExecutionOrderContract::default(),
+            source_activation: SourceActivationPlan::default(),
             graph: DiGraph::new(),
             topo_order: Vec::new(),
             source_dag: Vec::new(),

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -1735,7 +1735,7 @@ fn dot_escape(s: &str) -> String {
 /// across recompiles where `NodeIndex` values change.
 impl Serialize for ExecutionPlanDag {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(3))?;
+        let mut map = serializer.serialize_map(Some(4))?;
         map.serialize_entry("schema_version", "1")?;
 
         // Build node list in topo order
@@ -1782,6 +1782,7 @@ impl Serialize for ExecutionPlanDag {
             }
         }
         map.serialize_entry("node_properties", &PropsMap(self))?;
+        map.serialize_entry("source_activation", &self.source_activation.summary())?;
         map.end()
     }
 }

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -1380,6 +1380,11 @@ pub struct ExecutionPlanDag {
     /// Runtime source verification and downstream strategy checks borrow this
     /// value rather than reconstructing typed proof from raw configuration.
     pub(crate) order_contract: ExecutionOrderContract,
+    /// Sealed recursive inventory of external Source activation groups.
+    ///
+    /// Hand-built test DAGs start unsealed; the production compile path seals
+    /// this only after every structural rewrite and bound body is final.
+    pub(crate) source_activation: SourceActivationPlan,
     /// Topologically sorted node indices.
     pub topo_order: Vec<NodeIndex>,
     /// Topologically sorted source tiers for Phase 1 ordering.

--- a/crates/clinker-plan/src/plan/execution/scheduling.rs
+++ b/crates/clinker-plan/src/plan/execution/scheduling.rs
@@ -18,6 +18,222 @@ use crate::plan::properties::{
     PartitioningProvenance,
 };
 
+/// Existing compiled topology that proves one or more external Sources share
+/// a live consumer boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SourceActivationFusionKind {
+    /// Exclusive Sources are selected live by one unseeded interleave Merge.
+    LiveInterleave,
+    /// One exclusive Source hands its receiver directly to a Transform.
+    FusedStreaming,
+}
+
+/// Identity-only proof consumed while sealing source activation groups.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceActivationFusion {
+    /// Closed fusion class proven by the scheduling predicates.
+    pub kind: SourceActivationFusionKind,
+    /// External Source node identities in runtime consumption order.
+    pub sources: Box<[PlanNodeId]>,
+    /// Compiled consumer path that owns the live handoff.
+    pub consumer_path: Box<[PlanNodeId]>,
+}
+
+/// Topologically order one finalized graph with stable node-id tie breaks.
+///
+/// [`PlanNodeId`] values are minted in authored declaration order inside each
+/// scope. Using them for the ready set makes otherwise-independent nodes
+/// deterministic without relying on petgraph storage or neighbor iteration
+/// order. The error identifies the lowest-id node left in a cycle.
+pub(crate) fn stable_topological_order(
+    graph: &petgraph::graph::DiGraph<PlanNode, PlanEdge>,
+) -> Result<Vec<NodeIndex>, NodeIndex> {
+    let mut indegree: HashMap<NodeIndex, usize> = graph
+        .node_indices()
+        .map(|idx| {
+            (
+                idx,
+                graph
+                    .edges_directed(idx, petgraph::Direction::Incoming)
+                    .count(),
+            )
+        })
+        .collect();
+    let mut ready: BTreeSet<(PlanNodeId, usize)> = indegree
+        .iter()
+        .filter_map(|(&idx, &degree)| (degree == 0).then_some((graph[idx].id(), idx.index())))
+        .collect();
+    let mut ordered = Vec::with_capacity(graph.node_count());
+
+    while let Some(&(id, raw_idx)) = ready.first() {
+        ready.remove(&(id, raw_idx));
+        let idx = NodeIndex::new(raw_idx);
+        ordered.push(idx);
+        for edge in graph.edges_directed(idx, petgraph::Direction::Outgoing) {
+            let target = edge.target();
+            let Some(remaining) = indegree.get_mut(&target) else {
+                continue;
+            };
+            *remaining -= 1;
+            if *remaining == 0 {
+                ready.insert((graph[target].id(), target.index()));
+            }
+        }
+    }
+
+    if ordered.len() == graph.node_count() {
+        return Ok(ordered);
+    }
+    let cycle = indegree
+        .into_iter()
+        .filter(|(_, degree)| *degree > 0)
+        .min_by_key(|(idx, _)| graph[*idx].id())
+        .map(|(idx, _)| idx)
+        .unwrap_or_else(|| NodeIndex::new(0));
+    Err(cycle)
+}
+
+/// Prove the Source fusion groups already implemented by the compiled graph.
+///
+/// Only caller-identified external Sources participate; composition input-port
+/// Sources are deliberately excluded even though they share the same
+/// [`PlanNode::Source`] variant. Interleave fusion is atomic per Merge and
+/// requires exclusive receiver ownership. Transform fusion reuses the same
+/// window/init/fan-out exclusions as the runtime streaming classifier.
+pub(crate) fn derive_source_activation_fusions(
+    plan: &ExecutionPlanDag,
+    external_sources: &HashSet<PlanNodeId>,
+) -> Result<Vec<SourceActivationFusion>, NodeIndex> {
+    let stable_topo = stable_topological_order(&plan.graph)?;
+    let init_phase = compute_init_phase_node_set(plan);
+    let mut claimed_sources = HashSet::new();
+    let mut interleaves = Vec::new();
+
+    for &merge_idx in &stable_topo {
+        let PlanNode::Merge {
+            mode: crate::config::MergeMode::Interleave,
+            interleave_seed: None,
+            input_order,
+            ..
+        } = &plan.graph[merge_idx]
+        else {
+            continue;
+        };
+        let mut predecessors: Vec<_> = plan
+            .graph
+            .neighbors_directed(merge_idx, petgraph::Direction::Incoming)
+            .collect();
+        if predecessors.len() < 2
+            || predecessors.iter().any(|&idx| {
+                !matches!(plan.graph[idx], PlanNode::Source { .. })
+                    || !external_sources.contains(&plan.graph[idx].id())
+                    || plan
+                        .graph
+                        .edges_directed(idx, petgraph::Direction::Outgoing)
+                        .count()
+                        != 1
+            })
+        {
+            continue;
+        }
+        predecessors.sort_by_key(|idx| {
+            let name = plan.graph[*idx].name();
+            input_order
+                .iter()
+                .position(|input| input.split('.').next() == Some(name))
+                .unwrap_or(usize::MAX)
+        });
+        let source_ids: Vec<_> = predecessors
+            .iter()
+            .map(|&idx| plan.graph[idx].id())
+            .collect();
+        let unique: HashSet<_> = source_ids.iter().copied().collect();
+        if unique.len() != source_ids.len()
+            || source_ids
+                .iter()
+                .any(|source| claimed_sources.contains(source))
+        {
+            continue;
+        }
+        claimed_sources.extend(source_ids.iter().copied());
+        interleaves.push((source_ids, merge_idx));
+    }
+
+    let mut fused_transforms = Vec::new();
+    for &transform_idx in &stable_topo {
+        let PlanNode::Transform { window_index, .. } = &plan.graph[transform_idx] else {
+            continue;
+        };
+        if window_index.is_some() || init_phase.contains(&transform_idx) {
+            continue;
+        }
+        let mut incoming = plan
+            .graph
+            .neighbors_directed(transform_idx, petgraph::Direction::Incoming);
+        let Some(source_idx) = incoming.next() else {
+            continue;
+        };
+        if incoming.next().is_some()
+            || !matches!(plan.graph[source_idx], PlanNode::Source { .. })
+            || !external_sources.contains(&plan.graph[source_idx].id())
+            || claimed_sources.contains(&plan.graph[source_idx].id())
+            || plan
+                .graph
+                .edges_directed(source_idx, petgraph::Direction::Outgoing)
+                .count()
+                != 1
+        {
+            continue;
+        }
+        claimed_sources.insert(plan.graph[source_idx].id());
+        fused_transforms.push((plan.graph[source_idx].id(), transform_idx));
+    }
+
+    let fused_transform_indices: HashSet<_> = fused_transforms
+        .iter()
+        .map(|(_, transform_idx)| *transform_idx)
+        .collect();
+    let mut proofs = Vec::with_capacity(interleaves.len() + fused_transforms.len());
+    for (sources, merge_idx) in interleaves {
+        let mut consumer_path = vec![plan.graph[merge_idx].id()];
+        let mut outgoing = plan
+            .graph
+            .neighbors_directed(merge_idx, petgraph::Direction::Outgoing);
+        if let Some(consumer_idx) = outgoing.next()
+            && outgoing.next().is_none()
+            && certify_streaming_edge(plan, consumer_idx, &fused_transform_indices, &init_phase)
+                == Some(merge_idx)
+        {
+            consumer_path.push(plan.graph[consumer_idx].id());
+        }
+        proofs.push(SourceActivationFusion {
+            kind: SourceActivationFusionKind::LiveInterleave,
+            sources: sources.into_boxed_slice(),
+            consumer_path: consumer_path.into_boxed_slice(),
+        });
+    }
+    for (source, transform_idx) in fused_transforms {
+        let mut consumer_path = vec![plan.graph[transform_idx].id()];
+        let mut outgoing = plan
+            .graph
+            .neighbors_directed(transform_idx, petgraph::Direction::Outgoing);
+        if let Some(consumer_idx) = outgoing.next()
+            && outgoing.next().is_none()
+            && certify_streaming_edge(plan, consumer_idx, &fused_transform_indices, &init_phase)
+                == Some(transform_idx)
+        {
+            consumer_path.push(plan.graph[consumer_idx].id());
+        }
+        proofs.push(SourceActivationFusion {
+            kind: SourceActivationFusionKind::FusedStreaming,
+            sources: Box::new([source]),
+            consumer_path: consumer_path.into_boxed_slice(),
+        });
+    }
+    proofs.sort_by_key(|proof| proof.sources.iter().copied().min());
+    Ok(proofs)
+}
+
 /// Scope at which an ordering fact or requirement holds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/clinker-plan/src/plan/extraction.rs
+++ b/crates/clinker-plan/src/plan/extraction.rs
@@ -477,6 +477,7 @@ mod tests {
         let mut dag = ExecutionPlanDag {
             consumer_registry: Default::default(),
             order_contract: Default::default(),
+            source_activation: Default::default(),
             graph,
             topo_order: topo,
             source_dag: vec![SourceTier { sources }],

--- a/crates/clinker-plan/src/plan/tests/source_activation.rs
+++ b/crates/clinker-plan/src/plan/tests/source_activation.rs
@@ -6,7 +6,10 @@ use clinker_core_types::span::FileId;
 use crate::config::composition::CompositionFile;
 use crate::config::{CompileContext, PipelineConfig, PipelineNode, parse_config};
 use crate::plan::CompiledPlan;
-use crate::plan::execution::PlanNode;
+use crate::plan::execution::{
+    CompiledSourceInstance, CompiledSourceRoot, PlanNode, SourceActivationCapacity,
+    SourceActivationGroupKind,
+};
 
 const BODY: &str = r#"_compose:
   name: catalog_reader
@@ -88,9 +91,7 @@ fn compile(workspace: &Path) -> CompiledPlan {
         .unwrap_or_else(|diagnostics| panic!("pipeline compiles: {diagnostics:?}"))
 }
 
-fn body_source_instances(
-    plan: &CompiledPlan,
-) -> Vec<&crate::plan::execution::CompiledSourceInstance> {
+fn body_source_instances(plan: &CompiledPlan) -> Vec<&CompiledSourceInstance> {
     plan.dag()
         .graph
         .node_weights()
@@ -108,14 +109,13 @@ fn tracer() {
     let first_plan = compile(workspace.path());
     let first_instances = body_source_instances(&first_plan);
     assert_eq!(first_instances.len(), 2);
-    assert_ne!(first_instances[0].id, first_instances[1].id);
-    assert_ne!(
-        first_instances[0].id.body_scope,
-        first_instances[1].id.body_scope
-    );
-    assert_eq!(first_instances[0].source_name, "read");
+    assert_ne!(first_instances[0].id(), first_instances[1].id());
+    assert_ne!(first_instances[0].id().scope, first_instances[1].id().scope);
+    assert_eq!(first_instances[0].source_name(), "read");
 
-    let requirement = &first_instances[0].resource;
+    let requirement = first_instances[0]
+        .resource()
+        .expect("body Source has a catalog requirement");
     assert_eq!(requirement.slot, "orders");
     assert_eq!(requirement.binding.logical_id().as_str(), "shared_orders");
     assert_eq!(requirement.kind.label(), "file");
@@ -139,10 +139,21 @@ fn tracer() {
     let second_plan = compile(workspace.path());
     let second_ids: Vec<_> = body_source_instances(&second_plan)
         .iter()
-        .map(|instance| instance.id)
+        .map(|instance| instance.id())
         .collect();
-    let first_ids: Vec<_> = first_instances.iter().map(|instance| instance.id).collect();
+    let first_ids: Vec<_> = first_instances
+        .iter()
+        .map(|instance| instance.id())
+        .collect();
     assert_eq!(first_ids, second_ids);
+
+    let activation = first_plan.dag().source_activation();
+    assert!(activation.is_sealed());
+    assert_eq!(activation.instances().len(), 3);
+    assert_eq!(activation.groups().len(), 3);
+    assert_eq!(activation.credential_requirement_ids().len(), 0);
+    let second_activation = second_plan.dag().source_activation();
+    assert_eq!(activation, second_activation);
 }
 
 #[test]
@@ -284,4 +295,339 @@ nodes:
             && diagnostic.message.contains("resource")
             && diagnostic.primary.span.synthetic_line_number().is_some()
     }));
+}
+
+fn write_composition(workspace: &Path, name: &str, body: &str) {
+    std::fs::write(
+        workspace
+            .join("compositions")
+            .join(format!("{name}.comp.yaml")),
+        body,
+    )
+    .expect("composition body");
+}
+
+fn compile_pipeline(workspace: &Path, yaml: &str) -> CompiledPlan {
+    parse_config(yaml)
+        .expect("pipeline parses")
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace,
+            PathBuf::from("pipelines"),
+        ))
+        .unwrap_or_else(|diagnostics| panic!("pipeline compiles: {diagnostics:?}"))
+}
+
+fn one_call_pipeline(body: &str, call_fields: &str) -> String {
+    format!(
+        r#"pipeline: {{ name: activation_groups }}
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      path: driver.csv
+      schema: [{{ name: id, type: string }}]
+  - type: composition
+    name: call
+    input: driver
+    use: ../compositions/{body}.comp.yaml
+{call_fields}"#
+    )
+}
+
+fn instance_named<'a>(plan: &'a CompiledPlan, name: &str) -> &'a CompiledSourceInstance {
+    plan.dag()
+        .source_activation()
+        .instances()
+        .iter()
+        .find(|instance| instance.source_name() == name)
+        .unwrap_or_else(|| panic!("missing activation instance {name:?}"))
+}
+
+fn group_for_instance<'a>(
+    plan: &'a CompiledPlan,
+    instance: &CompiledSourceInstance,
+) -> &'a crate::plan::execution::SourceActivationGroup {
+    plan.dag()
+        .source_activation()
+        .groups()
+        .iter()
+        .find(|group| group.members().contains(&instance.id()))
+        .unwrap_or_else(|| panic!("missing group for {:?}", instance.id()))
+}
+
+#[test]
+fn input_ports_are_explicit_roots_but_not_activation_instances() {
+    let workspace = write_workspace(BODY);
+    write_composition(
+        workspace.path(),
+        "input_only",
+        r#"_compose:
+  name: input_only
+  inputs:
+    incoming: { schema: [{ name: id, type: string }] }
+  outputs: { out: shape }
+  config_schema: {}
+  resources_schema: {}
+nodes:
+  - type: transform
+    name: shape
+    input: incoming
+    config:
+      cxl: |
+        emit id = id
+"#,
+    );
+    let yaml = one_call_pipeline("input_only", "    inputs: { incoming: driver }\n");
+    let plan = compile_pipeline(workspace.path(), &yaml);
+    let activation = plan.dag().source_activation();
+
+    assert!(activation.is_sealed());
+    assert_eq!(activation.instances().len(), 1);
+    assert_eq!(activation.groups().len(), 1);
+    assert!(activation.roots().iter().any(|root| {
+        matches!(root, CompiledSourceRoot::InputPort { port_name, .. } if port_name.as_ref() == "incoming")
+    }));
+    assert_eq!(instance_named(&plan, "driver").resource(), None);
+}
+
+#[test]
+fn nested_body_sources_form_dependency_ordered_singleton_groups() {
+    let workspace = write_workspace(BODY);
+    write_composition(
+        workspace.path(),
+        "inner",
+        r#"_compose:
+  name: inner
+  inputs:
+    incoming: { schema: [{ name: id, type: string }] }
+  outputs: { out: inner_ref }
+  config_schema: {}
+  resources_schema:
+    inner_data: { kind: file, required: true }
+nodes:
+  - type: source
+    name: inner_ref
+    config:
+      name: inner_ref
+      type: csv
+      resource: inner_data
+      schema: [{ name: id, type: string }]
+"#,
+    );
+    write_composition(
+        workspace.path(),
+        "outer",
+        r#"_compose:
+  name: outer
+  inputs: {}
+  outputs: { out: inner_call }
+  config_schema: {}
+  resources_schema:
+    outer_data: { kind: file, required: true }
+    inner_data: { kind: file, required: true }
+nodes:
+  - type: source
+    name: outer_ref
+    config:
+      name: outer_ref
+      type: csv
+      resource: outer_data
+      schema: [{ name: id, type: string }]
+  - type: composition
+    name: inner_call
+    input: outer_ref
+    use: inner.comp.yaml
+    inputs: { incoming: outer_ref }
+    resources: { inner_data: shared_orders }
+"#,
+    );
+    let yaml = one_call_pipeline(
+        "outer",
+        "    inputs: {}\n    resources: { outer_data: shared_orders, inner_data: shared_orders }\n",
+    );
+    let first = compile_pipeline(workspace.path(), &yaml);
+    let outer = instance_named(&first, "outer_ref");
+    let inner = instance_named(&first, "inner_ref");
+    let outer_group = group_for_instance(&first, outer);
+    let inner_group = group_for_instance(&first, inner);
+
+    assert_eq!(outer_group.kind(), &SourceActivationGroupKind::Ordinary);
+    assert_eq!(inner_group.kind(), &SourceActivationGroupKind::Ordinary);
+    assert!(inner_group.dependencies().contains(&outer_group.id()));
+    assert!(outer_group.id() < inner_group.id());
+
+    let second = compile_pipeline(workspace.path(), &yaml);
+    assert_eq!(
+        first.dag().source_activation(),
+        second.dag().source_activation()
+    );
+}
+
+#[test]
+fn exclusive_live_interleave_sources_share_one_atomic_group() {
+    let workspace = write_workspace(BODY);
+    write_composition(
+        workspace.path(),
+        "interleave",
+        r#"_compose:
+  name: interleave
+  inputs: {}
+  outputs: { out: mixed }
+  config_schema: {}
+  resources_schema:
+    left_data: { kind: file, required: true }
+    right_data: { kind: file, required: true }
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: csv
+      resource: left_data
+      schema: [{ name: id, type: string }]
+  - type: source
+    name: right
+    config:
+      name: right
+      type: csv
+      resource: right_data
+      schema: [{ name: id, type: string }]
+  - type: merge
+    name: mixed
+    inputs: [left, right]
+    config:
+      mode: interleave
+"#,
+    );
+    let yaml = one_call_pipeline(
+        "interleave",
+        "    inputs: {}\n    resources: { left_data: shared_orders, right_data: shared_orders }\n",
+    );
+    let plan = compile_pipeline(workspace.path(), &yaml);
+    let left = instance_named(&plan, "left");
+    let right = instance_named(&plan, "right");
+    let group = group_for_instance(&plan, left);
+
+    assert!(group.members().contains(&right.id()));
+    assert!(matches!(
+        group.kind(),
+        SourceActivationGroupKind::LiveInterleave { consumer_path }
+            if consumer_path.len() == 1
+    ));
+    assert_eq!(group.capacity().resource_units(), 2);
+    assert_eq!(group.capacity().opener_units(), 2);
+    assert_eq!(group.capacity().credential_handle_units(), 0);
+    assert!(group.credential_requirement_ids().is_empty());
+    assert_eq!(
+        left.resource().unwrap().binding.logical_id(),
+        right.resource().unwrap().binding.logical_id()
+    );
+}
+
+#[test]
+fn exclusive_source_transform_path_is_compiled_as_fused() {
+    let workspace = write_workspace(BODY);
+    write_composition(
+        workspace.path(),
+        "fused",
+        r#"_compose:
+  name: fused
+  inputs: {}
+  outputs: { out: shaped }
+  config_schema: {}
+  resources_schema:
+    data: { kind: file, required: true }
+nodes:
+  - type: source
+    name: raw
+    config:
+      name: raw
+      type: csv
+      resource: data
+      schema: [{ name: id, type: string }]
+  - type: transform
+    name: shaped
+    input: raw
+    config:
+      cxl: |
+        emit id = id
+"#,
+    );
+    let yaml = one_call_pipeline(
+        "fused",
+        "    inputs: {}\n    resources: { data: shared_orders }\n",
+    );
+    let plan = compile_pipeline(workspace.path(), &yaml);
+    let raw = instance_named(&plan, "raw");
+    let group = group_for_instance(&plan, raw);
+
+    assert!(matches!(
+        group.kind(),
+        SourceActivationGroupKind::FusedStreaming { consumer_path }
+            if !consumer_path.is_empty()
+    ));
+}
+
+#[test]
+fn activation_capacity_overflow_is_rejected() {
+    let maximum = SourceActivationCapacity::new(u32::MAX, u32::MAX, u32::MAX);
+    let one = SourceActivationCapacity::new(1, 1, 1);
+    assert_eq!(maximum.checked_add(one), None);
+}
+
+#[test]
+fn topology_cycles_and_undeclared_dependencies_keep_authored_spans() {
+    let workspace = write_workspace(BODY);
+    let cycle = r#"pipeline: { name: cycle }
+nodes:
+  - type: source
+    name: source
+    config:
+      name: source
+      type: csv
+      path: source.csv
+      schema: [{ name: id, type: string }]
+  - type: transform
+    name: first
+    input: second
+    config: { cxl: "emit id = id" }
+  - type: transform
+    name: second
+    input: first
+    config: { cxl: "emit id = id" }
+"#;
+    let cycle_diags = parse_config(cycle)
+        .expect("cycle parses")
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace.path(),
+            PathBuf::from("pipelines"),
+        ))
+        .expect_err("cycle fails");
+    let cycle_diag = cycle_diags
+        .iter()
+        .find(|diagnostic| diagnostic.code == "E003")
+        .expect("cycle diagnostic");
+    assert!(cycle_diag.primary.span.synthetic_line_number().is_some());
+
+    let undeclared = cycle.replace("input: second", "input: missing");
+    let undeclared_diags = parse_config(&undeclared)
+        .expect("undeclared input parses")
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace.path(),
+            PathBuf::from("pipelines"),
+        ))
+        .expect_err("undeclared dependency fails");
+    let undeclared_diag = undeclared_diags
+        .iter()
+        .find(|diagnostic| diagnostic.code == "E004")
+        .expect("undeclared-input diagnostic");
+    assert!(
+        undeclared_diag
+            .primary
+            .span
+            .synthetic_line_number()
+            .is_some()
+    );
 }

--- a/crates/clinker-plan/src/plan/tests/source_activation.rs
+++ b/crates/clinker-plan/src/plan/tests/source_activation.rs
@@ -152,6 +152,14 @@ fn tracer() {
     assert_eq!(activation.instances().len(), 3);
     assert_eq!(activation.groups().len(), 3);
     assert_eq!(activation.credential_requirement_ids().len(), 0);
+    assert_eq!(
+        activation
+            .instances()
+            .iter()
+            .map(CompiledSourceInstance::source_name)
+            .collect::<Vec<_>>(),
+        vec!["driver", "read", "read"]
+    );
     let second_activation = second_plan.dag().source_activation();
     assert_eq!(activation, second_activation);
 }
@@ -387,9 +395,34 @@ nodes:
     assert_eq!(activation.instances().len(), 1);
     assert_eq!(activation.groups().len(), 1);
     assert!(activation.roots().iter().any(|root| {
-        matches!(root, CompiledSourceRoot::InputPort { port_name, .. } if port_name.as_ref() == "incoming")
+        matches!(
+            root,
+            CompiledSourceRoot::InputPort {
+                port_name,
+                dependency_groups,
+                ..
+            } if port_name.as_ref() == "incoming" && dependency_groups.len() == 1
+        )
     }));
     assert_eq!(instance_named(&plan, "driver").resource(), None);
+}
+
+#[test]
+fn explain_projects_only_fixed_cardinality_activation_counts() {
+    let workspace = write_workspace(BODY);
+    let plan = compile(workspace.path());
+    let explain = serde_json::to_value(plan.dag()).expect("plan serializes");
+    let activation = &explain["source_activation"];
+
+    assert_eq!(activation["sealed"], true);
+    assert_eq!(activation["instance_count"], 3);
+    assert_eq!(activation["group_count"], 3);
+    assert_eq!(activation["credential_requirement_count"], 0);
+    let rendered = activation.to_string();
+    assert!(!rendered.contains("shared_orders"));
+    assert!(!rendered.contains("orders.csv"));
+    assert!(!rendered.contains("driver"));
+    assert!(!rendered.contains("read"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- seal a recursive inventory of top-level and composition-body Source instances after final plan topology
- distinguish external Sources from synthetic composition input-port roots
- derive deterministic dependency groups and group only topology-proven live interleave or streaming handoffs
- retain checked resource, opener, and credential-handle capacity with complete logical credential requirement sets
- expose fixed-cardinality activation counts in explain output

## Validation

- focused Source activation tests: 14 passed
- full `clinker-plan` suite: 1,029 tests plus 2 doc tests
- semantic identity tests: 14 passed
- all-target `clinker-plan` Clippy with warnings denied
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

- Lineage is unchanged because this PR compiles plan-time activation topology without executing Sources or changing row values, routing, grouping, or ordering.
- Telemetry is unchanged because no runtime work begins here; explain output contains only fixed counts.
- Retained activation state is bounded by the already parsed finite plan and contains no input-growing runtime data.
- Runtime admission, opener execution, memory registration, and lifecycle signals remain separate follow-on product slices.
