### PR TITLE
Migrate executable documentation to Sink

### DIFF
--- a/crates/clinker/tests/output_containment.rs
+++ b/crates/clinker/tests/output_containment.rs
@@ -310,7 +310,7 @@ nodes:
     type: csv
     schema:
       - { name: id, type: int }
-- type: output
+- type: sink
   name: out
   input: src
   config:
@@ -359,7 +359,7 @@ nodes:
   config:
     cxl: |
       emit boom = id / 0
-- type: output
+- type: sink
   name: out
   input: fail
   config:

--- a/crates/clinker/tests/storage_config_cli.rs
+++ b/crates/clinker/tests/storage_config_cli.rs
@@ -31,7 +31,7 @@ nodes:
       path: in.csv
       schema:
         - { name: amount, type: int }
-  - type: output
+  - type: sink
     name: out
     input: src
     config:
@@ -237,7 +237,7 @@ nodes:
       cxl: |
         emit department = department
         emit total = sum(amount)
-  - type: output
+  - type: sink
     name: out
     input: dept_totals
     config:

--- a/docs/ai/10_ARCHITECTURE.md
+++ b/docs/ai/10_ARCHITECTURE.md
@@ -55,7 +55,7 @@ Verified facts:
 
 Verified end-to-end shape:
 
-1. A user-facing pipeline YAML looks like `examples/pipelines/customer_etl.yaml`: `pipeline:` metadata, a `nodes:` list with `type: source`, `type: transform`, `type: output`, and optional `error_handling:`.
+1. A user-facing pipeline YAML looks like `examples/pipelines/customer_etl.yaml`: `pipeline:` metadata, a `nodes:` list with `type: source`, `type: transform`, `type: sink`, and optional `error_handling:`.
 2. Config loading goes through `clinker-plan`. `load_config` / `load_config_with_vars` parse YAML into `PipelineConfig`, and `clinker_plan::yaml::from_str` is the parser chokepoint over `serde-saphyr` with a 32 MiB input cap and depth/node/alias budgets.
 3. `PipelineNode` deserialization is hand-written around the `type:` discriminator. It intentionally preserves per-node spans and per-variant `deny_unknown_fields` behavior.
 4. `PipelineConfig::compile_topology_only` checks duplicate names, self-loops, general cycles, undeclared input references, path validation, dotted-name restrictions, and log directive sanity.
@@ -118,7 +118,7 @@ envelope may refresh. See
 ### Current terminal node and locked target
 
 Current parser, planner, runtime, examples, and docs use `Output` and public
-YAML `type: output` for the terminal writer node. D-56 assigns one atomic,
+YAML `type: sink` for the terminal writer node. D-56 assigns one atomic,
 one-way migration of that **terminal destination concept** to Sink and
 `type: sink` under AUTH-09, before endpoint expansion. It is not
 available today. Output-port maps, produced artifacts and paths, serialization

--- a/docs/ai/20_CRATE_MAP.md
+++ b/docs/ai/20_CRATE_MAP.md
@@ -103,7 +103,7 @@ none of the D-19 seed symbols is assigned to it. In particular,
 ## Terminal Node Vocabulary
 
 The current planner and runtime use `PipelineNode::Output`, `OutputConfig`,
-Output-oriented dispatch, and public YAML `type: output`. D-56 assigns the
+Output-oriented dispatch, and public YAML `type: sink`. D-56 assigns the
 terminal-node-only migration to Sink to AUTH-09, wholly before Phase
 4.1 endpoint work. Phase 1 does not change Rust, YAML, examples, fixtures, or
 tests. Output ports, artifacts, paths, formats, stdout, machine output, writer

--- a/docs/ai/70_GLOSSARY.md
+++ b/docs/ai/70_GLOSSARY.md
@@ -82,7 +82,7 @@ Existing files under `docs/*` may be stale. Treat them as secondary context only
 
 ### Terminal vocabulary boundary
 
-`Output` and authored `type: output` are the current terminal-node names in
+`Output` and authored `type: sink` are the current terminal-node names in
 `PipelineNode`, `OutputConfig`, runtime dispatch, examples, and user docs.
 `Sink` and `type: sink` are the locked AUTH-09 target and are **not
 implemented**. AUTH-09 requires that one-way atomic migration before endpoint
@@ -102,7 +102,7 @@ machine output, writer output/results, and OpenLineage output datasets.
 | Route node | Per-record fan-out node that evaluates ordered CXL conditions and emits records to named output ports. | `docs/user/src/nodes/route.md`; `crates/clinker-plan/src/config/pipeline_node.rs`; `crates/clinker-exec/src/executor/route.rs` | RouteBody, RouteMode, ports | High |
 | Merge node | Fan-in node that concatenates or interleaves upstream streams sharing a compatible schema. | `docs/user/src/nodes/merge.md`; `crates/clinker-plan/src/config/format.rs`; `crates/clinker-exec/src/executor/merge_dispatch.rs` | MergeMode, inputs, streaming interleave | High |
 | Combine node | N-ary record-combining/join node using qualified inputs, a CXL `where:` predicate, match/on-miss policy, and output CXL. | `docs/user/src/nodes/combine.md`; `crates/clinker-plan/src/plan/combine.rs`; `crates/clinker-exec/src/pipeline/combine.rs` | driver, build side, IEJoin, grace hash | High |
-| Output node | Current terminal-destination node, authored as `type: output`, that writes records to a configured path and format with projection, splitting, correlation-key visibility, and envelope reconstruction options. | `docs/user/src/nodes/output.md`; `crates/clinker-plan/src/config/output.rs`; `crates/clinker-exec/src/executor/output_dispatch.rs` | OutputConfig, FormatWriter, split | High |
+| Output node | Current terminal-destination node, authored as `type: sink`, that writes records to a configured path and format with projection, splitting, correlation-key visibility, and envelope reconstruction options. | `docs/user/src/nodes/output.md`; `crates/clinker-plan/src/config/output.rs`; `crates/clinker-exec/src/executor/output_dispatch.rs` | OutputConfig, FormatWriter, split | High |
 | Sink | Locked target name for the terminal-destination node, authored as `type: sink` only after AUTH-09 lands. It is not current syntax or a current Rust variant. | `docs/ai/15_PRODUCTION_CONTRACTS.md` (D-56, AUTH-09) | Output node, AUTH-09, endpoint expansion | High for target; not implemented |
 | Reshape node | Blocking group operator that mutates trigger rows and/or synthesizes new rows within each `partition_by` group. | `docs/user/src/nodes/reshape.md`; `crates/clinker-plan/src/config/pipeline_node.rs`; `crates/clinker-exec/src/executor/reshape_dispatch.rs` | partition_by, `$meta.*`, synthesize | High |
 | Cull node | Blocking group operator that routes whole groups matching a group-level predicate to a side-output port instead of the main output. | `docs/user/src/nodes/cull.md`; `crates/clinker-plan/src/config/pipeline_node.rs`; `crates/clinker-exec/src/executor/cull_dispatch.rs` | removed_to, partition_by, route ports | High |

--- a/docs/engine/src/architecture.md
+++ b/docs/engine/src/architecture.md
@@ -77,7 +77,7 @@ and [Streaming vs. Blocking Stages](execution-model.md#plan-admission-and-runtim
 
 ## Terminal destination vocabulary
 
-`PipelineNode::Output` and YAML `type: output` are the current terminal-writer
+`PipelineNode::Output` and YAML `type: sink` are the current terminal-writer
 surface. D-56 assigns an atomic migration of that terminal destination concept
 to `Sink` / `type: sink` under AUTH-09, before endpoint expansion. The
 migration has not landed. Output ports, produced artifacts and

--- a/docs/engine/src/correlation-lifecycle.md
+++ b/docs/engine/src/correlation-lifecycle.md
@@ -11,7 +11,7 @@ The engine adds a shadow column named `$ck.<field>` (one per correlation-key fie
 Shadow columns are an internal engine namespace. You never write `$ck.<field>` in YAML or CXL — the engine manages them. They are stripped from default writer output. To surface them for debugging, set `include_correlation_keys: true` on an output node:
 
 ```yaml
-- type: output
+- type: sink
   name: debug_out
   input: validate
   config:

--- a/docs/engine/src/output-internals.md
+++ b/docs/engine/src/output-internals.md
@@ -250,7 +250,7 @@ The streaming path is selected **automatically** — there is no opt-in setting.
   inputs: [src_a, src_b]
   config:
     mode: interleave        # required
-- type: output
+- type: sink
   name: out
   input: merged
   config:

--- a/docs/explain/E110.md
+++ b/docs/explain/E110.md
@@ -34,7 +34,7 @@ nodes:
     input: orders
     config:
       cxl: "emit id = id"
-  - type: output
+  - type: sink
     name: write_order
     input: clean_order
     config:

--- a/docs/explain/E342.md
+++ b/docs/explain/E342.md
@@ -26,7 +26,7 @@ be divided across files; remove the `split` block or choose a splittable format
 ```yaml
 # Rejected: a SWIFT MT envelope cannot be split across files.
 nodes:
-  - type: output
+  - type: sink
     name: swift_out
     input: messages
     config:
@@ -40,7 +40,7 @@ nodes:
 ```yaml
 # Corrected (option A): drop the split block; write one message envelope.
 nodes:
-  - type: output
+  - type: sink
     name: swift_out
     input: messages
     config:

--- a/docs/explain/E346.md
+++ b/docs/explain/E346.md
@@ -61,7 +61,7 @@ nodes:
           Head:                       # declared section name is "Head"
             extract: { xml_path: /Batch/Header }
             fields: { batch_id: string }
-  - type: output
+  - type: sink
     name: out
     input: payments
     config:

--- a/docs/explain/E347.md
+++ b/docs/explain/E347.md
@@ -61,7 +61,7 @@ nodes:
       name: claims
       type: x12
       glob: ./claims/*.edi
-  - type: output
+  - type: sink
     name: out
     input: claims
     config:
@@ -84,7 +84,7 @@ nodes:
       name: claims
       type: x12
       glob: ./claims/*.edi
-  - type: output
+  - type: sink
     name: out
     input: claims
     config:

--- a/docs/explain/E350.md
+++ b/docs/explain/E350.md
@@ -66,7 +66,7 @@ nodes:
     name: framed
     body: both
     config: { strategy: concat }      # two distinct headers → E350
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:


### PR DESCRIPTION
## Summary

- migrate executable terminal examples in AI, engine, diagnostic, and CLI documentation to `type: sink`
- preserve output-port, output-dataset, path, and existing page terminology where those concepts are not the authored node discriminator
- keep the already-current E010 example unchanged

## Validation

- affected CLI and explain-document tests: 29 passed
- AI documentation checks
- user and engine documentation builds
- rendered-link checks for both books
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

- Documentation and embedded fixture spelling change only; runtime lineage, telemetry, row behavior, and retained memory are unchanged.
