### PR TITLE
Migrate remaining documentation examples to Sink

### DIFF
--- a/docs/explain/E351.md
+++ b/docs/explain/E351.md
@@ -56,7 +56,7 @@ nodes:
     body: payments
     header: rewrite_header
     config: { strategy: preserve }
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:

--- a/docs/explain/E352.md
+++ b/docs/explain/E352.md
@@ -53,7 +53,7 @@ nodes:
     body: payments
     header: rewrite_header
     config: { strategy: preserve }
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:

--- a/docs/explain/E355.md
+++ b/docs/explain/E355.md
@@ -53,7 +53,7 @@ nodes:
   - type: merge
     name: both
     inputs: [book_a, book_b]      # two documents in the body
-  - type: output
+  - type: sink
     name: out
     input: both
     config:
@@ -80,7 +80,7 @@ nodes:
     name: one_doc
     body: both
     config: { strategy: concat }  # collapse the body into one document
-  - type: output
+  - type: sink
     name: out
     input: one_doc
     config: { name: out, type: swift, path: out.mt }

--- a/docs/explain/E362.md
+++ b/docs/explain/E362.md
@@ -54,7 +54,7 @@ never consumes it — the declaration would be a silent no-op
 ```yaml
 # Rejected: join_values on a JSON output, whose writer emits a native array and
 # never reads the block.
-  - type: output
+  - type: sink
     name: report
     input: orders
     config:
@@ -75,7 +75,7 @@ never consumes it — the declaration would be a silent no-op
 ```yaml
 # Accepted: a well-formed CSV join. A multi-value field with no entry at all is
 # also fine — it joins with the default `;` and `on_conflict: error`.
-  - type: output
+  - type: sink
     name: report
     input: orders
     config:
@@ -90,7 +90,7 @@ never consumes it — the declaration would be a silent no-op
 ```yaml
 # Accepted: an XML join renaming the repeated element and adding a container. A
 # multi-value field with no entry emits bare repeats named after the field.
-  - type: output
+  - type: sink
     name: report
     input: orders
     config:

--- a/docs/explain/E367.md
+++ b/docs/explain/E367.md
@@ -14,7 +14,7 @@ an invalid width, or an unknown placeholder is rejected during planning.
 
 ```yaml
 nodes:
-  - type: output
+  - type: sink
     name: chunks
     input: rows
     config:

--- a/docs/user/src/README.md
+++ b/docs/user/src/README.md
@@ -117,7 +117,7 @@ nodes:
         emit full_name = first_name + " " + last_name
         emit tier = if lifetime_value >= 10000 then "gold" else "standard"
 
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:

--- a/docs/user/src/cookbook/aggregation.md
+++ b/docs/user/src/cookbook/aggregation.md
@@ -59,7 +59,7 @@ nodes:
         emit maximum = max(amount)
         emit minimum = min(amount)
 
-  - type: output
+  - type: sink
     name: report
     input: rollup
     config:
@@ -295,7 +295,7 @@ nodes:
         emit user_id = user_id
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: results
     input: hourly_clicks
     config:
@@ -363,7 +363,7 @@ nodes:
         emit total = sum(amount)
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: results
     input: sliding_amount
     config:
@@ -448,7 +448,7 @@ nodes:
         emit user_id = user_id
         emit logins = count(*)
 
-  - type: output
+  - type: sink
     name: results
     input: user_sessions
     config:

--- a/docs/user/src/cookbook/backfill-and-cull.md
+++ b/docs/user/src/cookbook/backfill-and-cull.md
@@ -74,12 +74,12 @@ nodes:
         - name: too_many_plans
           drop_group_when: "count(*) > 3"
 
-  - type: output
+  - type: sink
     name: out
     input: flag_large_histories         # main port — kept employees
     config: { name: out, type: csv, path: ./output/employee_plans_clean.csv }
 
-  - type: output
+  - type: sink
     name: review
     input: flag_large_histories.review  # side-output port — flagged employees
     config: { name: review, type: csv, path: ./output/employee_plans_review.csv }

--- a/docs/user/src/cookbook/combine.md
+++ b/docs/user/src/cookbook/combine.md
@@ -75,7 +75,7 @@ nodes:
         emit line_total = orders.quantity.to_float() * orders.unit_price
       propagate_ck: driver
 
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:


### PR DESCRIPTION
## Summary

- migrate remaining diagnostic and cookbook terminal examples to `type: sink`
- preserve semantic output names, paths, datasets, and diagnostic intent
- leave already-current explain pages unchanged

## Validation

- explain-document aggregate tests
- AI documentation checks
- user documentation build
- rendered-link checks
- `git diff --check`

## Runtime obligations

- Documentation example spelling changes only; runtime lineage, telemetry, row behavior, and retained memory are unchanged.
