### PR TITLE
Migrate user documentation to Sink

### DIFF
--- a/docs/user/src/cookbook/csv-transform.md
+++ b/docs/user/src/cookbook/csv-transform.md
@@ -54,7 +54,7 @@ nodes:
           _ => "under 70k"
         }
 
-  - type: output
+  - type: sink
     name: report
     input: classify
     config:

--- a/docs/user/src/cookbook/file-splitting.md
+++ b/docs/user/src/cookbook/file-splitting.md
@@ -24,7 +24,7 @@ nodes:
         - { name: amount, type: float }
         - { name: description, type: string }
 
-  - type: output
+  - type: sink
     name: split_output
     input: transactions
     config:
@@ -144,7 +144,7 @@ nodes:
       cxl: |
         filter date.starts_with("2026")
 
-  - type: output
+  - type: sink
     name: chunked
     input: current_year
     config:

--- a/docs/user/src/cookbook/intra-record-closures.md
+++ b/docs/user/src/cookbook/intra-record-closures.md
@@ -76,7 +76,7 @@ nodes:
           emit line_total = it["price"] * it["qty"]
         }
 
-  - type: output
+  - type: sink
     name: lines_out
     input: explode
     config:

--- a/docs/user/src/cookbook/routing.md
+++ b/docs/user/src/cookbook/routing.md
@@ -48,7 +48,7 @@ nodes:
         high: "amount >= $vars.high_value_threshold"
       default: standard
 
-  - type: output
+  - type: sink
     name: high_value_output
     input: split_by_value.high
     config:
@@ -56,7 +56,7 @@ nodes:
       type: csv
       path: "./output/high_value.csv"
 
-  - type: output
+  - type: sink
     name: standard_output
     input: split_by_value.standard
     config:
@@ -128,7 +128,7 @@ Route nodes can have any number of named branches:
         apac: "region == \"APAC\""
       default: other
 
-  - type: output
+  - type: sink
     name: us_output
     input: split_by_region.us
     config:
@@ -136,7 +136,7 @@ Route nodes can have any number of named branches:
       type: csv
       path: "./output/us_orders.csv"
 
-  - type: output
+  - type: sink
     name: eu_output
     input: split_by_region.eu
     config:
@@ -163,7 +163,7 @@ Insert a transform between the route and output to shape the data differently pe
         emit priority = "URGENT"
         emit review_required = true
 
-  - type: output
+  - type: sink
     name: high_value_output
     input: enrich_high_value
     config:

--- a/docs/user/src/cookbook/scd-type2.md
+++ b/docs/user/src/cookbook/scd-type2.md
@@ -76,7 +76,7 @@ nodes:
               plan_end: "plan_end"          # the rest of the window
               status: "'synthesized'"
 
-  - type: output
+  - type: sink
     name: out
     input: backfill
     config:

--- a/docs/user/src/cxl/aggregates.md
+++ b/docs/user/src/cxl/aggregates.md
@@ -175,7 +175,7 @@ pipeline:
         emit all_reps = collect(sales_rep)
 
     - name: output
-      type: output
+      type: sink
       input: monthly_summary
       format: json
       path: summary.json

--- a/docs/user/src/cxl/system-variables.md
+++ b/docs/user/src/cxl/system-variables.md
@@ -206,7 +206,7 @@ pipeline:
         emit pipeline_run = $pipeline.execution_id
 
     - name: output
-      type: output
+      type: sink
       input: enrich
       format: csv
       path: enriched_orders.csv

--- a/docs/user/src/formats/auto-widen.md
+++ b/docs/user/src/formats/auto-widen.md
@@ -40,7 +40,7 @@ Carried-along columns follow these rules through each node type:
 ## Output controls
 
 ```yaml
-- type: output
+- type: sink
   name: out
   input: src
   config:

--- a/docs/user/src/formats/csv.md
+++ b/docs/user/src/formats/csv.md
@@ -123,7 +123,7 @@ no configuration: values join with `;`, and a value that itself contains the
 delimiter is a hard error rather than a cell that would split back wrongly.
 
 ```yaml
-- type: output
+- type: sink
   name: report
   input: orders
   config:

--- a/docs/user/src/formats/edifact.md
+++ b/docs/user/src/formats/edifact.md
@@ -180,7 +180,7 @@ Engine-internal `$`-namespaced columns are excluded automatically.
 
 ```yaml
 nodes:
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:

--- a/docs/user/src/formats/hl7.md
+++ b/docs/user/src/formats/hl7.md
@@ -275,7 +275,7 @@ dropped upstream) is written with the conventional `|^~\&` set.
 
 ```yaml
 nodes:
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -181,7 +181,7 @@ single array (`format: array`, the default) or one object per line
 (`format: ndjson`).
 
 ```yaml
-- type: output
+- type: sink
   name: enriched
   input: processed
   config:

--- a/docs/user/src/formats/swift.md
+++ b/docs/user/src/formats/swift.md
@@ -174,7 +174,7 @@ as records — they ride the document context.
 
 ```yaml
 nodes:
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:

--- a/docs/user/src/formats/x12.md
+++ b/docs/user/src/formats/x12.md
@@ -255,7 +255,7 @@ automatically.
 
 ```yaml
 nodes:
-  - type: output
+  - type: sink
     name: out
     input: messages
     config:
@@ -317,7 +317,7 @@ nodes:
         emit set_type  = set_type
         emit e01       = e01
         # … remaining eNN columns …
-  - type: output
+  - type: sink
     name: out
     input: regroup
     config:


### PR DESCRIPTION
## Summary

- migrate cookbook, CXL, and format documentation examples to `type: sink`
- preserve output-port, output-file, output-dataset, and system-variable terminology
- leave the canonical terminal-node page for the dedicated page/navigation rename

## Validation

- SCD Type 2 end-to-end spill test
- AI documentation checks
- user documentation build
- rendered-link checks
- `git diff --check`

## Runtime obligations

- Documentation example spelling changes only; runtime lineage, telemetry, row behavior, and retained memory are unchanged.
