### PR TITLE
Migrate final user examples to Sink

### DIFF
--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -117,7 +117,7 @@ sibling `<a>` elements for that column set, which this reader then refused on
 the way back in.
 
 ```yaml
-- type: output
+- type: sink
   name: xml_out
   input: processed
   config:
@@ -184,7 +184,7 @@ reads, sharing the `field` key. The XML writer reads two keys from it and ignore
 the CSV-only `delimiter` / `on_conflict` / `escape`:
 
 ```yaml
-- type: output
+- type: sink
   name: xml_out
   input: processed
   config:

--- a/docs/user/src/getting-started/concepts.md
+++ b/docs/user/src/getting-started/concepts.md
@@ -214,7 +214,7 @@ port using dot notation:
       eu: region == "EU"
     default: other
 
-- type: output
+- type: sink
   name: us_output
   input: split_by_region.us    # reads from the "us" port
 ```

--- a/docs/user/src/getting-started/first-pipeline.md
+++ b/docs/user/src/getting-started/first-pipeline.md
@@ -48,7 +48,7 @@ nodes:
         emit salary = salary
         emit level = if salary >= 90000 then "senior" else "junior"
 
-  - type: output
+  - type: sink
     name: report
     input: classify
     config:

--- a/docs/user/src/nodes/aggregate.md
+++ b/docs/user/src/nodes/aggregate.md
@@ -322,7 +322,7 @@ nodes:
         emit user_id = user_id
         emit logins = count(*)
 
-  - type: output
+  - type: sink
     name: results
     input: user_sessions
     config:
@@ -376,7 +376,7 @@ cargo run -p clinker -- run examples/pipelines/multi_source_session.yaml
       emit max_amount = max(amount)
       emit categories = collect(category)
 
-- type: output
+- type: sink
   name: summary_output
   input: account_summary
   config:

--- a/docs/user/src/nodes/combine.md
+++ b/docs/user/src/nodes/combine.md
@@ -353,7 +353,7 @@ nodes:
         emit amount = orders.amount
       propagate_ck: driver
 
-  - type: output
+  - type: sink
     name: result
     input: enrich
     config:

--- a/docs/user/src/nodes/cull.md
+++ b/docs/user/src/nodes/cull.md
@@ -138,12 +138,12 @@ Downstream nodes draw from the two ports by reference:
 - The **side output** (removed groups) is referenced as `<cull>.<removed_to>`: `input: flag_large_histories.review`.
 
 ```yaml
-  - type: output
+  - type: sink
     name: kept
     input: flag_large_histories            # main port — kept groups
     config: { name: kept, type: csv, path: kept.csv }
 
-  - type: output
+  - type: sink
     name: review
     input: flag_large_histories.review     # side-output port — removed groups
     config: { name: review, type: csv, path: review.csv }

--- a/docs/user/src/nodes/envelope.md
+++ b/docs/user/src/nodes/envelope.md
@@ -95,7 +95,7 @@ nodes:
     name: framed
     body: both
     config: { strategy: concat }
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:
@@ -187,7 +187,7 @@ nodes:
     name: framed
     body: merged
     config: { strategy: preserve }
-  - type: output
+  - type: sink
     name: out
     input: framed
     config:

--- a/docs/user/src/nodes/merge.md
+++ b/docs/user/src/nodes/merge.md
@@ -38,7 +38,7 @@ The `inputs:` field is a list of upstream node references. These can be bare nod
 Downstream nodes wire to the merge as a normal single-input reference:
 
 ```yaml
-- type: output
+- type: sink
   name: final_output
   input: rejoin
   config:
@@ -161,7 +161,7 @@ The most common pattern is routing records through different processing paths an
     - process_standard
   config: {}
 
-- type: output
+- type: sink
   name: result
   input: all_orders
   config:

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -17,7 +17,7 @@ Output nodes write processed records to files. They are the terminal nodes of a 
 ## Basic structure
 
 ```yaml
-- type: output
+- type: sink
   name: result
   input: transform_node
   config:
@@ -404,7 +404,7 @@ file's own directory (not the invoking pipeline's).
 ### CSV
 
 ```yaml
-- type: output
+- type: sink
   name: csv_out
   input: processed
   config:
@@ -423,7 +423,7 @@ to its first byte.
 ### JSON
 
 ```yaml
-- type: output
+- type: sink
   name: json_out
   input: processed
   config:
@@ -445,7 +445,7 @@ an infinity fails the write with a JSON error instead of silently becoming
 ### XML
 
 ```yaml
-- type: output
+- type: sink
   name: xml_out
   input: processed
   config:
@@ -466,7 +466,7 @@ round-trip. See [XML Format](../formats/xml.md#writing-xml) for details.
 ### Fixed-width
 
 ```yaml
-- type: output
+- type: sink
   name: fw_out
   input: processed
   config:
@@ -486,7 +486,7 @@ for the layout semantics.
 ### EDIFACT
 
 ```yaml
-- type: output
+- type: sink
   name: edi_out
   input: messages
   config:
@@ -513,7 +513,7 @@ full option reference, the record schema, and the round-trip semantics.
 ### HL7 v2
 
 ```yaml
-- type: output
+- type: sink
   name: hl7_out
   input: messages
   config:
@@ -633,7 +633,7 @@ Output, mode, authored keys, and last reordering stage, and includes a corrected
 Split output into multiple files based on record count, byte size, or group boundaries:
 
 ```yaml
-- type: output
+- type: sink
   name: split_output
   input: processed
   config:
@@ -694,7 +694,7 @@ When a single Output sits directly after a `Merge` with `mode: interleave` whose
   inputs: [src_a, src_b]
   config:
     mode: interleave        # required
-- type: output
+- type: sink
   name: out
   input: merged
   config:
@@ -713,7 +713,7 @@ Output `sort_order` with a total business key when exact bytes are required.
 ## Complete example
 
 ```yaml
-- type: output
+- type: sink
   name: department_reports
   input: enriched_employees
   config:

--- a/docs/user/src/nodes/route.md
+++ b/docs/user/src/nodes/route.md
@@ -106,7 +106,7 @@ Downstream nodes reference route branches using **port syntax**: `route_name.bra
       emit txn_id = txn_id
       emit amount = amount
 
-- type: output
+- type: sink
   name: low_value_out
   input: classify.low
   config:
@@ -152,7 +152,7 @@ nodes:
         apac: "region == \"JP\" or region == \"AU\" or region == \"SG\""
       default: other
 
-  - type: output
+  - type: sink
     name: domestic_orders
     input: by_region.domestic
     config:
@@ -160,7 +160,7 @@ nodes:
       type: csv
       path: "./output/domestic.csv"
 
-  - type: output
+  - type: sink
     name: emea_orders
     input: by_region.emea
     config:
@@ -168,7 +168,7 @@ nodes:
       type: csv
       path: "./output/emea.csv"
 
-  - type: output
+  - type: sink
     name: apac_orders
     input: by_region.apac
     config:
@@ -176,7 +176,7 @@ nodes:
       type: csv
       path: "./output/apac.csv"
 
-  - type: output
+  - type: sink
     name: other_orders
     input: by_region.other
     config:

--- a/docs/user/src/pipelines/compositions.md
+++ b/docs/user/src/pipelines/compositions.md
@@ -247,7 +247,7 @@ nodes:
     config:
       threshold: 0.5
 
-  - type: output
+  - type: sink
     name: result
     input: risk
     config:

--- a/docs/user/src/pipelines/correlation-keys.md
+++ b/docs/user/src/pipelines/correlation-keys.md
@@ -167,7 +167,7 @@ A composition's body operates on records flowing in from the parent pipeline; co
 Correlation grouping is tracked on internal columns you never write in YAML or CXL, and they are hidden from writer output by default. To surface them for debugging, set `include_correlation_keys: true` on an output node:
 
 ```yaml
-- type: output
+- type: sink
   name: debug
   input: any_node
   config:

--- a/docs/user/src/pipelines/error-handling.md
+++ b/docs/user/src/pipelines/error-handling.md
@@ -301,7 +301,7 @@ nodes:
           severity: error
           message: "Order amount must be positive"
 
-  - type: output
+  - type: sink
     name: valid_orders
     input: validate_orders
     config:

--- a/docs/user/src/pipelines/structure.md
+++ b/docs/user/src/pipelines/structure.md
@@ -40,7 +40,7 @@ nodes:                         # Required — flat list of pipeline nodes
         emit id = id
         emit value = value.trim()
 
-  - type: output
+  - type: sink
     name: result
     input: clean
     config:
@@ -143,7 +143,7 @@ shape is specific to the node kind:
 **Port syntax** -- for consuming a specific branch from a route node, use `node.port`:
 
 ```yaml
-- type: output
+- type: sink
   name: high_value_out
   input: split.high     # Consumes the "high" branch of route node "split"
   config: ...

--- a/examples/pipelines/multi_source_session.yaml
+++ b/examples/pipelines/multi_source_session.yaml
@@ -64,7 +64,7 @@ nodes:
         emit user_id = user_id
         emit logins = count(*)
 
-  - type: output
+  - type: sink
     name: results
     input: user_sessions
     config:


### PR DESCRIPTION
## Summary

- migrate final format, getting-started, node, composition, correlation, error-handling, and structure examples to `type: sink`
- update the directly referenced multi-source pipeline example
- preserve output ports, files, datasets, correlation terminology, and the explicit migration note for the pending canonical page rename

## Validation

- direct multi-source pipeline explain execution
- explain-document tests: 2 passed
- AI documentation checks
- user documentation build
- rendered-link checks
- `git diff --check`

The broad example-explain aggregate still encounters ten standalone examples that retain the retired terminal discriminator. Those examples are intentionally kept out of this documentation PR and will be migrated in their executable corpus slices.

## Runtime obligations

- Documentation examples and one directly referenced pipeline change only; runtime lineage, telemetry, row behavior, and retained memory are unchanged.
