### PR TITLE
Admit credential-free Source capabilities

### DIFF
--- a/crates/clinker-exec/src/executor/capabilities.rs
+++ b/crates/clinker-exec/src/executor/capabilities.rs
@@ -302,7 +302,7 @@ impl AdmittedRunCapabilities {
     ///
     /// Inventory or capacity mismatches invoke no reservation and no opener.
     /// Reservation failure drops all earlier guards in reverse order. On
-    /// success this bundle becomes the sole owner of every guard and opener.
+    /// success this bundle owns every admitted guard and opener.
     pub fn admit(
         activation: &SourceActivationPlan,
         groups: Vec<AdmittedActivationGroup>,

--- a/crates/clinker-exec/src/executor/capabilities.rs
+++ b/crates/clinker-exec/src/executor/capabilities.rs
@@ -1,0 +1,580 @@
+//! Provider-neutral capabilities admitted before a compiled run may start.
+//!
+//! The executor owns this boundary so runtime code never imports a CLI
+//! provider, profile, credential, or secret type. Admission validates a
+//! complete sealed activation inventory before invoking any capacity
+//! reservation. The resulting bundle is move-only and releases reservations,
+//! unopened factories, and opened sessions in reverse order on every exit.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use clinker_plan::credentials::CredentialRequirementName;
+use clinker_plan::plan::execution::{
+    CompiledSourceInstanceId, SourceActivationCapacity, SourceActivationGroupId,
+    SourceActivationPlan,
+};
+
+/// An opaque provider-owned session opened for one compiled Source instance.
+///
+/// The executor never serializes or formats this value. Implementations use
+/// `Drop` to release local and provider-side state.
+pub trait CapabilitySession: Send {}
+
+/// A provider-neutral, single-use session factory.
+///
+/// Implementations retain any credential lease internally; they expose no
+/// secret accessor and return only a closed failure.
+pub trait CapabilityOpener: Send {
+    /// Consume this factory and open one opaque session.
+    fn open(self: Box<Self>) -> Result<Box<dyn CapabilitySession>, CapabilityOpenError>;
+}
+
+/// One all-or-none capacity reservation retained for an activation group.
+///
+/// The guard releases its reservation through `Drop`. It deliberately exposes
+/// no capacity mutation or provider-specific state.
+pub trait GroupCapacityLease: Send {}
+
+/// A deferred group-capacity reservation.
+///
+/// Admission first validates the complete compiled inventory, then invokes
+/// these reservations in dependency-stable group order. A later failure drops
+/// already-acquired guards in reverse order.
+pub trait GroupCapacityReservation: Send {
+    /// Reserve the exact capacity declared by the surrounding group request.
+    fn reserve(self: Box<Self>) -> Result<Box<dyn GroupCapacityLease>, CapabilityReservationError>;
+}
+
+/// Closed failure returned by an opaque opener.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CapabilityOpenError {
+    /// The provider could not open the admitted session.
+    Unavailable,
+}
+
+impl fmt::Display for CapabilityOpenError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("an admitted capability session could not be opened")
+    }
+}
+
+impl std::error::Error for CapabilityOpenError {}
+
+/// Closed failure returned by a group-capacity reservation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CapabilityReservationError {
+    /// The complete group capacity is unavailable.
+    Unavailable,
+}
+
+impl fmt::Display for CapabilityReservationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("activation-group capacity could not be reserved")
+    }
+}
+
+impl std::error::Error for CapabilityReservationError {}
+
+/// Stable closed classification for admitted-capability failures.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RunCapabilityErrorKind {
+    /// The recursive activation inventory was not sealed.
+    UnsealedActivation,
+    /// Credential-bearing activation is unsupported at this admission edge.
+    UnsupportedCredentialRequirements,
+    /// Group identities were missing, duplicated, or unexpected.
+    GroupInventoryMismatch,
+    /// A group did not carry its exact checked capacity.
+    CapacityMismatch,
+    /// A group did not carry the exact compiled Source identities.
+    SourceInventoryMismatch,
+    /// A group did not carry the exact logical credential requirement set.
+    CredentialInventoryMismatch,
+    /// A deferred all-or-none reservation failed.
+    ReservationFailed,
+    /// The bundle belongs to a different compiled activation inventory.
+    ActivationPlanMismatch,
+    /// The requested group was absent or already transferred.
+    GroupUnavailable,
+    /// The requested Source was absent or its opener was already consumed.
+    SourceUnavailable,
+    /// An admitted opener failed without exposing provider detail.
+    OpenFailed,
+}
+
+/// Sanitized admitted-capability failure.
+///
+/// The error retains no group ID, Source identity, logical credential name,
+/// provider text, or opaque payload.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RunCapabilityError {
+    kind: RunCapabilityErrorKind,
+}
+
+impl RunCapabilityError {
+    fn new(kind: RunCapabilityErrorKind) -> Self {
+        Self { kind }
+    }
+
+    /// Return the fixed-cardinality failure classification.
+    pub fn kind(self) -> RunCapabilityErrorKind {
+        self.kind
+    }
+}
+
+impl fmt::Display for RunCapabilityError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let message = match self.kind {
+            RunCapabilityErrorKind::UnsealedActivation => {
+                "runtime capabilities require a sealed activation inventory"
+            }
+            RunCapabilityErrorKind::UnsupportedCredentialRequirements => {
+                "credential-bearing activation requires an explicit supported profile preflight"
+            }
+            RunCapabilityErrorKind::GroupInventoryMismatch => {
+                "admitted activation groups do not match the compiled inventory"
+            }
+            RunCapabilityErrorKind::CapacityMismatch => {
+                "admitted group capacity does not match the compiled requirement"
+            }
+            RunCapabilityErrorKind::SourceInventoryMismatch => {
+                "admitted Source capabilities do not match the compiled group"
+            }
+            RunCapabilityErrorKind::CredentialInventoryMismatch => {
+                "admitted credential requirements do not match the compiled group"
+            }
+            RunCapabilityErrorKind::ReservationFailed => {
+                "complete activation-group capacity is unavailable"
+            }
+            RunCapabilityErrorKind::ActivationPlanMismatch => {
+                "admitted runtime capabilities do not belong to this compiled plan"
+            }
+            RunCapabilityErrorKind::GroupUnavailable => {
+                "the activation-group capability was already consumed or is unavailable"
+            }
+            RunCapabilityErrorKind::SourceUnavailable => {
+                "the Source capability was already consumed or is unavailable"
+            }
+            RunCapabilityErrorKind::OpenFailed => {
+                "an admitted Source capability could not be opened"
+            }
+        };
+        formatter.write_str(message)
+    }
+}
+
+impl std::error::Error for RunCapabilityError {}
+
+/// One compiled Source identity paired with its opaque, single-use opener.
+pub struct AdmittedSourceOpener {
+    instance: CompiledSourceInstanceId,
+    opener: Option<Box<dyn CapabilityOpener>>,
+}
+
+impl AdmittedSourceOpener {
+    /// Pair one compiled Source identity with its admitted opener.
+    pub fn new(instance: CompiledSourceInstanceId, opener: Box<dyn CapabilityOpener>) -> Self {
+        Self {
+            instance,
+            opener: Some(opener),
+        }
+    }
+}
+
+/// Unsealed input for one complete activation group.
+///
+/// Constructing this value performs no reservation or open operation. Only
+/// [`AdmittedRunCapabilities::admit`] can validate and seal it.
+pub struct AdmittedActivationGroup {
+    id: SourceActivationGroupId,
+    capacity: SourceActivationCapacity,
+    credential_requirement_ids: Box<[CredentialRequirementName]>,
+    sources: Vec<AdmittedSourceOpener>,
+    reservation: Option<Box<dyn GroupCapacityReservation>>,
+}
+
+impl AdmittedActivationGroup {
+    /// Describe one group without performing its capacity reservation.
+    pub fn new(
+        id: SourceActivationGroupId,
+        capacity: SourceActivationCapacity,
+        sources: Vec<AdmittedSourceOpener>,
+        reservation: Box<dyn GroupCapacityReservation>,
+    ) -> Self {
+        Self::with_credentials(id, capacity, Vec::new(), sources, reservation)
+    }
+
+    /// Describe a credential-bearing group without exposing provider state.
+    pub fn with_credentials(
+        id: SourceActivationGroupId,
+        capacity: SourceActivationCapacity,
+        credential_requirement_ids: Vec<CredentialRequirementName>,
+        sources: Vec<AdmittedSourceOpener>,
+        reservation: Box<dyn GroupCapacityReservation>,
+    ) -> Self {
+        Self {
+            id,
+            capacity,
+            credential_requirement_ids: credential_requirement_ids.into_boxed_slice(),
+            sources,
+            reservation: Some(reservation),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct GroupContract {
+    id: SourceActivationGroupId,
+    capacity: SourceActivationCapacity,
+    members: Box<[CompiledSourceInstanceId]>,
+    credential_requirement_ids: Box<[CredentialRequirementName]>,
+}
+
+impl GroupContract {
+    fn from_plan(plan: &SourceActivationPlan) -> Box<[Self]> {
+        plan.groups()
+            .iter()
+            .map(|group| Self {
+                id: group.id(),
+                capacity: group.capacity(),
+                members: group.members().into(),
+                credential_requirement_ids: group.credential_requirement_ids().into(),
+            })
+            .collect()
+    }
+}
+
+struct OwnedActivationGroup {
+    contract: GroupContract,
+    sources: Vec<AdmittedSourceOpener>,
+    capacity_lease: Option<Box<dyn GroupCapacityLease>>,
+}
+
+impl Drop for OwnedActivationGroup {
+    fn drop(&mut self) {
+        while let Some(source) = self.sources.pop() {
+            drop(source);
+        }
+        drop(self.capacity_lease.take());
+    }
+}
+
+impl OwnedActivationGroup {
+    fn into_active(mut self) -> ActiveActivationGroup {
+        ActiveActivationGroup {
+            contract: self.contract.clone(),
+            sources: std::mem::take(&mut self.sources),
+            sessions: Vec::new(),
+            capacity_lease: self.capacity_lease.take(),
+        }
+    }
+}
+
+struct GroupSlot {
+    contract: GroupContract,
+    owned: Option<OwnedActivationGroup>,
+}
+
+/// Sealed, move-only capabilities admitted for exactly one compiled plan.
+///
+/// This value is intentionally neither `Clone` nor serializable. Its `Debug`
+/// implementation renders counts only, never opaque factories, sessions,
+/// logical requirements, or compiled identities. It retains a fixed amount of
+/// configuration-derived state per compiled Source and activation group.
+pub struct AdmittedRunCapabilities {
+    contract: Box<[GroupContract]>,
+    groups: Vec<GroupSlot>,
+}
+
+impl fmt::Debug for AdmittedRunCapabilities {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AdmittedRunCapabilities")
+            .field("group_count", &self.group_count())
+            .field("remaining_group_count", &self.remaining_group_count())
+            .finish()
+    }
+}
+
+impl AdmittedRunCapabilities {
+    /// Validate a complete inventory, then reserve every group atomically.
+    ///
+    /// Inventory or capacity mismatches invoke no reservation and no opener.
+    /// Reservation failure drops all earlier guards in reverse order. On
+    /// success this bundle becomes the sole owner of every guard and opener.
+    pub fn admit(
+        activation: &SourceActivationPlan,
+        groups: Vec<AdmittedActivationGroup>,
+    ) -> Result<Self, RunCapabilityError> {
+        if !activation.is_sealed() {
+            return Err(RunCapabilityError::new(
+                RunCapabilityErrorKind::UnsealedActivation,
+            ));
+        }
+
+        let contract = GroupContract::from_plan(activation);
+        if groups.len() != contract.len() {
+            return Err(RunCapabilityError::new(
+                RunCapabilityErrorKind::GroupInventoryMismatch,
+            ));
+        }
+
+        let mut by_id = BTreeMap::new();
+        for group in groups {
+            let id = group.id;
+            if by_id.insert(id, group).is_some() {
+                return Err(RunCapabilityError::new(
+                    RunCapabilityErrorKind::GroupInventoryMismatch,
+                ));
+            }
+        }
+
+        for expected in &contract {
+            let Some(group) = by_id.get(&expected.id) else {
+                return Err(RunCapabilityError::new(
+                    RunCapabilityErrorKind::GroupInventoryMismatch,
+                ));
+            };
+            if group.capacity != expected.capacity {
+                return Err(RunCapabilityError::new(
+                    RunCapabilityErrorKind::CapacityMismatch,
+                ));
+            }
+            let members: Box<[_]> = group.sources.iter().map(|source| source.instance).collect();
+            if members != expected.members {
+                return Err(RunCapabilityError::new(
+                    RunCapabilityErrorKind::SourceInventoryMismatch,
+                ));
+            }
+            let unique_members: BTreeSet<_> = members.iter().copied().collect();
+            if unique_members.len() != members.len() {
+                return Err(RunCapabilityError::new(
+                    RunCapabilityErrorKind::SourceInventoryMismatch,
+                ));
+            }
+            if group.credential_requirement_ids.as_ref()
+                != expected.credential_requirement_ids.as_ref()
+            {
+                return Err(RunCapabilityError::new(
+                    RunCapabilityErrorKind::CredentialInventoryMismatch,
+                ));
+            }
+        }
+
+        let mut owned = Vec::with_capacity(contract.len());
+        for expected in &contract {
+            let mut group = by_id
+                .remove(&expected.id)
+                .expect("complete inventory was validated above");
+            let reservation = group
+                .reservation
+                .take()
+                .expect("unsealed group always retains its reservation");
+            let capacity_lease = match reservation.reserve() {
+                Ok(lease) => lease,
+                Err(_) => {
+                    while let Some(prior) = owned.pop() {
+                        drop(prior);
+                    }
+                    return Err(RunCapabilityError::new(
+                        RunCapabilityErrorKind::ReservationFailed,
+                    ));
+                }
+            };
+            owned.push(OwnedActivationGroup {
+                contract: expected.clone(),
+                sources: group.sources,
+                capacity_lease: Some(capacity_lease),
+            });
+        }
+
+        let groups = contract
+            .iter()
+            .cloned()
+            .zip(owned)
+            .map(|(contract, owned)| GroupSlot {
+                contract,
+                owned: Some(owned),
+            })
+            .collect();
+        Ok(Self { contract, groups })
+    }
+
+    /// Admit the current direct-source runtime when no credentials are needed.
+    ///
+    /// This is a real fail-closed admission path, not a credential selector.
+    /// Any logical credential requirement or credential-handle capacity rejects
+    /// the run before a reservation or opener can occur.
+    pub fn uncredentialed(activation: &SourceActivationPlan) -> Result<Self, RunCapabilityError> {
+        if !activation.is_sealed() {
+            return Err(RunCapabilityError::new(
+                RunCapabilityErrorKind::UnsealedActivation,
+            ));
+        }
+        if !activation.credential_requirement_ids().is_empty()
+            || activation.groups().iter().any(|group| {
+                !group.credential_requirement_ids().is_empty()
+                    || group.capacity().credential_handle_units() != 0
+            })
+        {
+            return Err(RunCapabilityError::new(
+                RunCapabilityErrorKind::UnsupportedCredentialRequirements,
+            ));
+        }
+
+        let groups = activation
+            .groups()
+            .iter()
+            .map(|group| {
+                AdmittedActivationGroup::new(
+                    group.id(),
+                    group.capacity(),
+                    group
+                        .members()
+                        .iter()
+                        .copied()
+                        .map(|member| {
+                            AdmittedSourceOpener::new(member, Box::new(UncredentialedOpener))
+                        })
+                        .collect(),
+                    Box::new(UncredentialedReservation),
+                )
+            })
+            .collect();
+        Self::admit(activation, groups)
+    }
+
+    /// Total number of sealed activation groups.
+    pub fn group_count(&self) -> usize {
+        self.groups.len()
+    }
+
+    /// Number of group leases not yet transferred to an active group.
+    pub fn remaining_group_count(&self) -> usize {
+        self.groups
+            .iter()
+            .filter(|slot| slot.owned.is_some())
+            .count()
+    }
+
+    /// Transfer one group lease and its Source factories exactly once.
+    pub fn take_group(
+        &mut self,
+        id: SourceActivationGroupId,
+    ) -> Result<ActiveActivationGroup, RunCapabilityError> {
+        let slot = self
+            .groups
+            .iter_mut()
+            .find(|slot| slot.contract.id == id)
+            .ok_or_else(|| RunCapabilityError::new(RunCapabilityErrorKind::GroupUnavailable))?;
+        let owned = slot
+            .owned
+            .take()
+            .ok_or_else(|| RunCapabilityError::new(RunCapabilityErrorKind::GroupUnavailable))?;
+        Ok(owned.into_active())
+    }
+
+    pub(crate) fn ensure_matches(
+        &self,
+        activation: &SourceActivationPlan,
+    ) -> Result<(), RunCapabilityError> {
+        if activation.is_sealed() && self.contract == GroupContract::from_plan(activation) {
+            Ok(())
+        } else {
+            Err(RunCapabilityError::new(
+                RunCapabilityErrorKind::ActivationPlanMismatch,
+            ))
+        }
+    }
+}
+
+impl Drop for AdmittedRunCapabilities {
+    fn drop(&mut self) {
+        while let Some(mut slot) = self.groups.pop() {
+            drop(slot.owned.take());
+        }
+    }
+}
+
+/// One transferred activation group and every session opened beneath it.
+///
+/// The value is move-only. Dropping it closes sessions and unopened factories
+/// in reverse order, then releases the group-capacity lease.
+pub struct ActiveActivationGroup {
+    contract: GroupContract,
+    sources: Vec<AdmittedSourceOpener>,
+    sessions: Vec<Box<dyn CapabilitySession>>,
+    capacity_lease: Option<Box<dyn GroupCapacityLease>>,
+}
+
+impl fmt::Debug for ActiveActivationGroup {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ActiveActivationGroup")
+            .field("source_count", &self.contract.members.len())
+            .field("opened_session_count", &self.sessions.len())
+            .finish()
+    }
+}
+
+impl ActiveActivationGroup {
+    /// Return the exact checked capacity retained by this group lease.
+    pub fn capacity(&self) -> SourceActivationCapacity {
+        self.contract.capacity
+    }
+
+    /// Consume one Source opener and retain its opaque session in this group.
+    pub fn open(&mut self, instance: CompiledSourceInstanceId) -> Result<(), RunCapabilityError> {
+        let source = self
+            .sources
+            .iter_mut()
+            .find(|source| source.instance == instance)
+            .ok_or_else(|| RunCapabilityError::new(RunCapabilityErrorKind::SourceUnavailable))?;
+        let opener = source
+            .opener
+            .take()
+            .ok_or_else(|| RunCapabilityError::new(RunCapabilityErrorKind::SourceUnavailable))?;
+        let session = opener
+            .open()
+            .map_err(|_| RunCapabilityError::new(RunCapabilityErrorKind::OpenFailed))?;
+        self.sessions.push(session);
+        Ok(())
+    }
+}
+
+impl Drop for ActiveActivationGroup {
+    fn drop(&mut self) {
+        while let Some(session) = self.sessions.pop() {
+            drop(session);
+        }
+        while let Some(source) = self.sources.pop() {
+            drop(source);
+        }
+        drop(self.capacity_lease.take());
+    }
+}
+
+struct UncredentialedReservation;
+
+impl GroupCapacityReservation for UncredentialedReservation {
+    fn reserve(self: Box<Self>) -> Result<Box<dyn GroupCapacityLease>, CapabilityReservationError> {
+        Ok(Box::new(UncredentialedCapacityLease))
+    }
+}
+
+struct UncredentialedCapacityLease;
+
+impl GroupCapacityLease for UncredentialedCapacityLease {}
+
+struct UncredentialedOpener;
+
+impl CapabilityOpener for UncredentialedOpener {
+    fn open(self: Box<Self>) -> Result<Box<dyn CapabilitySession>, CapabilityOpenError> {
+        Ok(Box::new(UncredentialedSession))
+    }
+}
+
+struct UncredentialedSession;
+
+impl CapabilitySession for UncredentialedSession {}

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1,3 +1,4 @@
+pub mod capabilities;
 pub mod stage_metrics;
 
 pub(crate) mod aggregate_dispatch;
@@ -272,6 +273,12 @@ impl RecordStorage for NullStorage {
 /// - TwoPass (arena + indices) when windows are present
 pub struct PipelineExecutor;
 
+fn run_capability_error(error: capabilities::RunCapabilityError) -> PipelineError {
+    PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+        "[E379] activation admission failed: {error}"
+    )))
+}
+
 impl PipelineExecutor {
     /// `&CompiledPlan`-consuming public entry point.
     ///
@@ -310,6 +317,28 @@ impl PipelineExecutor {
         writers: W,
         params: &PipelineRunParams,
     ) -> Result<ExecutionReport, PipelineError> {
+        let capabilities =
+            capabilities::AdmittedRunCapabilities::uncredentialed(plan.dag().source_activation())
+                .map_err(run_capability_error)?;
+        Self::run_admitted_plan_with_readers_writers(plan, capabilities, readers, writers, params)
+    }
+
+    /// Run a compiled plan using one executor-owned sealed capability bundle.
+    ///
+    /// The bundle is validated against this exact compiled activation inventory
+    /// before the executor recompiles the effective config, creates its memory
+    /// arbitrator, or constructs a Source or Sink. It remains owned by this
+    /// stack frame until success, failure, or interruption unwinds the run.
+    pub fn run_admitted_plan_with_readers_writers<W: Into<WriterRegistry>>(
+        plan: &clinker_plan::plan::CompiledPlan,
+        capabilities: capabilities::AdmittedRunCapabilities,
+        readers: SourceReaders,
+        writers: W,
+        params: &PipelineRunParams,
+    ) -> Result<ExecutionReport, PipelineError> {
+        capabilities
+            .ensure_matches(plan.dag().source_activation())
+            .map_err(run_capability_error)?;
         if plan.cxl_modules().is_empty() {
             return Self::run_with_readers_writers(plan.config(), readers, writers.into(), params);
         }
@@ -350,8 +379,37 @@ impl PipelineExecutor {
         readers: SourceReaders,
         writers: W,
         params: &PipelineRunParams,
+        compile_ctx: clinker_plan::config::CompileContext,
+    ) -> Result<ExecutionReport, PipelineError> {
+        let capabilities =
+            capabilities::AdmittedRunCapabilities::uncredentialed(plan.dag().source_activation())
+                .map_err(run_capability_error)?;
+        Self::run_admitted_plan_with_readers_writers_in_context(
+            plan,
+            capabilities,
+            readers,
+            writers,
+            params,
+            compile_ctx,
+        )
+    }
+
+    /// Run an admitted compiled plan against an explicit compile anchor.
+    ///
+    /// Capability ownership and cleanup match
+    /// [`Self::run_admitted_plan_with_readers_writers`]; this variant only
+    /// supplies the runtime compile context used for file-size estimates.
+    pub fn run_admitted_plan_with_readers_writers_in_context<W: Into<WriterRegistry>>(
+        plan: &clinker_plan::plan::CompiledPlan,
+        capabilities: capabilities::AdmittedRunCapabilities,
+        readers: SourceReaders,
+        writers: W,
+        params: &PipelineRunParams,
         mut compile_ctx: clinker_plan::config::CompileContext,
     ) -> Result<ExecutionReport, PipelineError> {
+        capabilities
+            .ensure_matches(plan.dag().source_activation())
+            .map_err(run_capability_error)?;
         compile_ctx.cxl_modules = plan.cxl_modules().clone();
         Self::run_with_readers_writers_in_context(
             plan.config(),

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -275,7 +275,7 @@ pub struct PipelineExecutor;
 
 fn run_capability_error(error: capabilities::RunCapabilityError) -> PipelineError {
     PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
-        "[E379] activation admission failed: {error}"
+        "activation admission failed: {error}"
     )))
 }
 
@@ -323,12 +323,15 @@ impl PipelineExecutor {
         Self::run_admitted_plan_with_readers_writers(plan, capabilities, readers, writers, params)
     }
 
-    /// Run a compiled plan using one executor-owned sealed capability bundle.
+    /// Run a compiled plan while retaining its sealed activation contract.
     ///
     /// The bundle is validated against this exact compiled activation inventory
-    /// before the executor recompiles the effective config, creates its memory
-    /// arbitrator, or constructs a Source or Sink. It remains owned by this
-    /// stack frame until success, failure, or interruption unwinds the run.
+    /// before the executor recompiles the effective config or begins ingest and
+    /// dispatch. This slice still receives caller-constructed `SourceReaders`
+    /// and writers; it retains the matching opener/group contract for the full
+    /// run but does not consume those openers or groups yet. The bundle remains
+    /// owned by this stack frame until success, failure, or interruption
+    /// unwinds the run.
     pub fn run_admitted_plan_with_readers_writers<W: Into<WriterRegistry>>(
         plan: &clinker_plan::plan::CompiledPlan,
         capabilities: capabilities::AdmittedRunCapabilities,
@@ -394,7 +397,7 @@ impl PipelineExecutor {
         )
     }
 
-    /// Run an admitted compiled plan against an explicit compile anchor.
+    /// Run a compiled plan with a retained activation contract and anchor.
     ///
     /// Capability ownership and cleanup match
     /// [`Self::run_admitted_plan_with_readers_writers`]; this variant only

--- a/crates/clinker-exec/tests/admitted_run_capabilities.rs
+++ b/crates/clinker-exec/tests/admitted_run_capabilities.rs
@@ -5,6 +5,7 @@ use clinker_exec::executor::capabilities::{
     CapabilityOpener, CapabilityReservationError, CapabilitySession, GroupCapacityLease,
     GroupCapacityReservation, RunCapabilityErrorKind,
 };
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams, WriterRegistry};
 use clinker_plan::config::{CompileContext, PipelineConfig, parse_config};
 use clinker_plan::plan::execution::{
     CompiledSourceInstanceId, SourceActivationCapacity, SourceActivationGroup,
@@ -80,9 +81,7 @@ struct FixtureReservation {
 }
 
 impl GroupCapacityReservation for FixtureReservation {
-    fn reserve(
-        self: Box<Self>,
-    ) -> Result<Box<dyn GroupCapacityLease>, CapabilityReservationError> {
+    fn reserve(self: Box<Self>) -> Result<Box<dyn GroupCapacityLease>, CapabilityReservationError> {
         self.events.push(format!("reserve:{}", self.label));
         if self.fail {
             Err(CapabilityReservationError::Unavailable)
@@ -165,12 +164,13 @@ fn group_request(
     group: &SourceActivationGroup,
     label: &'static str,
     events: &Events,
+    capacity: SourceActivationCapacity,
     fail_reservation: bool,
     fail_open: bool,
 ) -> AdmittedActivationGroup {
     AdmittedActivationGroup::new(
         group.id(),
-        group.capacity(),
+        capacity,
         group
             .members()
             .iter()
@@ -195,7 +195,14 @@ fn exact_contract_reserves_then_transfers_each_group_once() {
 
     let mut admitted = AdmittedRunCapabilities::admit(
         activation,
-        vec![group_request(group, "orders", &events, false, false)],
+        vec![group_request(
+            group,
+            "orders",
+            &events,
+            group.capacity(),
+            false,
+            false,
+        )],
     )
     .expect("exact contract admits");
     assert_eq!(admitted.group_count(), 1);
@@ -236,12 +243,18 @@ fn required_plus_one_capacity_is_rejected_before_reservation() {
     let activation = plan.dag().source_activation();
     let group = &activation.groups()[0];
     let events = Events::new();
-    let mut request = group_request(group, "orders", &events, false, false);
-    request.set_capacity_for_test(SourceActivationCapacity::new(
-        group.capacity().resource_units() + 1,
-        group.capacity().opener_units(),
-        group.capacity().credential_handle_units(),
-    ));
+    let request = group_request(
+        group,
+        "orders",
+        &events,
+        SourceActivationCapacity::new(
+            group.capacity().resource_units() + 1,
+            group.capacity().opener_units(),
+            group.capacity().credential_handle_units(),
+        ),
+        false,
+        false,
+    );
 
     let error = AdmittedRunCapabilities::admit(activation, vec![request]).unwrap_err();
     assert_eq!(error.kind(), RunCapabilityErrorKind::CapacityMismatch);
@@ -255,8 +268,22 @@ fn partial_reservation_failure_releases_prior_groups_in_reverse_order() {
     assert_eq!(activation.groups().len(), 2, "fixture needs two groups");
     let events = Events::new();
     let requests = vec![
-        group_request(&activation.groups()[0], "first", &events, false, false),
-        group_request(&activation.groups()[1], "second", &events, true, false),
+        group_request(
+            &activation.groups()[0],
+            "first",
+            &events,
+            activation.groups()[0].capacity(),
+            false,
+            false,
+        ),
+        group_request(
+            &activation.groups()[1],
+            "second",
+            &events,
+            activation.groups()[1].capacity(),
+            true,
+            false,
+        ),
     ];
 
     let error = AdmittedRunCapabilities::admit(activation, requests).unwrap_err();
@@ -276,8 +303,22 @@ fn dropping_unconsumed_bundle_releases_group_leases_in_reverse_order() {
     let admitted = AdmittedRunCapabilities::admit(
         activation,
         vec![
-            group_request(&activation.groups()[0], "first", &events, false, false),
-            group_request(&activation.groups()[1], "second", &events, false, false),
+            group_request(
+                &activation.groups()[0],
+                "first",
+                &events,
+                activation.groups()[0].capacity(),
+                false,
+                false,
+            ),
+            group_request(
+                &activation.groups()[1],
+                "second",
+                &events,
+                activation.groups()[1].capacity(),
+                false,
+                false,
+            ),
         ],
     )
     .expect("all reservations succeed");
@@ -303,7 +344,14 @@ fn opener_failure_and_downstream_error_release_active_group() {
     let events = Events::new();
     let mut admitted = AdmittedRunCapabilities::admit(
         activation,
-        vec![group_request(group, "orders", &events, false, true)],
+        vec![group_request(
+            group,
+            "orders",
+            &events,
+            group.capacity(),
+            false,
+            true,
+        )],
     )
     .expect("group reserves");
 
@@ -323,6 +371,71 @@ fn opener_failure_and_downstream_error_release_active_group() {
 }
 
 #[test]
+fn executor_error_releases_the_unconsumed_bundle() {
+    let plan = one_source_plan();
+    let activation = plan.dag().source_activation();
+    let group = &activation.groups()[0];
+    let events = Events::new();
+    let admitted = AdmittedRunCapabilities::admit(
+        activation,
+        vec![group_request(
+            group,
+            "orders",
+            &events,
+            group.capacity(),
+            false,
+            false,
+        )],
+    )
+    .expect("group admits");
+
+    let result = PipelineExecutor::run_admitted_plan_with_readers_writers(
+        &plan,
+        admitted,
+        std::collections::HashMap::new(),
+        WriterRegistry::default(),
+        &PipelineRunParams::default(),
+    );
+
+    assert!(result.is_err(), "missing Source reader must fail the run");
+    assert_eq!(events.snapshot(), ["reserve:orders", "lease_drop:orders"]);
+}
+
+#[test]
+fn interruption_drop_releases_opened_session_before_group_capacity() {
+    let plan = one_source_plan();
+    let activation = plan.dag().source_activation();
+    let group = &activation.groups()[0];
+    let member = group.members()[0];
+    let events = Events::new();
+    let mut admitted = AdmittedRunCapabilities::admit(
+        activation,
+        vec![group_request(
+            group,
+            "orders",
+            &events,
+            group.capacity(),
+            false,
+            false,
+        )],
+    )
+    .expect("group admits");
+    let mut active = admitted.take_group(group.id()).expect("group transfers");
+    active.open(member).expect("session opens");
+
+    drop(active);
+    assert_eq!(
+        events.snapshot(),
+        [
+            "reserve:orders",
+            "open:orders",
+            "session_drop:orders",
+            "lease_drop:orders",
+        ]
+    );
+}
+
+#[test]
 fn debug_and_errors_never_render_opaque_payloads() {
     let plan = one_source_plan();
     let activation = plan.dag().source_activation();
@@ -330,7 +443,14 @@ fn debug_and_errors_never_render_opaque_payloads() {
     let events = Events::new();
     let admitted = AdmittedRunCapabilities::admit(
         activation,
-        vec![group_request(group, "orders", &events, false, false)],
+        vec![group_request(
+            group,
+            "orders",
+            &events,
+            group.capacity(),
+            false,
+            false,
+        )],
     )
     .expect("group admits");
 
@@ -338,8 +458,14 @@ fn debug_and_errors_never_render_opaque_payloads() {
     assert!(debug.contains("AdmittedRunCapabilities"));
     assert!(!debug.contains("opener-secret-must-not-escape"));
 
-    let mut mismatched = group_request(group, "orders", &events, false, false);
-    mismatched.set_capacity_for_test(SourceActivationCapacity::default());
+    let mismatched = group_request(
+        group,
+        "orders",
+        &events,
+        SourceActivationCapacity::default(),
+        false,
+        false,
+    );
     let error = AdmittedRunCapabilities::admit(activation, vec![mismatched]).unwrap_err();
     let rendered = format!("{error:?} {error}");
     assert!(!rendered.contains("orders"));

--- a/crates/clinker-exec/tests/admitted_run_capabilities.rs
+++ b/crates/clinker-exec/tests/admitted_run_capabilities.rs
@@ -402,6 +402,42 @@ fn executor_error_releases_the_unconsumed_bundle() {
 }
 
 #[test]
+fn mismatched_plan_reports_an_uncoded_sanitized_admission_error() {
+    let admitted_plan = one_source_plan();
+    let activation = admitted_plan.dag().source_activation();
+    let group = &activation.groups()[0];
+    let events = Events::new();
+    let admitted = AdmittedRunCapabilities::admit(
+        activation,
+        vec![group_request(
+            group,
+            "orders",
+            &events,
+            group.capacity(),
+            false,
+            false,
+        )],
+    )
+    .expect("group admits");
+    let different_plan = two_source_plan();
+
+    let error = PipelineExecutor::run_admitted_plan_with_readers_writers(
+        &different_plan,
+        admitted,
+        std::collections::HashMap::new(),
+        WriterRegistry::default(),
+        &PipelineRunParams::default(),
+    )
+    .expect_err("capabilities cannot cross compiled activation inventories");
+    let rendered = error.to_string();
+
+    assert!(rendered.contains("activation admission failed"));
+    assert!(!rendered.starts_with('['));
+    assert!(!rendered.contains("orders"));
+    assert_eq!(events.snapshot(), ["reserve:orders", "lease_drop:orders"]);
+}
+
+#[test]
 fn interruption_drop_releases_opened_session_before_group_capacity() {
     let plan = one_source_plan();
     let activation = plan.dag().source_activation();

--- a/crates/clinker-exec/tests/admitted_run_capabilities.rs
+++ b/crates/clinker-exec/tests/admitted_run_capabilities.rs
@@ -1,0 +1,347 @@
+use std::sync::{Arc, Mutex};
+
+use clinker_exec::executor::capabilities::{
+    AdmittedActivationGroup, AdmittedRunCapabilities, AdmittedSourceOpener, CapabilityOpenError,
+    CapabilityOpener, CapabilityReservationError, CapabilitySession, GroupCapacityLease,
+    GroupCapacityReservation, RunCapabilityErrorKind,
+};
+use clinker_plan::config::{CompileContext, PipelineConfig, parse_config};
+use clinker_plan::plan::execution::{
+    CompiledSourceInstanceId, SourceActivationCapacity, SourceActivationGroup,
+};
+
+fn compile(yaml: &str) -> clinker_plan::plan::CompiledPlan {
+    let config: PipelineConfig = parse_config(yaml).expect("fixture parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("fixture compiles")
+}
+
+fn one_source_plan() -> clinker_plan::plan::CompiledPlan {
+    compile(
+        r#"
+pipeline: { name: admitted_capability }
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema: [{ name: id, type: string }]
+"#,
+    )
+}
+
+fn two_source_plan() -> clinker_plan::plan::CompiledPlan {
+    compile(
+        r#"
+pipeline: { name: admitted_capability_cleanup }
+nodes:
+  - type: source
+    name: first
+    config:
+      name: first
+      type: csv
+      path: first.csv
+      schema: [{ name: id, type: string }]
+  - type: source
+    name: second
+    config:
+      name: second
+      type: csv
+      path: second.csv
+      schema: [{ name: id, type: string }]
+"#,
+    )
+}
+
+#[derive(Clone)]
+struct Events(Arc<Mutex<Vec<String>>>);
+
+impl Events {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+
+    fn push(&self, event: impl Into<String>) {
+        self.0.lock().expect("event mutex").push(event.into());
+    }
+
+    fn snapshot(&self) -> Vec<String> {
+        self.0.lock().expect("event mutex").clone()
+    }
+}
+
+struct FixtureReservation {
+    label: &'static str,
+    events: Events,
+    fail: bool,
+}
+
+impl GroupCapacityReservation for FixtureReservation {
+    fn reserve(
+        self: Box<Self>,
+    ) -> Result<Box<dyn GroupCapacityLease>, CapabilityReservationError> {
+        self.events.push(format!("reserve:{}", self.label));
+        if self.fail {
+            Err(CapabilityReservationError::Unavailable)
+        } else {
+            Ok(Box::new(FixtureLease {
+                label: self.label,
+                events: self.events.clone(),
+            }))
+        }
+    }
+}
+
+struct FixtureLease {
+    label: &'static str,
+    events: Events,
+}
+
+impl GroupCapacityLease for FixtureLease {}
+
+impl Drop for FixtureLease {
+    fn drop(&mut self) {
+        self.events.push(format!("lease_drop:{}", self.label));
+    }
+}
+
+struct FixtureOpener {
+    label: &'static str,
+    events: Events,
+    fail: bool,
+    secret: Box<str>,
+}
+
+impl CapabilityOpener for FixtureOpener {
+    fn open(self: Box<Self>) -> Result<Box<dyn CapabilitySession>, CapabilityOpenError> {
+        self.events.push(format!("open:{}", self.label));
+        if self.fail {
+            Err(CapabilityOpenError::Unavailable)
+        } else {
+            Ok(Box::new(FixtureSession {
+                label: self.label,
+                events: self.events.clone(),
+                _secret: self.secret,
+            }))
+        }
+    }
+}
+
+struct FixtureSession {
+    label: &'static str,
+    events: Events,
+    _secret: Box<str>,
+}
+
+impl CapabilitySession for FixtureSession {}
+
+impl Drop for FixtureSession {
+    fn drop(&mut self) {
+        self.events.push(format!("session_drop:{}", self.label));
+    }
+}
+
+fn source_opener(
+    member: CompiledSourceInstanceId,
+    label: &'static str,
+    events: &Events,
+    fail: bool,
+) -> AdmittedSourceOpener {
+    AdmittedSourceOpener::new(
+        member,
+        Box::new(FixtureOpener {
+            label,
+            events: events.clone(),
+            fail,
+            secret: "opener-secret-must-not-escape".into(),
+        }),
+    )
+}
+
+fn group_request(
+    group: &SourceActivationGroup,
+    label: &'static str,
+    events: &Events,
+    fail_reservation: bool,
+    fail_open: bool,
+) -> AdmittedActivationGroup {
+    AdmittedActivationGroup::new(
+        group.id(),
+        group.capacity(),
+        group
+            .members()
+            .iter()
+            .copied()
+            .map(|member| source_opener(member, label, events, fail_open))
+            .collect(),
+        Box::new(FixtureReservation {
+            label,
+            events: events.clone(),
+            fail: fail_reservation,
+        }),
+    )
+}
+
+#[test]
+fn exact_contract_reserves_then_transfers_each_group_once() {
+    let plan = one_source_plan();
+    let activation = plan.dag().source_activation();
+    let group = &activation.groups()[0];
+    let member = group.members()[0];
+    let events = Events::new();
+
+    let mut admitted = AdmittedRunCapabilities::admit(
+        activation,
+        vec![group_request(group, "orders", &events, false, false)],
+    )
+    .expect("exact contract admits");
+    assert_eq!(admitted.group_count(), 1);
+    assert_eq!(admitted.remaining_group_count(), 1);
+
+    let mut active = admitted
+        .take_group(group.id())
+        .expect("group transfers once");
+    assert_eq!(active.capacity(), group.capacity());
+    assert_eq!(admitted.remaining_group_count(), 0);
+    assert_eq!(
+        admitted.take_group(group.id()).unwrap_err().kind(),
+        RunCapabilityErrorKind::GroupUnavailable
+    );
+
+    active.open(member).expect("source opener runs once");
+    assert_eq!(
+        active.open(member).unwrap_err().kind(),
+        RunCapabilityErrorKind::SourceUnavailable
+    );
+    drop(active);
+    drop(admitted);
+
+    assert_eq!(
+        events.snapshot(),
+        [
+            "reserve:orders",
+            "open:orders",
+            "session_drop:orders",
+            "lease_drop:orders",
+        ]
+    );
+}
+
+#[test]
+fn required_plus_one_capacity_is_rejected_before_reservation() {
+    let plan = one_source_plan();
+    let activation = plan.dag().source_activation();
+    let group = &activation.groups()[0];
+    let events = Events::new();
+    let mut request = group_request(group, "orders", &events, false, false);
+    request.set_capacity_for_test(SourceActivationCapacity::new(
+        group.capacity().resource_units() + 1,
+        group.capacity().opener_units(),
+        group.capacity().credential_handle_units(),
+    ));
+
+    let error = AdmittedRunCapabilities::admit(activation, vec![request]).unwrap_err();
+    assert_eq!(error.kind(), RunCapabilityErrorKind::CapacityMismatch);
+    assert!(events.snapshot().is_empty());
+}
+
+#[test]
+fn partial_reservation_failure_releases_prior_groups_in_reverse_order() {
+    let plan = two_source_plan();
+    let activation = plan.dag().source_activation();
+    assert_eq!(activation.groups().len(), 2, "fixture needs two groups");
+    let events = Events::new();
+    let requests = vec![
+        group_request(&activation.groups()[0], "first", &events, false, false),
+        group_request(&activation.groups()[1], "second", &events, true, false),
+    ];
+
+    let error = AdmittedRunCapabilities::admit(activation, requests).unwrap_err();
+    assert_eq!(error.kind(), RunCapabilityErrorKind::ReservationFailed);
+    assert_eq!(
+        events.snapshot(),
+        ["reserve:first", "reserve:second", "lease_drop:first"]
+    );
+}
+
+#[test]
+fn dropping_unconsumed_bundle_releases_group_leases_in_reverse_order() {
+    let plan = two_source_plan();
+    let activation = plan.dag().source_activation();
+    assert_eq!(activation.groups().len(), 2, "fixture needs two groups");
+    let events = Events::new();
+    let admitted = AdmittedRunCapabilities::admit(
+        activation,
+        vec![
+            group_request(&activation.groups()[0], "first", &events, false, false),
+            group_request(&activation.groups()[1], "second", &events, false, false),
+        ],
+    )
+    .expect("all reservations succeed");
+
+    drop(admitted);
+    assert_eq!(
+        events.snapshot(),
+        [
+            "reserve:first",
+            "reserve:second",
+            "lease_drop:second",
+            "lease_drop:first",
+        ]
+    );
+}
+
+#[test]
+fn opener_failure_and_downstream_error_release_active_group() {
+    let plan = one_source_plan();
+    let activation = plan.dag().source_activation();
+    let group = &activation.groups()[0];
+    let member = group.members()[0];
+    let events = Events::new();
+    let mut admitted = AdmittedRunCapabilities::admit(
+        activation,
+        vec![group_request(group, "orders", &events, false, true)],
+    )
+    .expect("group reserves");
+
+    let result: Result<(), RunCapabilityErrorKind> = (|| {
+        let mut active = admitted
+            .take_group(group.id())
+            .map_err(|error| error.kind())?;
+        active.open(member).map_err(|error| error.kind())?;
+        Err(RunCapabilityErrorKind::SourceUnavailable)
+    })();
+
+    assert_eq!(result, Err(RunCapabilityErrorKind::OpenFailed));
+    assert_eq!(
+        events.snapshot(),
+        ["reserve:orders", "open:orders", "lease_drop:orders"]
+    );
+}
+
+#[test]
+fn debug_and_errors_never_render_opaque_payloads() {
+    let plan = one_source_plan();
+    let activation = plan.dag().source_activation();
+    let group = &activation.groups()[0];
+    let events = Events::new();
+    let admitted = AdmittedRunCapabilities::admit(
+        activation,
+        vec![group_request(group, "orders", &events, false, false)],
+    )
+    .expect("group admits");
+
+    let debug = format!("{admitted:?}");
+    assert!(debug.contains("AdmittedRunCapabilities"));
+    assert!(!debug.contains("opener-secret-must-not-escape"));
+
+    let mut mismatched = group_request(group, "orders", &events, false, false);
+    mismatched.set_capacity_for_test(SourceActivationCapacity::default());
+    let error = AdmittedRunCapabilities::admit(activation, vec![mismatched]).unwrap_err();
+    let rendered = format!("{error:?} {error}");
+    assert!(!rendered.contains("orders"));
+    assert!(!rendered.contains("opener-secret-must-not-escape"));
+}

--- a/crates/clinker/src/credential_profile.rs
+++ b/crates/clinker/src/credential_profile.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use clinker_exec::executor::capabilities::{AdmittedRunCapabilities, RunCapabilityErrorKind};
 use clinker_exec::pipeline::memory::{
     ConsumerHandle, ConsumerId, ConsumerSpillError, MemoryArbitrator, MemoryConsumer,
 };
@@ -73,6 +74,51 @@ pub const DEFAULT_MAX_CREDENTIAL_DEFINITION_BYTES: usize = 1_048_576;
 pub const DEFAULT_MAX_LIVE_CREDENTIAL_HANDLES: usize = 256;
 
 const CREDENTIAL_LIFECYCLE_SCOPE: &str = "credential-lifecycle";
+
+/// Closed failure from the current CLI activation-admission boundary.
+///
+/// The binary has no credential-profile option or profile configuration table
+/// yet. It therefore admits only sealed activation inventories whose complete
+/// credential sets and credential-handle capacities are empty.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ActivationAdmissionError {
+    /// The compiled activation inventory requires the absent profile preflight.
+    UnsupportedCredentialPreflight,
+    /// The compiled activation inventory was not sealed or was inconsistent.
+    InvalidCompiledActivation,
+}
+
+impl fmt::Display for ActivationAdmissionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedCredentialPreflight => formatter.write_str(
+                "credential-bearing activation is unsupported because no credential profile preflight is configured",
+            ),
+            Self::InvalidCompiledActivation => formatter
+                .write_str("the compiled activation inventory could not be admitted for execution"),
+        }
+    }
+}
+
+impl std::error::Error for ActivationAdmissionError {}
+
+/// Admit one compiled run only when its complete credential contract is empty.
+///
+/// The returned executor-owned bundle preserves each group's exact checked
+/// resource/opener capacity and owns its no-op direct-source guards. It is
+/// created without discovery, I/O, worker startup, telemetry, lineage, opener,
+/// session, or credential-provider side effects.
+pub fn admit_uncredentialed_run_capabilities(
+    plan: &clinker_plan::plan::CompiledPlan,
+) -> Result<AdmittedRunCapabilities, ActivationAdmissionError> {
+    AdmittedRunCapabilities::uncredentialed(plan.dag().source_activation()).map_err(|error| {
+        if error.kind() == RunCapabilityErrorKind::UnsupportedCredentialRequirements {
+            ActivationAdmissionError::UnsupportedCredentialPreflight
+        } else {
+            ActivationAdmissionError::InvalidCompiledActivation
+        }
+    })
+}
 
 #[derive(Clone, Copy)]
 struct OperationSignals {

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -2799,17 +2799,19 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
         channel_record_vars.extend(overlay.record_vars);
     }
 
-    // Seal the only runtime capability source immediately after the effective
-    // plan exists and before lineage construction, machine lifecycle writes,
-    // worker startup, discovery, staging, or Source/Sink construction. This
-    // binary does not yet expose a credential-profile surface, so any nonempty
-    // logical credential set or credential-handle capacity fails closed here.
+    // Validate and retain the runtime activation contract immediately after the
+    // effective plan exists and before lineage construction, machine lifecycle
+    // writes, worker startup, discovery, staging, or the caller-owned reader /
+    // writer setup below. Runtime opener/group consumption lands separately;
+    // this binary does not yet expose a credential-profile surface, so any
+    // nonempty logical credential set or credential-handle capacity fails
+    // closed here.
     let admitted_run_capabilities = credential_profile::admit_uncredentialed_run_capabilities(
         &compiled_plan,
     )
     .map_err(|error| {
         PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
-            "[E379] activation admission failed: {error}"
+            "activation admission failed: {error}"
         )))
     })?;
 

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -2799,6 +2799,20 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
         channel_record_vars.extend(overlay.record_vars);
     }
 
+    // Seal the only runtime capability source immediately after the effective
+    // plan exists and before lineage construction, machine lifecycle writes,
+    // worker startup, discovery, staging, or Source/Sink construction. This
+    // binary does not yet expose a credential-profile surface, so any nonempty
+    // logical credential set or credential-handle capacity fails closed here.
+    let admitted_run_capabilities = credential_profile::admit_uncredentialed_run_capabilities(
+        &compiled_plan,
+    )
+    .map_err(|error| {
+        PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+            "[E379] activation admission failed: {error}"
+        )))
+    })?;
+
     // Resolve every emitted source/output identity before discovery, staging,
     // publication-attempt creation, or lineage-sink opening. A missing or
     // ambiguous external binding is an admission failure, not a mid-run event.
@@ -3526,8 +3540,9 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
     // post-overlay config — so the context it recompiles under must NOT carry
     // the overlay ops again (they would double-apply and collide). For a plain
     // run this is identical to `compile_ctx.clone()` (the op stream is empty).
-    let execution_result = PipelineExecutor::run_plan_with_readers_writers_in_context(
+    let execution_result = PipelineExecutor::run_admitted_plan_with_readers_writers_in_context(
         &compiled_plan,
+        admitted_run_capabilities,
         readers,
         registry,
         &run_params,

--- a/crates/clinker/tests/activation_admission.rs
+++ b/crates/clinker/tests/activation_admission.rs
@@ -1,0 +1,96 @@
+use std::process::Command;
+
+use clinker_plan::config::{CompileContext, PipelineConfig, parse_config};
+
+#[path = "../src/credential_profile.rs"]
+mod credential_profile;
+
+use credential_profile::admit_uncredentialed_run_capabilities;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+fn direct_file_plan() -> clinker_plan::plan::CompiledPlan {
+    let config: PipelineConfig = parse_config(
+        r#"
+pipeline: { name: zero_credential_admission }
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema: [{ name: id, type: string }]
+"#,
+    )
+    .expect("fixture parses");
+    config
+        .compile(&CompileContext::default())
+        .expect("fixture compiles")
+}
+
+#[test]
+fn zero_credential_plan_admits_exact_compiled_group_capacity() {
+    let plan = direct_file_plan();
+    let activation = plan.dag().source_activation();
+    let group = &activation.groups()[0];
+
+    let mut admitted =
+        admit_uncredentialed_run_capabilities(&plan).expect("credential-free plan admits");
+    let active = admitted
+        .take_group(group.id())
+        .expect("compiled group transfers once");
+
+    assert_eq!(active.capacity(), group.capacity());
+    assert_eq!(active.capacity().resource_units(), 1);
+    assert_eq!(active.capacity().opener_units(), 1);
+    assert_eq!(active.capacity().credential_handle_units(), 0);
+}
+
+#[test]
+fn credential_free_file_run_crosses_admitted_executor_boundary() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::write(workspace.path().join("orders.csv"), "id\n1\n2\n").expect("source fixture");
+    let pipeline = workspace.path().join("pipeline.yaml");
+    std::fs::write(
+        &pipeline,
+        r#"pipeline: { name: admitted_cli_run }
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema: [{ name: id, type: string }]
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#,
+    )
+    .expect("pipeline fixture");
+
+    let output = Command::new(clinker_bin())
+        .current_dir(workspace.path())
+        .arg("run")
+        .arg(&pipeline)
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        output.status.success(),
+        "credential-free run must be admitted; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        std::fs::read_to_string(workspace.path().join("out.csv")).expect("published output"),
+        "id\n1\n2\n"
+    );
+}

--- a/crates/clinker/tests/activation_admission.rs
+++ b/crates/clinker/tests/activation_admission.rs
@@ -2,6 +2,7 @@ use std::process::Command;
 
 use clinker_plan::config::{CompileContext, PipelineConfig, parse_config};
 
+#[allow(dead_code)]
 #[path = "../src/credential_profile.rs"]
 mod credential_profile;
 

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -1357,6 +1357,7 @@ fn unsupported_activation_preflight_error_is_fixed_and_sanitized() {
     let rendered = format!("{error:?} {error}");
 
     assert!(rendered.contains("credential profile preflight"));
+    assert!(!rendered.contains("[E"));
     assert!(!rendered.contains("orders.api"));
     assert!(!rendered.contains("saturated-profile"));
     assert!(!rendered.contains("lease-secret"));

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -9,7 +9,7 @@ use clinker_exec::telemetry::{
     AdmissionOutcome, MetricKey, SpanFact, SpanName, SpanStatus, TelemetryArena, TelemetryProducer,
     TelemetryReceiver,
 };
-use clinker_plan::config::ClinkerToml;
+use clinker_plan::config::{ClinkerToml, CompileContext, PipelineConfig, parse_config};
 use clinker_plan::credentials::{
     CredentialCapability, CredentialHandleUnits, CredentialLifetime, CredentialProviderKind,
     CredentialRenewal, CredentialRequirement, CredentialRequirementName, CredentialRevocation,
@@ -23,7 +23,8 @@ use credential_profile::{
     CredentialProfile, CredentialProfileAdmissionErrorKind, CredentialProfileCatalog,
     CredentialProfileLimits, CredentialProfileName, CredentialProvider, CredentialProviderFailure,
     CredentialRegistryErrorKind, CredentialResolutionErrorKind, LeasedCredentialHandle,
-    resolve_explicit_profile, resolve_explicit_profile_with_telemetry,
+    admit_uncredentialed_run_capabilities, resolve_explicit_profile,
+    resolve_explicit_profile_with_telemetry,
 };
 
 fn requirement(capabilities: Vec<CredentialCapability>) -> CredentialRequirement {
@@ -1359,4 +1360,30 @@ fn unsupported_activation_preflight_error_is_fixed_and_sanitized() {
     assert!(!rendered.contains("orders.api"));
     assert!(!rendered.contains("saturated-profile"));
     assert!(!rendered.contains("lease-secret"));
+}
+
+#[test]
+fn credential_free_compiled_plan_enters_the_executor_owned_bundle() {
+    let config: PipelineConfig = parse_config(
+        r#"pipeline: { name: credential_free_bundle }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: rows.csv
+      schema: [{ name: id, type: string }]
+"#,
+    )
+    .expect("fixture parses");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("fixture compiles");
+
+    let admitted =
+        admit_uncredentialed_run_capabilities(&plan).expect("empty credential inventory admits");
+
+    assert_eq!(admitted.group_count(), 1);
+    assert_eq!(admitted.remaining_group_count(), 1);
 }

--- a/crates/clinker/tests/credential_profiles.rs
+++ b/crates/clinker/tests/credential_profiles.rs
@@ -19,9 +19,9 @@ use clinker_plan::credentials::{
 mod credential_profile;
 
 use credential_profile::{
-    CredentialHandleRegistry, CredentialLease, CredentialLeaseFailure, CredentialProfile,
-    CredentialProfileAdmissionErrorKind, CredentialProfileCatalog, CredentialProfileLimits,
-    CredentialProfileName, CredentialProvider, CredentialProviderFailure,
+    ActivationAdmissionError, CredentialHandleRegistry, CredentialLease, CredentialLeaseFailure,
+    CredentialProfile, CredentialProfileAdmissionErrorKind, CredentialProfileCatalog,
+    CredentialProfileLimits, CredentialProfileName, CredentialProvider, CredentialProviderFailure,
     CredentialRegistryErrorKind, CredentialResolutionErrorKind, LeasedCredentialHandle,
     resolve_explicit_profile, resolve_explicit_profile_with_telemetry,
 };
@@ -1348,4 +1348,15 @@ fn admission_loss_preserves_resolution_and_reverse_cleanup() {
             SpanName::CredentialResolve | SpanName::CredentialRevoke
         )
     }));
+}
+
+#[test]
+fn unsupported_activation_preflight_error_is_fixed_and_sanitized() {
+    let error = ActivationAdmissionError::UnsupportedCredentialPreflight;
+    let rendered = format!("{error:?} {error}");
+
+    assert!(rendered.contains("credential profile preflight"));
+    assert!(!rendered.contains("orders.api"));
+    assert!(!rendered.contains("saturated-profile"));
+    assert!(!rendered.contains("lease-secret"));
 }


### PR DESCRIPTION
## Summary

- add a move-only executor-owned capability bundle matched to one sealed Source activation inventory
- validate complete group, Source, credential, and checked-capacity contracts before reservations begin
- provide one-time group and Source opener transfer with reverse-order rollback and cleanup
- admit current credential-free runs immediately after compilation and before lineage, workers, discovery, staging, or Source/Sink setup
- fail closed when a compiled group requires credentials, without adding an inert profile selector or configuration table

## Validation

- admitted runtime capability tests: 9 passed
- credential profile tests: 24 passed
- activation admission tests: 3 passed
- affected-crate Clippy with warnings denied
- `cargo fmt --all --check`
- user and engine documentation builds
- `git diff --check`

## Current boundary

The current resource catalog does not compile credential slots, so real command admission is intentionally limited to groups with empty credential requirements and zero credential-handle capacity. Nonempty profile resolution remains blocked on a resource-kind-owned credential-slot compiler and an explicit profile surface. This PR does not claim that behavior complete.

## Runtime obligations

- Lineage is unchanged because this handoff does not alter values, routing, ordering, or dataset identity.
- No provider, opener, or session operation begins here, and admission intentionally precedes telemetry-worker creation.
- The retained inventory is bounded by the finite compiled plan. Future provider-owned lease memory remains the registered credential registry’s responsibility.
