### PR TITLE
Migrate benchmark pipelines to sink syntax

### DIFF
--- a/benches/pipelines/combine/equi_2input.yaml
+++ b/benches/pipelines/combine/equi_2input.yaml
@@ -54,7 +54,7 @@ nodes:
         emit customer_tier = customers.f3 ?? "standard"
       propagate_ck: driver
 
-  - type: output
+  - type: sink
     name: enriched_out
     input: enrich
     config:

--- a/benches/pipelines/combine/equi_2input_collect.yaml
+++ b/benches/pipelines/combine/equi_2input_collect.yaml
@@ -52,7 +52,7 @@ nodes:
       cxl: ""
       propagate_ck: driver
 
-  - type: output
+  - type: sink
     name: drivers_with_trips_out
     input: gather_trips
     config:

--- a/benches/pipelines/combine/equi_2input_e2e.yaml
+++ b/benches/pipelines/combine/equi_2input_e2e.yaml
@@ -53,7 +53,7 @@ nodes:
         high_priority: "not product_name.is_null() and product_name != \"UNKNOWN\""
       default: standard
 
-  - type: output
+  - type: sink
     name: high_priority_out
     input: priority_split.high_priority
     config:
@@ -62,7 +62,7 @@ nodes:
       path: bench://output_high.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: standard_out
     input: priority_split.standard
     config:

--- a/benches/pipelines/combine/equi_multikey.yaml
+++ b/benches/pipelines/combine/equi_multikey.yaml
@@ -54,7 +54,7 @@ nodes:
         emit tracking_region = shipments.f3 ?? "unknown"
       propagate_ck: driver
 
-  - type: output
+  - type: sink
     name: matched_out
     input: match_shipment
     config:

--- a/benches/pipelines/combine/mixed_equi_range.yaml
+++ b/benches/pipelines/combine/mixed_equi_range.yaml
@@ -51,7 +51,7 @@ nodes:
         emit bracket = brackets.f1 ?? "UNASSIGNED"
       propagate_ck: driver
 
-  - type: output
+  - type: sink
     name: assigned_out
     input: assign_bracket
     config:

--- a/benches/pipelines/cxl_ops/coalesce.yaml
+++ b/benches/pipelines/cxl_ops/coalesce.yaml
@@ -24,7 +24,7 @@ nodes:
         emit c1 = f1 ?? "default"
         emit c2 = f2 ?? f0 ?? -1
 
-  - type: output
+  - type: sink
     name: sink
     input: coalesce
     config:

--- a/benches/pipelines/cxl_ops/complex_realistic.yaml
+++ b/benches/pipelines/cxl_ops/complex_realistic.yaml
@@ -54,7 +54,7 @@ nodes:
         emit c29 = f1.find("a")
         emit c30 = if f0 > 750000 then "top" else if f0 > 250000 then "mid" else "low"
 
-  - type: output
+  - type: sink
     name: sink
     input: complex
     config:

--- a/benches/pipelines/cxl_ops/conditionals.yaml
+++ b/benches/pipelines/cxl_ops/conditionals.yaml
@@ -29,7 +29,7 @@ nodes:
           _ => "low"
         }
 
-  - type: output
+  - type: sink
     name: sink
     input: conditionals
     config:

--- a/benches/pipelines/cxl_ops/date_methods.yaml
+++ b/benches/pipelines/cxl_ops/date_methods.yaml
@@ -24,7 +24,7 @@ nodes:
         emit d_add = f1.add_days(30)
         emit d_fmt = f1.format_date("%m/%d/%Y")
 
-  - type: output
+  - type: sink
     name: sink
     input: dates
     config:

--- a/benches/pipelines/cxl_ops/distinct_by_field.yaml
+++ b/benches/pipelines/cxl_ops/distinct_by_field.yaml
@@ -22,7 +22,7 @@ nodes:
         emit out = f0
         distinct by f0
 
-  - type: output
+  - type: sink
     name: sink
     input: dedup_by
     config:

--- a/benches/pipelines/cxl_ops/distinct_full.yaml
+++ b/benches/pipelines/cxl_ops/distinct_full.yaml
@@ -22,7 +22,7 @@ nodes:
         emit out = f0
         distinct
 
-  - type: output
+  - type: sink
     name: sink
     input: dedup
     config:

--- a/benches/pipelines/cxl_ops/filter_selectivity.yaml
+++ b/benches/pipelines/cxl_ops/filter_selectivity.yaml
@@ -63,7 +63,7 @@ nodes:
         filter f0 > 900000
         emit out = f0
 
-  - type: output
+  - type: sink
     name: high_pass
     input: filter_90pct
     config:
@@ -72,7 +72,7 @@ nodes:
       path: bench://output_90.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: mid_pass
     input: filter_50pct
     config:
@@ -81,7 +81,7 @@ nodes:
       path: bench://output_50.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: low_pass
     input: filter_10pct
     config:

--- a/benches/pipelines/cxl_ops/numeric_methods.yaml
+++ b/benches/pipelines/cxl_ops/numeric_methods.yaml
@@ -28,7 +28,7 @@ nodes:
         emit n_min = f0.min(500000)
         emit n_max = f0.max(100000)
 
-  - type: output
+  - type: sink
     name: sink
     input: numerics
     config:

--- a/benches/pipelines/cxl_ops/string_methods.yaml
+++ b/benches/pipelines/cxl_ops/string_methods.yaml
@@ -37,7 +37,7 @@ nodes:
         emit s_find = f1.find("e")
         emit s_split = f1.split(",").join(";")
 
-  - type: output
+  - type: sink
     name: sink
     input: strings
     config:

--- a/benches/pipelines/cxl_ops/type_conversions.yaml
+++ b/benches/pipelines/cxl_ops/type_conversions.yaml
@@ -26,7 +26,7 @@ nodes:
         emit t_try_int = f1.try_int()
         emit t_try_float = f1.try_float()
 
-  - type: output
+  - type: sink
     name: sink
     input: conversions
     config:

--- a/benches/pipelines/execution_mode/hash_aggregate_high_cardinality.yaml
+++ b/benches/pipelines/execution_mode/hash_aggregate_high_cardinality.yaml
@@ -25,7 +25,7 @@ nodes:
         emit total = sum(f2)
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: sink
     input: agg
     config:

--- a/benches/pipelines/execution_mode/hash_aggregate_low_cardinality.yaml
+++ b/benches/pipelines/execution_mode/hash_aggregate_low_cardinality.yaml
@@ -25,7 +25,7 @@ nodes:
         emit total = sum(f2)
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: sink
     input: agg
     config:

--- a/benches/pipelines/execution_mode/streaming_aggregate_presorted.yaml
+++ b/benches/pipelines/execution_mode/streaming_aggregate_presorted.yaml
@@ -25,7 +25,7 @@ nodes:
         emit total = sum(f2)
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: sink
     input: agg
     config:

--- a/benches/pipelines/execution_mode/streaming_multi_output.yaml
+++ b/benches/pipelines/execution_mode/streaming_multi_output.yaml
@@ -33,7 +33,7 @@ nodes:
         high: "f0 > 500000"
       default: low
 
-  - type: output
+  - type: sink
     name: high
     input: classify_route.high
     config:
@@ -42,7 +42,7 @@ nodes:
       path: bench://output_high.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: low
     input: classify_route.low
     config:

--- a/benches/pipelines/execution_mode/streaming_simple.yaml
+++ b/benches/pipelines/execution_mode/streaming_simple.yaml
@@ -22,7 +22,7 @@ nodes:
       cxl: |
         emit out = f0 + f2
 
-  - type: output
+  - type: sink
     name: sink
     input: compute
     config:

--- a/benches/pipelines/execution_mode/two_pass_parallel_scaling.yaml
+++ b/benches/pipelines/execution_mode/two_pass_parallel_scaling.yaml
@@ -26,7 +26,7 @@ nodes:
       analytic_window:
         group_by: [f0]
 
-  - type: output
+  - type: sink
     name: sink
     input: windowed
     config:

--- a/benches/pipelines/execution_mode/two_pass_window_all_fns.yaml
+++ b/benches/pipelines/execution_mode/two_pass_window_all_fns.yaml
@@ -28,7 +28,7 @@ nodes:
       analytic_window:
         group_by: [f0]
 
-  - type: output
+  - type: sink
     name: sink
     input: windowed
     config:

--- a/benches/pipelines/execution_mode/two_pass_window_sum.yaml
+++ b/benches/pipelines/execution_mode/two_pass_window_sum.yaml
@@ -24,7 +24,7 @@ nodes:
       analytic_window:
         group_by: [f0]
 
-  - type: output
+  - type: sink
     name: sink
     input: windowed
     config:

--- a/benches/pipelines/features/dlq_basic.yaml
+++ b/benches/pipelines/features/dlq_basic.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/features/multi_output_exclusive.yaml
+++ b/benches/pipelines/features/multi_output_exclusive.yaml
@@ -31,7 +31,7 @@ nodes:
         high: "f0 > 500000"
       default: low
 
-  - type: output
+  - type: sink
     name: high
     input: classify_route.high
     config:
@@ -40,7 +40,7 @@ nodes:
       path: bench://output_high.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: low
     input: classify_route.low
     config:

--- a/benches/pipelines/features/multi_output_inclusive.yaml
+++ b/benches/pipelines/features/multi_output_inclusive.yaml
@@ -32,7 +32,7 @@ nodes:
         long_string: "f1.length() > 5"
       default: remainder
 
-  - type: output
+  - type: sink
     name: high_value
     input: classify_route.high_value
     config:
@@ -41,7 +41,7 @@ nodes:
       path: bench://output_high_value.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: long_string
     input: classify_route.long_string
     config:
@@ -50,7 +50,7 @@ nodes:
       path: bench://output_long_string.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: remainder
     input: classify_route.remainder
     config:

--- a/benches/pipelines/features/projection_exclude.yaml
+++ b/benches/pipelines/features/projection_exclude.yaml
@@ -25,7 +25,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/features/projection_mapping.yaml
+++ b/benches/pipelines/features/projection_mapping.yaml
@@ -22,7 +22,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/features/splitting_by_bytes.yaml
+++ b/benches/pipelines/features/splitting_by_bytes.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/features/splitting_by_group_key.yaml
+++ b/benches/pipelines/features/splitting_by_group_key.yaml
@@ -23,7 +23,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/features/splitting_by_records.yaml
+++ b/benches/pipelines/features/splitting_by_records.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/features/validation_error.yaml
+++ b/benches/pipelines/features/validation_error.yaml
@@ -25,7 +25,7 @@ nodes:
           severity: error
           message: "f0 must be positive"
 
-  - type: output
+  - type: sink
     name: sink
     input: validated
     config:

--- a/benches/pipelines/features/validation_warn.yaml
+++ b/benches/pipelines/features/validation_warn.yaml
@@ -25,7 +25,7 @@ nodes:
           severity: warn
           message: "f0 should be positive"
 
-  - type: output
+  - type: sink
     name: sink
     input: validated
     config:

--- a/benches/pipelines/format/cross_format_csv_to_xml.yaml
+++ b/benches/pipelines/format/cross_format_csv_to_xml.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/format/csv_passthrough.yaml
+++ b/benches/pipelines/format/csv_passthrough.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/format/csv_to_json.yaml
+++ b/benches/pipelines/format/csv_to_json.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/format/fixed_width_passthrough.yaml
+++ b/benches/pipelines/format/fixed_width_passthrough.yaml
@@ -19,7 +19,7 @@ nodes:
       cxl: |
         emit f0 = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/format/json_array_passthrough.yaml
+++ b/benches/pipelines/format/json_array_passthrough.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/format/json_ndjson_passthrough.yaml
+++ b/benches/pipelines/format/json_ndjson_passthrough.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/format/xml_passthrough.yaml
+++ b/benches/pipelines/format/xml_passthrough.yaml
@@ -21,7 +21,7 @@ nodes:
       cxl: |
         emit out = f0
 
-  - type: output
+  - type: sink
     name: sink
     input: passthrough
     config:

--- a/benches/pipelines/realistic/cross_format_etl.yaml
+++ b/benches/pipelines/realistic/cross_format_etl.yaml
@@ -35,7 +35,7 @@ nodes:
         emit total = sum(value)
         emit count = count(*)
 
-  - type: output
+  - type: sink
     name: sink
     input: summarize
     config:

--- a/benches/pipelines/realistic/etl_classic.yaml
+++ b/benches/pipelines/realistic/etl_classic.yaml
@@ -39,7 +39,7 @@ nodes:
         emit record_count = count(*)
         emit max_derived = max(derived)
 
-  - type: output
+  - type: sink
     name: sink
     input: summarize
     config:

--- a/benches/pipelines/realistic/nested_json_etl.yaml
+++ b/benches/pipelines/realistic/nested_json_etl.yaml
@@ -38,7 +38,7 @@ nodes:
         emit total = sum(value)
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: sink
     input: summarize
     config:

--- a/benches/pipelines/realistic/nested_xml_etl.yaml
+++ b/benches/pipelines/realistic/nested_xml_etl.yaml
@@ -35,7 +35,7 @@ nodes:
         emit total = sum(value)
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: sink
     input: summarize
     config:

--- a/benches/pipelines/realistic/route_fanout.yaml
+++ b/benches/pipelines/realistic/route_fanout.yaml
@@ -54,7 +54,7 @@ nodes:
         emit total = sum(value)
         emit n = count(*)
 
-  - type: output
+  - type: sink
     name: high_out
     input: agg_high
     config:
@@ -63,7 +63,7 @@ nodes:
       path: bench://output_high.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: medium_out
     input: split.medium
     config:
@@ -72,7 +72,7 @@ nodes:
       path: bench://output_medium.csv
       include_unmapped: true
 
-  - type: output
+  - type: sink
     name: low_out
     input: agg_low
     config:

--- a/benches/pipelines/realistic/transform_chain.yaml
+++ b/benches/pipelines/realistic/transform_chain.yaml
@@ -49,7 +49,7 @@ nodes:
         emit final_ratio = ratio.round(2)
         filter amount > 0
 
-  - type: output
+  - type: sink
     name: sink
     input: finalize
     config:

--- a/benches/pipelines/realistic/windowed_analytics.yaml
+++ b/benches/pipelines/realistic/windowed_analytics.yaml
@@ -41,7 +41,7 @@ nodes:
         emit avg_w_sum = avg(w_sum)
         emit record_count = count(*)
 
-  - type: output
+  - type: sink
     name: sink
     input: summarize
     config:

--- a/benches/pipelines/scale/narrow_5fields.yaml
+++ b/benches/pipelines/scale/narrow_5fields.yaml
@@ -28,7 +28,7 @@ nodes:
         emit r3 = f3
         emit r4 = f4
 
-  - type: output
+  - type: sink
     name: sink
     input: compute
     config:

--- a/benches/pipelines/scale/wide_50fields.yaml
+++ b/benches/pipelines/scale/wide_50fields.yaml
@@ -74,7 +74,7 @@ nodes:
         emit r40 = f40
         emit r49 = f49
 
-  - type: output
+  - type: sink
     name: sink
     input: compute
     config:


### PR DESCRIPTION
## Summary

- migrate every committed benchmark pipeline from the retired terminal discriminator to `type: sink`
- preserve benchmark identities, inputs, expressions, routes, formats, paths, and output policies byte-for-byte outside the terminal spelling
- restore the benchmark corpus validator and real benchmark preflights on the Sink-only parser

This is one complete corpus boundary: the validator intentionally sweeps all benchmark YAML, so a partial category migration leaves the normal gate red.

## Verification

- `cargo test -p clinker-exec --test bench_config_validation --locked --offline` (16 passed)
- `cargo test --benches -p clinker-benchmarks --locked --offline` (unit and end-to-end preflights passed)
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

- Lineage, telemetry, and memory behavior are unchanged; this changes only authored terminal discriminators in committed benchmark fixtures.
