### PR TITLE
Migrate scenario pipelines to sink syntax

### DIFF
--- a/examples/scenarios/01-storefront-orders/pipeline.yaml
+++ b/examples/scenarios/01-storefront-orders/pipeline.yaml
@@ -60,7 +60,7 @@ nodes:
         emit ship_country = ship_country
         emit status = status
 
-  - type: output
+  - type: sink
     name: billable
     input: billable_lines
     config:

--- a/examples/scenarios/02-product-feed-normalize/pipeline.yaml
+++ b/examples/scenarios/02-product-feed-normalize/pipeline.yaml
@@ -76,7 +76,7 @@ nodes:
         emit in_stock = stock_on_hand > 0
         emit stock_on_hand = stock_on_hand
 
-  - type: output
+  - type: sink
     name: catalog_csv
     description: Flat row per product; the multi-value column joins into one cell
     input: normalize
@@ -91,7 +91,7 @@ nodes:
       join_values:
         - { field: categories, delimiter: "|" }
 
-  - type: output
+  - type: sink
     name: catalog_xml
     description: Normalised XML — repeated <category> elements survive the round trip
     input: normalize

--- a/examples/scenarios/03-support-triage/pipeline.yaml
+++ b/examples/scenarios/03-support-triage/pipeline.yaml
@@ -97,7 +97,7 @@ nodes:
         standard_queue: 'priority == "standard"'
       default: backlog_queue
 
-  - type: output
+  - type: sink
     name: urgent_queue
     input: triage.urgent_queue
     config:
@@ -106,7 +106,7 @@ nodes:
       path: ./output/urgent.csv
       include_unmapped: false
 
-  - type: output
+  - type: sink
     name: standard_queue
     input: triage.standard_queue
     config:
@@ -115,7 +115,7 @@ nodes:
       path: ./output/standard.csv
       include_unmapped: false
 
-  - type: output
+  - type: sink
     name: backlog_queue
     input: triage.backlog_queue
     config:

--- a/examples/scenarios/04-ordering-contract/pipeline.yaml
+++ b/examples/scenarios/04-ordering-contract/pipeline.yaml
@@ -28,7 +28,7 @@ nodes:
         - account_id
         - batch_seq
 
-  - type: output
+  - type: sink
     name: ordered
     input: events
     config:


### PR DESCRIPTION
## Summary

- migrate all four committed end-to-end scenario pipelines to `type: sink`
- preserve every source, transform, route, schema, output policy, and golden artifact unchanged
- keep the Sink migration covered by real input generation, execution, and byte-for-byte output comparison

## Verification

- `cargo test -p clinker --test scenarios --locked --offline` (7 passed, including every scenario against committed goldens)
- `cargo fmt --all --check`
- `git diff --check`

## Runtime obligations

- Lineage, telemetry, and memory behavior are unchanged; this changes only seven authored terminal discriminators in the existing scenarios.
