### PR TITLE
Execute catalog-backed composition Sources

### DIFF
--- a/crates/clinker-exec/src/executor/capabilities.rs
+++ b/crates/clinker-exec/src/executor/capabilities.rs
@@ -19,7 +19,16 @@ use clinker_plan::plan::execution::{
 ///
 /// The executor never serializes or formats this value. Implementations use
 /// `Drop` to release local and provider-side state.
-pub trait CapabilitySession: Send {}
+pub trait CapabilitySession: Send {
+    /// Transfer this session's finite Source input exactly once.
+    ///
+    /// The session remains owned by its active group until execution finishes,
+    /// so provider-side authority outlives the reader it supplied. Sessions
+    /// that do not represent a body Source return the closed failure.
+    fn take_source_input(&mut self) -> Result<crate::source::SourceInput, CapabilityOpenError> {
+        Err(CapabilityOpenError::Unavailable)
+    }
+}
 
 /// A provider-neutral, single-use session factory.
 ///
@@ -180,6 +189,12 @@ impl AdmittedSourceOpener {
             opener: Some(opener),
         }
     }
+
+    /// Build the inert capability paired with an existing caller-supplied
+    /// top-level Source reader.
+    pub fn caller_supplied(instance: CompiledSourceInstanceId) -> Self {
+        Self::new(instance, Box::new(UncredentialedOpener))
+    }
 }
 
 /// Unsealed input for one complete activation group.
@@ -203,6 +218,16 @@ impl AdmittedActivationGroup {
         reservation: Box<dyn GroupCapacityReservation>,
     ) -> Self {
         Self::with_credentials(id, capacity, Vec::new(), sources, reservation)
+    }
+
+    /// Describe a credential-free group using the executor's no-op capacity
+    /// reservation.
+    pub fn uncredentialed(
+        id: SourceActivationGroupId,
+        capacity: SourceActivationCapacity,
+        sources: Vec<AdmittedSourceOpener>,
+    ) -> Self {
+        Self::new(id, capacity, sources, Box::new(UncredentialedReservation))
     }
 
     /// Describe a credential-bearing group without exposing provider state.
@@ -249,6 +274,11 @@ struct OwnedActivationGroup {
     contract: GroupContract,
     sources: Vec<AdmittedSourceOpener>,
     capacity_lease: Option<Box<dyn GroupCapacityLease>>,
+}
+
+struct OpenedCapabilitySession {
+    instance: CompiledSourceInstanceId,
+    session: Box<dyn CapabilitySession>,
 }
 
 impl Drop for OwnedActivationGroup {
@@ -504,7 +534,7 @@ impl Drop for AdmittedRunCapabilities {
 pub struct ActiveActivationGroup {
     contract: GroupContract,
     sources: Vec<AdmittedSourceOpener>,
-    sessions: Vec<Box<dyn CapabilitySession>>,
+    sessions: Vec<OpenedCapabilitySession>,
     capacity_lease: Option<Box<dyn GroupCapacityLease>>,
 }
 
@@ -538,15 +568,45 @@ impl ActiveActivationGroup {
         let session = opener
             .open()
             .map_err(|_| RunCapabilityError::new(RunCapabilityErrorKind::OpenFailed))?;
-        self.sessions.push(session);
+        self.sessions
+            .push(OpenedCapabilitySession { instance, session });
         Ok(())
+    }
+
+    /// Open every member in compiled group order before downstream work starts.
+    ///
+    /// On failure, the caller must drop this active group; its `Drop` closes
+    /// already-opened sessions and unopened factories in reverse order before
+    /// releasing the complete group lease.
+    pub fn open_all(&mut self) -> Result<(), RunCapabilityError> {
+        let members: Box<[_]> = self.contract.members.clone();
+        for member in members {
+            self.open(member)?;
+        }
+        Ok(())
+    }
+
+    /// Transfer one opened member's finite input exactly once.
+    pub fn take_source_input(
+        &mut self,
+        instance: CompiledSourceInstanceId,
+    ) -> Result<crate::source::SourceInput, RunCapabilityError> {
+        let opened = self
+            .sessions
+            .iter_mut()
+            .find(|opened| opened.instance == instance)
+            .ok_or_else(|| RunCapabilityError::new(RunCapabilityErrorKind::SourceUnavailable))?;
+        opened
+            .session
+            .take_source_input()
+            .map_err(|_| RunCapabilityError::new(RunCapabilityErrorKind::SourceUnavailable))
     }
 }
 
 impl Drop for ActiveActivationGroup {
     fn drop(&mut self) {
-        while let Some(session) = self.sessions.pop() {
-            drop(session);
+        while let Some(opened) = self.sessions.pop() {
+            drop(opened.session);
         }
         while let Some(source) = self.sources.pop() {
             drop(source);

--- a/crates/clinker-exec/src/executor/composition_dispatch.rs
+++ b/crates/clinker-exec/src/executor/composition_dispatch.rs
@@ -440,7 +440,8 @@ fn execute_composition_body(
         &mut ctx.planned_node_buffer_readers,
         planned_materialized_reader_counts(&body_dag),
     );
-    let saved_combine = std::mem::take(&mut ctx.source_records);
+    let saved_source_records = std::mem::take(&mut ctx.source_records);
+    let saved_source_consumers = std::mem::take(&mut ctx.source_consumers);
     // Window-arena consumer ids key by slot index, which the body
     // re-uses from zero alongside its window-runtime overlay. Swap to a
     // fresh map so a body arena registration at slot N does not clobber
@@ -549,7 +550,42 @@ fn execute_composition_body(
     ctx.node_buffer_consumer_ids = saved_consumer_ids;
     ctx.node_buffer_readers = saved_readers;
     ctx.planned_node_buffer_readers = saved_planned_readers;
-    ctx.source_records = saved_combine;
+    // Drop every residual body receiver before joining its finite ingest
+    // workers. This unblocks a producer whose downstream body failed before
+    // draining the bounded channel. Source arms that reached EOF already
+    // removed and unregistered their own consumer; the sweep covers only
+    // early-return residue.
+    drop(std::mem::take(&mut ctx.source_records));
+    for (_, (id, handle)) in std::mem::take(&mut ctx.source_consumers) {
+        handle.resume();
+        handle.clear_active();
+        handle.set_bytes(0);
+        ctx.memory_budget.unregister_consumer(id);
+    }
+    let activation_cleanup = match ctx.source_activation.as_mut() {
+        Some(controller) => controller.finish_scope(bound_body.body_scope),
+        None => Ok(Vec::new()),
+    };
+    let activation_cleanup = activation_cleanup.and_then(|outcomes| {
+        for outcome in outcomes {
+            ctx.counters.total_count = ctx
+                .counters
+                .total_count
+                .checked_add(outcome.total_count)
+                .ok_or_else(|| PipelineError::Internal {
+                    op: "body-source-count",
+                    node: outcome.source_name.clone(),
+                    detail: "body Source record count overflowed u64".to_string(),
+                })?;
+            for (file, timestamp) in outcome.watermark_observations {
+                ctx.watermarks
+                    .observe(&outcome.source_name, &file, timestamp);
+            }
+        }
+        Ok(())
+    });
+    ctx.source_records = saved_source_records;
+    ctx.source_consumers = saved_source_consumers;
     ctx.current_body_node_input_refs = saved_body_refs;
     // Unregister body-local window-arena consumers and restore the
     // parent map. The body's node-rooted arenas drop when its window-
@@ -563,5 +599,9 @@ fn execute_composition_body(
     ctx.composition_call_sites.pop();
     ctx.window_runtime.remove_body_scope(bound_body.body_scope);
 
-    walk_and_harvest
+    match (walk_and_harvest, activation_cleanup) {
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Ok(output), Ok(())) => Ok(output),
+    }
 }

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1207,11 +1207,11 @@ pub(crate) struct ExecutorContext<'a> {
     /// via [`Self::release_source_consumer`] at receiver disconnect,
     /// zeroing the mirrored queue charge and unregistering the wrapper so
     /// the drained channel stops counting toward `sum_consumer_usage`.
-    /// Body-scope walks (composition / commit) swap `source_records` to an
-    /// empty map, so no body arm can reach a live receiver — this map
-    /// therefore never needs the body-scope save/restore its sibling
-    /// consumer-id maps get. Entries still present after the walk (error
-    /// unwind, interrupt before dispatch) are swept at top-scope teardown.
+    /// Body-scope walks save/restore this map with `source_records`, install
+    /// registrations for activated body Sources, and sweep every residual
+    /// entry before joining that scope's ingest workers. Entries still present
+    /// after the top-level walk (error unwind, interrupt before dispatch) are
+    /// swept at top-scope teardown.
     pub(crate) source_consumers: HashMap<
         String,
         (
@@ -1219,6 +1219,13 @@ pub(crate) struct ExecutorContext<'a> {
             std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
         ),
     >,
+    /// Sealed run-local capability owner for composition-body Sources.
+    ///
+    /// `None` is retained only by crate-internal legacy test seams that do not
+    /// execute external body Sources. Production compiled-plan entry points
+    /// install the matching controller before any source work begins.
+    pub(crate) source_activation:
+        Option<crate::executor::source_activation::SourceActivationController>,
     /// Top-level Source-node names whose receivers have been moved out of
     /// `source_records` by a downstream Merge.interleave or Transform fusion.
     /// The Source dispatch arm returns cleanly without consuming when its name
@@ -3534,7 +3541,7 @@ pub(crate) fn merge_fused_interleave(
             .map(build_engine_stamped_tail)
             .unwrap_or_default();
         states.push(PredState {
-            source_name_arc: Arc::from(name.as_str()),
+            source_name_arc: Arc::from(ctx.qualified_node_name(name).into_owned()),
             source_name_string: name.clone(),
             source_schema,
             engine_stamped,

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -233,36 +233,16 @@ fn build_multi_file_reader(
 
 /// Wrap a format reader with schema-based type coercion if the source
 /// declares typed columns in its `schema:` block.
-fn wrap_with_schema_coercion(
+fn wrap_source_body_with_schema_coercion(
     reader: Box<dyn FormatReader>,
-    config: &PipelineConfig,
-    source_name: &str,
+    body: &clinker_plan::config::pipeline_node::SourceBody,
 ) -> Result<Box<dyn FormatReader>, PipelineError> {
-    use clinker_plan::config::PipelineNode;
     use clinker_plan::config::pipeline_node::OnUnmapped;
 
-    // Find the source node's schema + on_unmapped policy + format. Format is
-    // needed for the auto_widen-on-fixed-width structural-inertness diagnostic
-    // below.
-    let body_data = config.nodes.iter().find_map(|s| {
-        if let PipelineNode::Source {
-            header,
-            config: body,
-        } = &s.value
-            && header.name == source_name
-        {
-            return Some((
-                &body.schema,
-                body.on_unmapped.clone(),
-                body.source.format.clone(),
-            ));
-        }
-        None
-    });
-
-    let Some((schema, policy, format)) = body_data else {
-        return Ok(reader);
-    };
+    let schema = &body.schema;
+    let policy = body.on_unmapped.clone();
+    let format = &body.source.format;
+    let source_name = body.source.name.as_str();
 
     // The unified `schema:` is resolved to its effective column list (single-
     // record columns, or the multi-record superset). Its `File` form was
@@ -362,17 +342,6 @@ fn coercible_columns(
 /// Borrow a source node's unified `schema:` ([`SourceSchema`]) from the compiled
 /// plan, keyed by node identity (`header.name`) — the same key every other
 /// source lookup on the ingest path uses.
-fn source_schema<'a>(config: &'a PipelineConfig, source_name: &str) -> Option<&'a SourceSchema> {
-    use clinker_plan::config::PipelineNode;
-    config.nodes.iter().find_map(|s| match &s.value {
-        PipelineNode::Source {
-            header,
-            config: body,
-        } if header.name == source_name => Some(&body.schema),
-        _ => None,
-    })
-}
-
 /// Convert a record value at a declared watermark column into the
 /// canonical i64-nanoseconds event-time stamp folded into
 /// [`crate::executor::watermark::PerSourceWatermarks`].
@@ -436,6 +405,39 @@ pub(super) fn ingest_source(
     shutdown_token: Option<crate::pipeline::shutdown::ShutdownToken>,
     progress: Option<crate::progress::RunProgress>,
 ) -> Result<IngestTaskOutcome, PipelineError> {
+    use clinker_plan::config::PipelineNode;
+
+    let body = config
+        .nodes
+        .iter()
+        .find_map(|node| match &node.value {
+            PipelineNode::Source { header, config } if header.name == src_cfg.name => {
+                Some(config.clone())
+            }
+            _ => None,
+        })
+        .ok_or_else(|| {
+            PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+                "source '{}' not found in the compiled plan while building its reader",
+                src_cfg.name
+            )))
+        })?;
+    ingest_source_body(body, input, stream, shutdown_token, progress)
+}
+
+/// Ingest one retained Source body through the common finite reader path.
+///
+/// Composition bodies call this entry because their Sources do not appear in
+/// the top-level [`PipelineConfig`]. The caller must supply the planner-retained
+/// resolved body; this function never reconstructs schema or reader policy.
+pub(super) fn ingest_source_body(
+    body: clinker_plan::config::pipeline_node::SourceBody,
+    input: crate::source::SourceInput,
+    stream: crate::executor::source_stream::SourceIngestChannel,
+    shutdown_token: Option<crate::pipeline::shutdown::ShutdownToken>,
+    progress: Option<crate::progress::RunProgress>,
+) -> Result<IngestTaskOutcome, PipelineError> {
+    let src_cfg = body.source.clone();
     // Branch once on transport. The file arm builds the
     // MultiFileFormatReader + schema-coercion stack and hands the
     // resulting `Box<dyn FormatReader>` to the shared driver as a
@@ -454,14 +456,9 @@ pub(super) fn ingest_source(
                     )),
                 ));
             }
-            let schema = source_schema(&config, &src_cfg.name).ok_or_else(|| {
-                PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
-                    "source '{}' not found in the compiled plan while building its reader",
-                    src_cfg.name
-                )))
-            })?;
-            let raw_reader = build_multi_file_reader(&src_cfg, schema, files, progress.clone())?;
-            let src_reader = wrap_with_schema_coercion(raw_reader, &config, &src_cfg.name)?;
+            let raw_reader =
+                build_multi_file_reader(&src_cfg, &body.schema, files, progress.clone())?;
+            let src_reader = wrap_source_body_with_schema_coercion(raw_reader, &body)?;
             // The file arm reaches the shared driver through the blanket
             // `RecordSource for Box<dyn FormatReader>` impl.
             drive_record_source(src_cfg, Box::new(src_reader), stream, shutdown_token)

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -29,6 +29,7 @@ mod route;
 pub(crate) mod route_dispatch;
 mod schema_check;
 pub(crate) mod sort_dispatch;
+pub(crate) mod source_activation;
 pub(crate) mod source_dispatch;
 pub mod source_stream;
 pub mod spill_purge;
@@ -200,6 +201,8 @@ struct DagExecInputs<'a> {
 /// [`DagExecInputs`] because every field here transfers ownership into
 /// the walk rather than being borrowed for its duration.
 struct DagExecResources {
+    /// Executor-owned sealed Source capabilities for body activation.
+    source_activation: Option<source_activation::SourceActivationController>,
     /// One live crossbeam `Receiver` per declared Source, drained by
     /// the Source dispatch arm.
     source_records: HashMap<
@@ -329,9 +332,10 @@ impl PipelineExecutor {
     /// before the executor recompiles the effective config or begins ingest and
     /// dispatch. This slice still receives caller-constructed `SourceReaders`
     /// and writers; it retains the matching opener/group contract for the full
-    /// run but does not consume those openers or groups yet. The bundle remains
-    /// owned by this stack frame until success, failure, or interruption
-    /// unwinds the run.
+    /// run. Composition-body Sources consume their opaque openers and complete
+    /// group leases; top-level Sources continue to use caller-supplied readers.
+    /// The controller retains every opened session until its composition scope
+    /// finishes, and unwinding releases every remaining lease and session.
     pub fn run_admitted_plan_with_readers_writers<W: Into<WriterRegistry>>(
         plan: &clinker_plan::plan::CompiledPlan,
         capabilities: capabilities::AdmittedRunCapabilities,
@@ -339,22 +343,13 @@ impl PipelineExecutor {
         writers: W,
         params: &PipelineRunParams,
     ) -> Result<ExecutionReport, PipelineError> {
-        capabilities
-            .ensure_matches(plan.dag().source_activation())
-            .map_err(run_capability_error)?;
-        if plan.cxl_modules().is_empty() {
-            return Self::run_with_readers_writers(plan.config(), readers, writers.into(), params);
-        }
-        let compile_ctx = clinker_plan::config::CompileContext {
-            cxl_modules: plan.cxl_modules().clone(),
-            ..clinker_plan::config::CompileContext::default()
-        };
-        Self::run_with_readers_writers_in_context(
-            plan.config(),
+        Self::run_admitted_plan_with_readers_writers_in_context(
+            plan,
+            capabilities,
             readers,
-            writers.into(),
+            writers,
             params,
-            compile_ctx,
+            clinker_plan::config::CompileContext::default(),
         )
     }
 
@@ -414,12 +409,46 @@ impl PipelineExecutor {
             .ensure_matches(plan.dag().source_activation())
             .map_err(run_capability_error)?;
         compile_ctx.cxl_modules = plan.cxl_modules().clone();
-        Self::run_with_readers_writers_in_context(
+        let source_activation = source_activation::SourceActivationController::new(
+            plan.dag().source_activation().clone(),
+            capabilities,
+        );
+        Self::run_with_readers_writers_in_context_and_activation(
             plan.config(),
             readers,
             writers.into(),
             params,
             compile_ctx,
+            Some(source_activation),
+        )
+    }
+
+    #[cfg(test)]
+    fn run_admitted_plan_with_readers_writers_and_arbitrator(
+        plan: &clinker_plan::plan::CompiledPlan,
+        capabilities: capabilities::AdmittedRunCapabilities,
+        readers: SourceReaders,
+        writers: WriterRegistry,
+        params: &PipelineRunParams,
+        mut compile_ctx: clinker_plan::config::CompileContext,
+        memory_budget: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
+    ) -> Result<ExecutionReport, PipelineError> {
+        capabilities
+            .ensure_matches(plan.dag().source_activation())
+            .map_err(run_capability_error)?;
+        compile_ctx.cxl_modules = plan.cxl_modules().clone();
+        let source_activation = source_activation::SourceActivationController::new(
+            plan.dag().source_activation().clone(),
+            capabilities,
+        );
+        Self::run_with_readers_writers_with_arbitrator_and_activation(
+            plan.config(),
+            readers,
+            writers,
+            params,
+            compile_ctx,
+            memory_budget,
+            Some(source_activation),
         )
     }
 
@@ -444,6 +473,7 @@ impl PipelineExecutor {
     ///
     /// Returns an [`ExecutionReport`] containing record counts, DLQ entries,
     /// execution mode, peak RSS, and wall-clock start/finish timestamps.
+    #[cfg(test)]
     pub(crate) fn run_with_readers_writers(
         config: &PipelineConfig,
         readers: SourceReaders,
@@ -473,12 +503,31 @@ impl PipelineExecutor {
     /// production call sites free of any test-only seam.
     ///
     /// [`MemoryArbitrator`]: crate::pipeline::memory::MemoryArbitrator
+    #[cfg(test)]
     pub(crate) fn run_with_readers_writers_in_context(
         config: &PipelineConfig,
         readers: SourceReaders,
         writers: WriterRegistry,
         params: &PipelineRunParams,
         compile_ctx: clinker_plan::config::CompileContext,
+    ) -> Result<ExecutionReport, PipelineError> {
+        Self::run_with_readers_writers_in_context_and_activation(
+            config,
+            readers,
+            writers,
+            params,
+            compile_ctx,
+            None,
+        )
+    }
+
+    fn run_with_readers_writers_in_context_and_activation(
+        config: &PipelineConfig,
+        readers: SourceReaders,
+        writers: WriterRegistry,
+        params: &PipelineRunParams,
+        compile_ctx: clinker_plan::config::CompileContext,
+        source_activation: Option<source_activation::SourceActivationController>,
     ) -> Result<ExecutionReport, PipelineError> {
         // Reject an unsatisfiable memory budget before building the run.
         // A `memory.limit` below the process's live baseline RSS can never
@@ -516,13 +565,14 @@ impl PipelineExecutor {
             arbitrator.set_max_spill_bytes(cap);
         }
         let memory_budget = std::sync::Arc::new(arbitrator);
-        Self::run_with_readers_writers_with_arbitrator(
+        Self::run_with_readers_writers_with_arbitrator_and_activation(
             config,
             readers,
             writers,
             params,
             compile_ctx,
             memory_budget,
+            source_activation,
         )
     }
 
@@ -536,13 +586,34 @@ impl PipelineExecutor {
     /// arbitrator from `config` and delegates.
     ///
     /// [`MemoryArbitrator`]: crate::pipeline::memory::MemoryArbitrator
+    #[cfg(test)]
     pub(crate) fn run_with_readers_writers_with_arbitrator(
+        config: &PipelineConfig,
+        readers: SourceReaders,
+        writers: WriterRegistry,
+        params: &PipelineRunParams,
+        compile_ctx: clinker_plan::config::CompileContext,
+        memory_budget: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
+    ) -> Result<ExecutionReport, PipelineError> {
+        Self::run_with_readers_writers_with_arbitrator_and_activation(
+            config,
+            readers,
+            writers,
+            params,
+            compile_ctx,
+            memory_budget,
+            None,
+        )
+    }
+
+    fn run_with_readers_writers_with_arbitrator_and_activation(
         config: &PipelineConfig,
         mut readers: SourceReaders,
         writers: WriterRegistry,
         params: &PipelineRunParams,
         compile_ctx: clinker_plan::config::CompileContext,
         memory_budget: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
+        source_activation: Option<source_activation::SourceActivationController>,
     ) -> Result<ExecutionReport, PipelineError> {
         let started_at = Utc::now();
         let output_staging = writers.output_staging.clone();
@@ -918,6 +989,7 @@ impl PipelineExecutor {
                 params,
             },
             DagExecResources {
+                source_activation,
                 source_records,
                 source_consumers,
                 writers,
@@ -1161,6 +1233,7 @@ impl PipelineExecutor {
             params,
         } = inputs;
         let DagExecResources {
+            source_activation,
             source_records,
             source_consumers,
             mut writers,
@@ -1479,6 +1552,7 @@ impl PipelineExecutor {
             window_arena_consumer_ids: HashMap::new(),
             source_records,
             source_consumers,
+            source_activation,
             fused_sources,
             fused_transforms,
             record_var_seed: &record_var_seed,

--- a/crates/clinker-exec/src/executor/source_activation.rs
+++ b/crates/clinker-exec/src/executor/source_activation.rs
@@ -1,0 +1,541 @@
+//! Runtime consumption of sealed composition-body Source activation groups.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use clinker_plan::error::PipelineError;
+use clinker_plan::plan::composition_body::BodyScopeId;
+use clinker_plan::plan::execution::{
+    CompiledSourceInstanceId, CompiledSourceScope, ExecutionPlanDag, PlanNode,
+    SourceActivationGroupId, SourceActivationPlan,
+};
+
+use super::capabilities::{ActiveActivationGroup, AdmittedRunCapabilities, RunCapabilityError};
+use super::ingest::{IngestTaskOutcome, ingest_source_body};
+use super::source_stream::{SourceConsumer, SourceIngestChannel, SourceStreamEvent};
+use crate::pipeline::memory::{ConsumerHandle, ConsumerId, MemoryArbitrator};
+use crate::telemetry::{
+    MetricKey, SpanFact, SpanName, SpanStatus, TelemetryProducer, unix_nanos_now,
+};
+
+type SourceReceiver = crossbeam_channel::Receiver<SourceStreamEvent>;
+type SourceConsumerRegistration = (ConsumerId, Arc<ConsumerHandle>);
+
+struct ActiveGroupRuntime {
+    scope: BodyScopeId,
+    group: ActiveActivationGroup,
+    workers: Vec<std::thread::JoinHandle<Result<IngestTaskOutcome, PipelineError>>>,
+}
+
+/// Receivers and memory registrations produced by one atomic group activation.
+pub(crate) struct ActivatedSourceGroup {
+    pub(crate) receivers: Vec<(String, SourceReceiver)>,
+    pub(crate) consumers: Vec<(String, SourceConsumerRegistration)>,
+}
+
+/// Run-local controller for the planner's sealed activation inventory.
+///
+/// The controller indexes only immutable configuration-derived identities. It
+/// never resolves a catalog entry, physical path, profile, or credential. Live
+/// input-growing state resides in the bounded Source channels registered with
+/// the run's [`MemoryArbitrator`].
+pub(crate) struct SourceActivationController {
+    plan: SourceActivationPlan,
+    capabilities: AdmittedRunCapabilities,
+    active: BTreeMap<SourceActivationGroupId, ActiveGroupRuntime>,
+}
+
+impl SourceActivationController {
+    pub(crate) fn new(plan: SourceActivationPlan, capabilities: AdmittedRunCapabilities) -> Self {
+        Self {
+            plan,
+            capabilities,
+            active: BTreeMap::new(),
+        }
+    }
+
+    /// Activate the complete group containing `instance`, exactly once.
+    ///
+    /// The pre-admitted group lease transfers before any opener runs. Every
+    /// opener completes before a Source channel is registered or a worker is
+    /// spawned, so partial open failure cannot start downstream work.
+    pub(crate) fn activate(
+        &mut self,
+        instance: CompiledSourceInstanceId,
+        dag: &ExecutionPlanDag,
+        logical_prefix: &str,
+        memory: &Arc<MemoryArbitrator>,
+        shutdown: Option<crate::pipeline::shutdown::ShutdownToken>,
+        telemetry: Option<&TelemetryProducer>,
+    ) -> Result<Option<ActivatedSourceGroup>, PipelineError> {
+        let CompiledSourceScope::CompositionBody(scope) = instance.scope else {
+            return Ok(None);
+        };
+        let group = self
+            .plan
+            .groups()
+            .iter()
+            .find(|group| group.members().contains(&instance))
+            .ok_or_else(|| PipelineError::Internal {
+                op: "source-activation",
+                node: String::new(),
+                detail: "compiled body Source has no sealed activation group".to_string(),
+            })?;
+        let group_id = group.id();
+        if self.active.contains_key(&group_id) {
+            return Ok(None);
+        }
+        let members: Box<[_]> = group.members().into();
+
+        let mut active = self
+            .capabilities
+            .take_group(group_id)
+            .map_err(capability_error)?;
+        for member in members.iter().copied() {
+            let source_name = source_name_for(dag, member)?;
+            let logical_node = if logical_prefix.is_empty() {
+                source_name.to_string()
+            } else {
+                format!("{logical_prefix}.{source_name}")
+            };
+            observe_open(telemetry, &logical_node, || active.open(member))?;
+        }
+
+        let mut prepared = Vec::with_capacity(members.len());
+        for member in members.iter().copied() {
+            let body = source_body_for(dag, member)?.clone();
+            let input = active.take_source_input(member).map_err(capability_error)?;
+            prepared.push((member, body, input));
+        }
+
+        let mut activated = ActivatedSourceGroup {
+            receivers: Vec::with_capacity(prepared.len()),
+            consumers: Vec::with_capacity(prepared.len()),
+        };
+        let mut workers = Vec::with_capacity(prepared.len());
+        for (member, body, input) in prepared {
+            let source_name = body.source.name.clone();
+            let logical_source_name = if logical_prefix.is_empty() {
+                source_name.clone()
+            } else {
+                format!("{logical_prefix}.{source_name}")
+            };
+            let handle = ConsumerHandle::new();
+            let (stream, receiver) = SourceIngestChannel::new(
+                SourceIngestChannel::DEFAULT_CAPACITY,
+                Arc::clone(&handle),
+                member.source_node,
+            );
+            let consumer_id =
+                memory.register_consumer(Arc::new(SourceConsumer::new(Arc::clone(&handle))));
+            activated.receivers.push((source_name.clone(), receiver));
+            activated
+                .consumers
+                .push((source_name.clone(), (consumer_id, handle)));
+            let worker_shutdown = shutdown.clone();
+            let spawn = std::thread::Builder::new()
+                .name(format!("clinker-body-source-{source_name}"))
+                .spawn(move || {
+                    let mut outcome =
+                        ingest_source_body(body, input, stream, worker_shutdown, None)?;
+                    outcome.source_name = logical_source_name;
+                    Ok(outcome)
+                });
+            match spawn {
+                Ok(worker) => workers.push(worker),
+                Err(error) => {
+                    drop(activated.receivers);
+                    for (_, (id, handle)) in activated.consumers {
+                        handle.resume();
+                        handle.set_bytes(0);
+                        memory.unregister_consumer(id);
+                    }
+                    for worker in workers {
+                        let _ = worker.join();
+                    }
+                    return Err(PipelineError::Internal {
+                        op: "body-source-spawn",
+                        node: String::new(),
+                        detail: format!("failed to spawn body Source worker: {error}"),
+                    });
+                }
+            }
+        }
+
+        self.active.insert(
+            group_id,
+            ActiveGroupRuntime {
+                scope,
+                group: active,
+                workers,
+            },
+        );
+        Ok(Some(activated))
+    }
+
+    /// Join and close every active group in `scope` after its receivers drop.
+    pub(super) fn finish_scope(
+        &mut self,
+        scope: BodyScopeId,
+    ) -> Result<Vec<IngestTaskOutcome>, PipelineError> {
+        let group_ids: Vec<_> = self
+            .active
+            .iter()
+            .filter_map(|(id, runtime)| (runtime.scope == scope).then_some(*id))
+            .collect();
+        let mut outcomes = Vec::new();
+        let mut first_error = None;
+        for id in group_ids.into_iter().rev() {
+            let mut runtime = self
+                .active
+                .remove(&id)
+                .expect("active group id was collected from the same map");
+            while let Some(worker) = runtime.workers.pop() {
+                match worker.join() {
+                    Ok(Ok(outcome)) => outcomes.push(outcome),
+                    Ok(Err(error)) => {
+                        if first_error.is_none() {
+                            first_error = Some(error);
+                        }
+                    }
+                    Err(_) => {
+                        if first_error.is_none() {
+                            first_error = Some(PipelineError::Internal {
+                                op: "body-source-thread",
+                                node: String::new(),
+                                detail: "body Source worker panicked".to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+            drop(runtime.group);
+        }
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(outcomes),
+        }
+    }
+}
+
+impl Drop for SourceActivationController {
+    fn drop(&mut self) {
+        while let Some((_, mut runtime)) = self.active.pop_last() {
+            while let Some(worker) = runtime.workers.pop() {
+                let _ = worker.join();
+            }
+            drop(runtime.group);
+        }
+    }
+}
+
+fn source_name_for(
+    dag: &ExecutionPlanDag,
+    instance: CompiledSourceInstanceId,
+) -> Result<&str, PipelineError> {
+    dag.graph
+        .node_weights()
+        .find(|node| node.id() == instance.source_node)
+        .map(PlanNode::name)
+        .ok_or_else(|| PipelineError::Internal {
+            op: "source-activation",
+            node: String::new(),
+            detail: "sealed Source identity is absent from the active body DAG".to_string(),
+        })
+}
+
+fn source_body_for(
+    dag: &ExecutionPlanDag,
+    instance: CompiledSourceInstanceId,
+) -> Result<&clinker_plan::config::pipeline_node::SourceBody, PipelineError> {
+    dag.graph
+        .node_weights()
+        .find_map(|node| match node {
+            PlanNode::Source {
+                id,
+                resolved: Some(payload),
+                ..
+            } if *id == instance.source_node => Some(&payload.body),
+            _ => None,
+        })
+        .ok_or_else(|| PipelineError::Internal {
+            op: "source-activation",
+            node: String::new(),
+            detail: "sealed body Source has no retained reader contract".to_string(),
+        })
+}
+
+fn observe_open<T>(
+    producer: Option<&TelemetryProducer>,
+    logical_node: &str,
+    operation: impl FnOnce() -> Result<T, RunCapabilityError>,
+) -> Result<T, PipelineError> {
+    let Some(producer) = producer else {
+        return operation().map_err(capability_error);
+    };
+    let started_at_unix_nanos = unix_nanos_now();
+    producer.record_metric(MetricKey::ResourceOpenStarted, 1);
+    let result = operation();
+    let ended_at_unix_nanos = unix_nanos_now().max(started_at_unix_nanos);
+    let (metric, status) = if result.is_ok() {
+        (MetricKey::ResourceOpenCompleted, SpanStatus::Ok)
+    } else {
+        (MetricKey::ResourceOpenFailed, SpanStatus::Error)
+    };
+    producer.record_metric(metric, 1);
+    producer.emit_span(SpanFact {
+        name: SpanName::ResourceOpen,
+        status,
+        logical_node,
+        started_at_unix_nanos,
+        ended_at_unix_nanos,
+    });
+    result.map_err(capability_error)
+}
+
+fn capability_error(error: RunCapabilityError) -> PipelineError {
+    PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+        "body Source activation failed: {error}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::io::Cursor;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use clinker_bench_support::io::SharedBuffer;
+    use clinker_plan::config::{CompileContext, parse_config};
+    use clinker_plan::error::PipelineError;
+
+    use super::super::capabilities::{
+        AdmittedActivationGroup, AdmittedRunCapabilities, AdmittedSourceOpener,
+        CapabilityOpenError, CapabilityOpener, CapabilitySession,
+    };
+    use super::super::{PipelineExecutor, PipelineRunParams, SourceInput};
+    use crate::pipeline::memory::MemoryArbitrator;
+    use crate::pipeline::shutdown::ShutdownToken;
+    use crate::source::multi_file::FileSlot;
+
+    const BODY: &str = r#"_compose:
+  name: memory_reader
+  inputs: {}
+  outputs: { out: read }
+  config_schema: {}
+  resources_schema:
+    input: { kind: file, required: true }
+nodes:
+  - type: source
+    name: read
+    config:
+      name: read
+      type: csv
+      resource: input
+      on_unmapped: { mode: drop }
+      schema: [{ name: id, type: int }]
+"#;
+
+    const PIPELINE: &str = r#"pipeline: { name: body_source_memory }
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      path: driver.csv
+      schema: [{ name: seed, type: string }]
+  - type: composition
+    name: call
+    input: driver
+    use: ../compositions/memory_reader.comp.yaml
+    inputs: {}
+    resources: { input: shared_input }
+  - type: output
+    name: out
+    input: call
+    config: { name: out, type: csv, path: out.csv }
+"#;
+
+    struct InputOpener {
+        body: Vec<u8>,
+        shutdown: Option<ShutdownToken>,
+    }
+
+    impl CapabilityOpener for InputOpener {
+        fn open(self: Box<Self>) -> Result<Box<dyn CapabilitySession>, CapabilityOpenError> {
+            if let Some(token) = &self.shutdown {
+                token.request();
+            }
+            Ok(Box::new(InputSession {
+                input: Some(SourceInput::Files(vec![FileSlot::new(
+                    "logical.csv",
+                    Box::new(Cursor::new(self.body)),
+                )])),
+            }))
+        }
+    }
+
+    struct InputSession {
+        input: Option<SourceInput>,
+    }
+
+    impl CapabilitySession for InputSession {
+        fn take_source_input(&mut self) -> Result<SourceInput, CapabilityOpenError> {
+            self.input.take().ok_or(CapabilityOpenError::Unavailable)
+        }
+    }
+
+    fn fixture() -> (tempfile::TempDir, clinker_plan::plan::CompiledPlan) {
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::fs::create_dir_all(workspace.path().join("compositions"))
+            .expect("composition directory");
+        std::fs::create_dir_all(workspace.path().join("pipelines")).expect("pipeline directory");
+        std::fs::create_dir_all(workspace.path().join("data")).expect("data directory");
+        std::fs::write(workspace.path().join("data/input.csv"), "id\n1\n")
+            .expect("catalog resource");
+        std::fs::write(
+            workspace
+                .path()
+                .join("compositions/memory_reader.comp.yaml"),
+            BODY,
+        )
+        .expect("composition body");
+        std::fs::write(
+            workspace.path().join("clinker.toml"),
+            r#"[catalog.resources.shared_input]
+kind = "file"
+path = "data/input.csv"
+access = "read"
+"#,
+        )
+        .expect("catalog");
+        let config = parse_config(PIPELINE).expect("pipeline parses");
+        let plan = config
+            .compile(&CompileContext::with_pipeline_dir(
+                workspace.path(),
+                PathBuf::from("pipelines"),
+            ))
+            .unwrap_or_else(|diagnostics| panic!("pipeline compiles: {diagnostics:?}"));
+        (workspace, plan)
+    }
+
+    fn capabilities(
+        plan: &clinker_plan::plan::CompiledPlan,
+        body: &[u8],
+        shutdown: Option<ShutdownToken>,
+    ) -> AdmittedRunCapabilities {
+        let activation = plan.dag().source_activation();
+        let groups = activation
+            .groups()
+            .iter()
+            .map(|group| {
+                let sources = group
+                    .members()
+                    .iter()
+                    .copied()
+                    .map(|member| {
+                        let opener: Box<dyn CapabilityOpener> = match member.scope {
+                            clinker_plan::plan::execution::CompiledSourceScope::TopLevel => {
+                                return AdmittedSourceOpener::caller_supplied(member);
+                            }
+                            clinker_plan::plan::execution::CompiledSourceScope::CompositionBody(
+                                _,
+                            ) => Box::new(InputOpener {
+                                body: body.to_vec(),
+                                shutdown: shutdown.clone(),
+                            }),
+                        };
+                        AdmittedSourceOpener::new(member, opener)
+                    })
+                    .collect();
+                AdmittedActivationGroup::uncredentialed(group.id(), group.capacity(), sources)
+            })
+            .collect();
+        AdmittedRunCapabilities::admit(activation, groups).expect("capabilities admit")
+    }
+
+    fn run(
+        workspace: &std::path::Path,
+        plan: &clinker_plan::plan::CompiledPlan,
+        capabilities: AdmittedRunCapabilities,
+        params: &PipelineRunParams,
+        memory: Arc<MemoryArbitrator>,
+    ) -> Result<super::super::ExecutionReport, PipelineError> {
+        let readers = HashMap::from([(
+            "driver".to_string(),
+            SourceInput::Files(vec![FileSlot::new(
+                "driver.csv",
+                Box::new(Cursor::new(b"seed\ngo\n".to_vec())),
+            )]),
+        )]);
+        let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+            HashMap::from([("out".to_string(), Box::new(SharedBuffer::new()) as _)]);
+        PipelineExecutor::run_admitted_plan_with_readers_writers_and_arbitrator(
+            plan,
+            capabilities,
+            readers,
+            writers.into(),
+            params,
+            CompileContext::with_pipeline_dir(workspace, PathBuf::from("pipelines")),
+            memory,
+        )
+    }
+
+    fn memory() -> Arc<MemoryArbitrator> {
+        Arc::new(MemoryArbitrator::with_policy(
+            100 * 1024 * 1024 * 1024,
+            0.80,
+            0.70,
+            MemoryArbitrator::default_policy(),
+        ))
+    }
+
+    #[test]
+    fn body_source_consumers_leave_the_memory_registry_on_every_exit() {
+        let (workspace, plan) = fixture();
+
+        let success_memory = memory();
+        let success = run(
+            workspace.path(),
+            &plan,
+            capabilities(&plan, b"id\n1\n2\n", None),
+            &PipelineRunParams::default(),
+            Arc::clone(&success_memory),
+        )
+        .expect("successful body Source run");
+        assert_eq!(success.counters.ok_count, 2);
+        assert_eq!(success_memory.consumer_count(), 0);
+        assert_eq!(success_memory.sum_consumer_usage(), 0);
+
+        let error_memory = memory();
+        run(
+            workspace.path(),
+            &plan,
+            capabilities(&plan, b"id\nnot-an-int\n", None),
+            &PipelineRunParams::default(),
+            Arc::clone(&error_memory),
+        )
+        .expect_err("reader failure propagates");
+        assert_eq!(error_memory.consumer_count(), 0);
+        assert_eq!(error_memory.sum_consumer_usage(), 0);
+
+        let shutdown = ShutdownToken::detached();
+        let cancel_memory = memory();
+        let cancelled = run(
+            workspace.path(),
+            &plan,
+            capabilities(&plan, b"id\n1\n2\n", Some(shutdown.clone())),
+            &PipelineRunParams {
+                shutdown_token: Some(shutdown),
+                ..Default::default()
+            },
+            Arc::clone(&cancel_memory),
+        )
+        .expect("cancellation unwinds cleanly");
+        assert!(cancelled.interrupted);
+        assert_eq!(cancel_memory.consumer_count(), 0);
+        assert_eq!(cancel_memory.sum_consumer_usage(), 0);
+    }
+}

--- a/crates/clinker-exec/src/executor/source_dispatch.rs
+++ b/crates/clinker-exec/src/executor/source_dispatch.rs
@@ -71,7 +71,13 @@ pub(crate) fn dispatch_source<'borrow, 'plan>(
 where
     'plan: 'borrow,
 {
-    let PlanNode::Source { ref name, .. } = *node else {
+    let PlanNode::Source {
+        ref name,
+        id,
+        ref resolved,
+        ..
+    } = *node
+    else {
         return Err(crate::executor::invariant::dispatch_mismatch(
             "dispatch_source",
             "source",
@@ -85,6 +91,89 @@ where
     };
     #[cfg(not(feature = "test-utils"))]
     let SourceDispatchContext::Live(ctx) = ctx.into();
+
+    // An authored body Source carries a resolved reader contract; a synthetic
+    // input-port Source does not. Activate the exact sealed group on the first
+    // authored member encountered. Group activation may install receivers for
+    // several fused members, but it opens every session before publishing any
+    // receiver to this body scope.
+    if resolved.is_some()
+        && let Some(body_id) = ctx.window_runtime.active_stack.last().copied()
+    {
+        let body_scope = ctx
+            .composition_bodies
+            .get(&body_id)
+            .ok_or_else(|| PipelineError::compose_body_missing(name.clone()))?
+            .body_scope;
+        let instance = clinker_plan::plan::execution::CompiledSourceInstanceId {
+            scope: clinker_plan::plan::execution::CompiledSourceScope::CompositionBody(body_scope),
+            source_node: id,
+        };
+        let mut controller =
+            ctx.source_activation
+                .take()
+                .ok_or_else(|| PipelineError::Internal {
+                    op: "source-activation",
+                    node: ctx.qualified_node_name(name).into_owned(),
+                    detail: "body Source reached execution without admitted capabilities"
+                        .to_string(),
+                })?;
+        let logical_prefix = ctx.composition_call_sites.join(".");
+        let activated = controller.activate(
+            instance,
+            current_dag,
+            &logical_prefix,
+            &ctx.memory_budget,
+            ctx.shutdown_token.clone(),
+            ctx.telemetry_producer.as_ref(),
+        );
+        ctx.source_activation = Some(controller);
+        if let Some(activated) = activated? {
+            for (source_name, receiver) in activated.receivers {
+                if ctx
+                    .source_records
+                    .insert(source_name.clone(), receiver)
+                    .is_some()
+                {
+                    return Err(PipelineError::Internal {
+                        op: "source-activation",
+                        node: source_name,
+                        detail: "body Source receiver was activated more than once".to_string(),
+                    });
+                }
+            }
+            for (source_name, registration) in activated.consumers {
+                if let Some((id, handle)) = ctx
+                    .source_consumers
+                    .insert(source_name.clone(), registration)
+                {
+                    handle.resume();
+                    handle.set_bytes(0);
+                    ctx.memory_budget.unregister_consumer(id);
+                    return Err(PipelineError::Internal {
+                        op: "source-activation",
+                        node: source_name,
+                        detail: "body Source memory consumer was activated more than once"
+                            .to_string(),
+                    });
+                }
+            }
+        }
+    }
+    let source_identity: Arc<str> = if !ctx.window_runtime.active_stack.is_empty() {
+        Arc::from(ctx.qualified_node_name(name).into_owned())
+    } else {
+        Arc::from(name.as_str())
+    };
+    ctx.source_count_per_source
+        .entry(Arc::clone(&source_identity))
+        .or_insert(None);
+    ctx.total_per_source
+        .entry(Arc::clone(&source_identity))
+        .or_insert(0);
+    ctx.dlq_per_source
+        .entry(Arc::clone(&source_identity))
+        .or_insert(0);
     // Three input paths feed a Source's emit:
     //
     // 1. Records already seeded into `ctx.node_buffers[node_idx]`
@@ -205,7 +294,7 @@ where
         // wherever the executor task scheduler interleaves.
         let timeout = ctx.idle_timeouts.get(name.as_str()).copied();
         let has_record_seed = !ctx.record_var_seed.is_empty();
-        let source_name_arc: Arc<str> = Arc::from(name.as_str());
+        let source_name_arc = Arc::clone(&source_identity);
         let mut drained: Vec<(Record, crate::executor::stream_event::SourceRowId)> = Vec::new();
         let mut drained_puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
         // Tracked so an idle-timeout flips THAT file's
@@ -241,7 +330,8 @@ where
                         // to `Idle`. The next record un-
                         // idles via `observe`. Idempotent on
                         // repeat timeouts.
-                        ctx.watermarks.mark_idle(name.as_str(), &last_file);
+                        ctx.watermarks
+                            .mark_idle(source_identity.as_ref(), &last_file);
                         continue;
                     }
                     Err(crossbeam_channel::RecvTimeoutError::Disconnected) => None,
@@ -290,7 +380,7 @@ where
         }
         ctx.finalize_source_count(&source_name_arc, count);
         ctx.release_source_consumer(name.as_str());
-        if timeout.is_some() && ctx.watermarks.is_idle(name.as_str()) {
+        if timeout.is_some() && ctx.watermarks.is_idle(source_identity.as_ref()) {
             tracing::debug!(
                 target: "clinker::watermark",
                 source = %name,

--- a/crates/clinker-exec/tests/body_source_execution.rs
+++ b/crates/clinker-exec/tests/body_source_execution.rs
@@ -1,0 +1,622 @@
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::capabilities::{
+    AdmittedActivationGroup, AdmittedRunCapabilities, AdmittedSourceOpener, CapabilityOpenError,
+    CapabilityOpener, CapabilityReservationError, CapabilitySession, GroupCapacityLease,
+    GroupCapacityReservation,
+};
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams, SourceInput};
+use clinker_exec::pipeline::shutdown::ShutdownToken;
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_exec::telemetry::{MetricKey, SpanName, SpanStatus, TelemetryArena};
+use clinker_plan::config::{ClinkerToml, CompileContext, PipelineConfig, parse_config};
+use clinker_plan::plan::execution::{CompiledSourceInstanceId, CompiledSourceScope};
+
+const BODY: &str = r#"_compose:
+  name: fixed_reader
+  inputs: {}
+  outputs: { out: read }
+  config_schema: {}
+  resources_schema:
+    input: { kind: file, required: true }
+nodes:
+  - type: source
+    name: read
+    config:
+      name: read
+      type: fixed_width
+      resource: input
+      on_unmapped: { mode: drop }
+      schema:
+        discriminator: { start: 0, width: 1 }
+        records:
+          - id: header
+            tag: H
+            columns: [{ name: batch, type: string, start: 1, width: 4 }]
+          - id: detail
+            tag: D
+            columns: [{ name: id, type: int, start: 1, width: 4 }]
+"#;
+
+const CSV_DROP_BODY: &str = r#"_compose:
+  name: csv_drop_reader
+  inputs: {}
+  outputs: { out: read }
+  config_schema: {}
+  resources_schema:
+    input: { kind: file, required: true }
+nodes:
+  - type: source
+    name: read
+    config:
+      name: read
+      type: csv
+      resource: input
+      on_unmapped: { mode: drop }
+      schema: [{ name: id, type: string }]
+"#;
+
+const INTERLEAVE_BODY: &str = r#"_compose:
+  name: interleave_reader
+  inputs: {}
+  outputs: { out: mixed }
+  config_schema: {}
+  resources_schema:
+    input: { kind: file, required: true }
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: csv
+      resource: input
+      schema: [{ name: id, type: string }]
+  - type: source
+    name: right
+    config:
+      name: right
+      type: csv
+      resource: input
+      schema: [{ name: id, type: string }]
+  - type: merge
+    name: mixed
+    inputs: [left, right]
+    config: { mode: interleave }
+"#;
+
+const PIPELINE: &str = r#"pipeline: { name: body_source_runtime }
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      path: driver.csv
+      schema: [{ name: seed, type: string }]
+  - type: composition
+    name: first
+    input: driver
+    use: ../compositions/fixed_reader.comp.yaml
+    inputs: {}
+    resources: { input: shared_input }
+  - type: composition
+    name: second
+    input: driver
+    use: ../compositions/fixed_reader.comp.yaml
+    inputs: {}
+    resources: { input: shared_input }
+  - type: output
+    name: first_out
+    input: first
+    config: { name: first_out, type: csv, path: first.csv }
+  - type: output
+    name: second_out
+    input: second
+    config: { name: second_out, type: csv, path: second.csv }
+"#;
+
+fn workspace(body: &str) -> tempfile::TempDir {
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::create_dir_all(workspace.path().join("compositions")).expect("composition dir");
+    std::fs::create_dir_all(workspace.path().join("pipelines")).expect("pipeline dir");
+    std::fs::create_dir_all(workspace.path().join("data")).expect("data dir");
+    std::fs::write(
+        workspace.path().join("compositions/fixed_reader.comp.yaml"),
+        body,
+    )
+    .expect("body");
+    std::fs::write(workspace.path().join("data/input.txt"), "H0001\nD0002\n")
+        .expect("resource file");
+    std::fs::write(
+        workspace.path().join("clinker.toml"),
+        r#"[catalog.resources.shared_input]
+kind = "file"
+path = "data/input.txt"
+access = "read"
+"#,
+    )
+    .expect("catalog");
+    workspace
+}
+
+fn compile(workspace: &Path) -> clinker_plan::plan::CompiledPlan {
+    let config: PipelineConfig = parse_config(PIPELINE).expect("pipeline parses");
+    config
+        .compile(&CompileContext::with_pipeline_dir(
+            workspace,
+            PathBuf::from("pipelines"),
+        ))
+        .unwrap_or_else(|diagnostics| panic!("pipeline compiles: {diagnostics:?}"))
+}
+
+#[derive(Clone, Default)]
+struct Events(Arc<Mutex<Vec<String>>>);
+
+impl Events {
+    fn push(&self, event: impl Into<String>) {
+        self.0.lock().expect("event log").push(event.into());
+    }
+
+    fn snapshot(&self) -> Vec<String> {
+        self.0.lock().expect("event log").clone()
+    }
+}
+
+struct Lease {
+    label: String,
+    events: Events,
+}
+impl GroupCapacityLease for Lease {}
+impl Drop for Lease {
+    fn drop(&mut self) {
+        self.events.push(format!("release:{}", self.label));
+    }
+}
+
+struct Reservation {
+    label: String,
+    events: Events,
+}
+impl GroupCapacityReservation for Reservation {
+    fn reserve(self: Box<Self>) -> Result<Box<dyn GroupCapacityLease>, CapabilityReservationError> {
+        self.events.push(format!("reserve:{}", self.label));
+        Ok(Box::new(Lease {
+            label: self.label,
+            events: self.events,
+        }))
+    }
+}
+
+struct FixtureOpener {
+    label: String,
+    events: Events,
+    body: Option<Vec<u8>>,
+    fail: bool,
+    request_shutdown: Option<ShutdownToken>,
+}
+
+impl CapabilityOpener for FixtureOpener {
+    fn open(self: Box<Self>) -> Result<Box<dyn CapabilitySession>, CapabilityOpenError> {
+        self.events.push(format!("open:{}", self.label));
+        if self.fail {
+            return Err(CapabilityOpenError::Unavailable);
+        }
+        if let Some(token) = &self.request_shutdown {
+            token.request();
+        }
+        Ok(Box::new(FixtureSession {
+            label: self.label,
+            events: self.events,
+            input: self.body.map(|body| {
+                SourceInput::Files(vec![FileSlot::new(
+                    PathBuf::from("logical-input.txt"),
+                    Box::new(Cursor::new(body)),
+                )])
+            }),
+        }))
+    }
+}
+
+struct FixtureSession {
+    label: String,
+    events: Events,
+    input: Option<SourceInput>,
+}
+
+impl CapabilitySession for FixtureSession {
+    fn take_source_input(&mut self) -> Result<SourceInput, CapabilityOpenError> {
+        self.input.take().ok_or(CapabilityOpenError::Unavailable)
+    }
+}
+
+impl Drop for FixtureSession {
+    fn drop(&mut self) {
+        self.events.push(format!("close:{}", self.label));
+    }
+}
+
+fn admitted(
+    plan: &clinker_plan::plan::CompiledPlan,
+    events: &Events,
+    body_input: &[u8],
+    failing_source: Option<&str>,
+    shutdown_on_open: Option<(&str, &ShutdownToken)>,
+) -> AdmittedRunCapabilities {
+    let activation = plan.dag().source_activation();
+    let groups = activation
+        .groups()
+        .iter()
+        .map(|group| {
+            let sources = group
+                .members()
+                .iter()
+                .copied()
+                .map(|member| {
+                    let source_name = activation
+                        .instances()
+                        .iter()
+                        .find(|instance| instance.id() == member)
+                        .expect("group member is inventoried")
+                        .source_name();
+                    let body = matches!(member.scope, CompiledSourceScope::CompositionBody(_))
+                        .then(|| body_input.to_vec());
+                    AdmittedSourceOpener::new(
+                        member,
+                        Box::new(FixtureOpener {
+                            label: format!("{}:{source_name}", instance_label(member)),
+                            events: events.clone(),
+                            body,
+                            fail: failing_source == Some(source_name),
+                            request_shutdown: shutdown_on_open
+                                .filter(|(name, _)| *name == source_name)
+                                .map(|(_, token)| token.clone()),
+                        }),
+                    )
+                })
+                .collect();
+            AdmittedActivationGroup::new(
+                group.id(),
+                group.capacity(),
+                sources,
+                Box::new(Reservation {
+                    label: format!("group-{}", group.id().index()),
+                    events: events.clone(),
+                }),
+            )
+        })
+        .collect();
+    AdmittedRunCapabilities::admit(activation, groups).expect("capabilities admit")
+}
+
+fn telemetry_policy() -> clinker_plan::config::ResolvedObservabilityPolicy {
+    ClinkerToml::parse(
+        r#"
+[observability]
+arena_bytes = "64KB"
+ordinary_lane_bytes = "48KB"
+high_severity_lane_bytes = "16KB"
+max_batch_bytes = "8KB"
+max_attributes_per_event = 8
+max_attribute_bytes = "256B"
+drop_policy = "drop_newest"
+sample_every = 1
+rate_limit_per_second = 100000
+rate_limit_burst = 100000
+flush_timeout_ms = 1000
+"#,
+    )
+    .expect("telemetry policy parses")
+    .resolve_observability(None)
+    .expect("telemetry policy resolves")
+}
+
+fn instance_label(instance: CompiledSourceInstanceId) -> String {
+    match instance.scope {
+        CompiledSourceScope::TopLevel => "top-level".to_string(),
+        CompiledSourceScope::CompositionBody(scope) => format!("body-{}", scope.0),
+    }
+}
+
+#[test]
+fn tracer_two_calls_open_distinct_finite_body_source_sessions() {
+    let workspace = workspace(BODY);
+    let plan = compile(workspace.path());
+    let events = Events::default();
+    let capabilities = admitted(&plan, &events, b"H0001\nD0002\n", None, None);
+    let (producer, receiver) =
+        TelemetryArena::reserve(&telemetry_policy()).expect("telemetry arena reserves");
+    let readers = HashMap::from([(
+        "driver".to_string(),
+        SourceInput::Files(vec![FileSlot::new(
+            "driver.csv",
+            Box::new(Cursor::new(b"seed\ngo\n".to_vec())),
+        )]),
+    )]);
+    let first = SharedBuffer::new();
+    let second = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        ("first_out".to_string(), Box::new(first.clone()) as _),
+        ("second_out".to_string(), Box::new(second.clone()) as _),
+    ]);
+
+    let report = PipelineExecutor::run_admitted_plan_with_readers_writers_in_context(
+        &plan,
+        capabilities,
+        readers,
+        writers,
+        &PipelineRunParams {
+            telemetry_producer: Some(producer),
+            ..Default::default()
+        },
+        CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines")),
+    )
+    .expect("body Sources execute");
+
+    assert_eq!(report.counters.ok_count, 4);
+    assert_eq!(report.per_source_record_counts.get("first.read"), Some(&2));
+    assert_eq!(report.per_source_record_counts.get("second.read"), Some(&2));
+    assert!(!report.per_source_record_counts.contains_key("read"));
+    assert!(first.as_string().contains("0001"));
+    assert!(first.as_string().contains('2'));
+    assert!(second.as_string().contains("0001"));
+    assert!(second.as_string().contains('2'));
+    let events = events.snapshot();
+    let opens: Vec<_> = events
+        .iter()
+        .filter(|event| event.starts_with("open:body-"))
+        .collect();
+    let closes: Vec<_> = events
+        .iter()
+        .filter(|event| event.starts_with("close:body-"))
+        .collect();
+    assert_eq!(opens.len(), 2, "{events:?}");
+    assert_eq!(closes.len(), 2, "{events:?}");
+    assert_ne!(
+        opens[0], opens[1],
+        "call sites must keep distinct identities"
+    );
+
+    let mut started = 0;
+    let mut completed = 0;
+    let mut spans = Vec::new();
+    while let Some(batch) = receiver.try_recv_batch() {
+        started += batch.metric(MetricKey::ResourceOpenStarted);
+        completed += batch.metric(MetricKey::ResourceOpenCompleted);
+        spans.extend(
+            batch
+                .traces()
+                .iter()
+                .filter(|span| span.name == SpanName::ResourceOpen)
+                .cloned(),
+        );
+    }
+    assert_eq!(started, 2);
+    assert_eq!(completed, 2);
+    assert_eq!(spans.len(), 2);
+    assert!(spans.iter().all(|span| span.status == SpanStatus::Ok));
+    let mut logical_nodes: Vec<_> = spans
+        .iter()
+        .map(|span| span.logical_node.as_str())
+        .collect();
+    logical_nodes.sort_unstable();
+    assert_eq!(logical_nodes, ["first.read", "second.read"]);
+    let rendered = format!("{spans:?}");
+    assert!(!rendered.contains("shared_input"));
+    assert!(!rendered.contains("logical-input"));
+    assert!(!rendered.contains("H0001"));
+}
+
+fn run_with_fixture(
+    plan: &clinker_plan::plan::CompiledPlan,
+    workspace: &Path,
+    capabilities: AdmittedRunCapabilities,
+    params: &PipelineRunParams,
+) -> (
+    Result<clinker_exec::executor::ExecutionReport, clinker_plan::error::PipelineError>,
+    SharedBuffer,
+    SharedBuffer,
+) {
+    let readers = HashMap::from([(
+        "driver".to_string(),
+        SourceInput::Files(vec![FileSlot::new(
+            "driver.csv",
+            Box::new(Cursor::new(b"seed\ngo\n".to_vec())),
+        )]),
+    )]);
+    let first = SharedBuffer::new();
+    let second = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        ("first_out".to_string(), Box::new(first.clone()) as _),
+        ("second_out".to_string(), Box::new(second.clone()) as _),
+    ]);
+    let result = PipelineExecutor::run_admitted_plan_with_readers_writers_in_context(
+        plan,
+        capabilities,
+        readers,
+        writers,
+        params,
+        CompileContext::with_pipeline_dir(workspace, PathBuf::from("pipelines")),
+    );
+    (result, first, second)
+}
+
+#[test]
+fn body_source_honors_the_retained_unmapped_drop_policy() {
+    let workspace = workspace(CSV_DROP_BODY);
+    let plan = compile(workspace.path());
+    let events = Events::default();
+    let capabilities = admitted(
+        &plan,
+        &events,
+        b"id,extra\none,hidden\ntwo,private\n",
+        None,
+        None,
+    );
+
+    let (result, first, second) = run_with_fixture(
+        &plan,
+        workspace.path(),
+        capabilities,
+        &PipelineRunParams::default(),
+    );
+    let report = result.expect("body CSV Sources execute");
+
+    assert_eq!(report.counters.ok_count, 4);
+    for source in ["first.read", "second.read"] {
+        assert_eq!(report.per_source_record_counts.get(source), Some(&2));
+    }
+    for output in [first.as_string(), second.as_string()] {
+        assert!(output.contains("one"));
+        assert!(output.contains("two"));
+        assert!(!output.contains("extra"));
+        assert!(!output.contains("hidden"));
+        assert!(!output.contains("private"));
+    }
+}
+
+#[test]
+fn partial_group_open_failure_closes_sessions_without_starting_downstream() {
+    let workspace = workspace(INTERLEAVE_BODY);
+    let plan = compile(workspace.path());
+    let events = Events::default();
+    let capabilities = admitted(&plan, &events, b"id\n1\n", Some("right"), None);
+    let (producer, receiver) =
+        TelemetryArena::reserve(&telemetry_policy()).expect("telemetry arena reserves");
+    let params = PipelineRunParams {
+        telemetry_producer: Some(producer),
+        ..Default::default()
+    };
+
+    let (result, first, second) = run_with_fixture(&plan, workspace.path(), capabilities, &params);
+    let error = result.expect_err("second opener fails the complete group");
+    let rendered_error = error.to_string();
+    assert!(rendered_error.contains("admitted Source capability could not be opened"));
+    assert!(!rendered_error.contains("shared_input"));
+    assert!(!rendered_error.contains("logical-input"));
+    assert!(first.as_string().is_empty());
+    assert!(second.as_string().is_empty());
+
+    let events = events.snapshot();
+    let open_left = events
+        .iter()
+        .position(|event| event.contains("open:body-") && event.ends_with(":left"))
+        .expect("left opens");
+    let open_right = events
+        .iter()
+        .position(|event| event.contains("open:body-") && event.ends_with(":right"))
+        .expect("right open is attempted");
+    let close_left = events
+        .iter()
+        .position(|event| event.contains("close:body-") && event.ends_with(":left"))
+        .expect("left session closes");
+    assert!(
+        open_left < open_right && open_right < close_left,
+        "{events:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.starts_with("release:group-"))
+            .count(),
+        plan.dag().source_activation().groups().len(),
+        "every reserved group lease is released: {events:?}"
+    );
+
+    let mut started = 0;
+    let mut completed = 0;
+    let mut failed = 0;
+    let mut spans = Vec::new();
+    while let Some(batch) = receiver.try_recv_batch() {
+        started += batch.metric(MetricKey::ResourceOpenStarted);
+        completed += batch.metric(MetricKey::ResourceOpenCompleted);
+        failed += batch.metric(MetricKey::ResourceOpenFailed);
+        spans.extend(
+            batch
+                .traces()
+                .iter()
+                .filter(|span| span.name == SpanName::ResourceOpen)
+                .cloned(),
+        );
+    }
+    assert_eq!((started, completed, failed), (2, 1, 1));
+    assert_eq!(spans.len(), 2);
+    assert!(spans.iter().any(|span| span.status == SpanStatus::Error));
+}
+
+#[test]
+fn simultaneous_group_opens_every_member_before_body_records_flow() {
+    let workspace = workspace(INTERLEAVE_BODY);
+    let plan = compile(workspace.path());
+    let events = Events::default();
+    let capabilities = admitted(&plan, &events, b"id\n1\n", None, None);
+
+    let (result, first, second) = run_with_fixture(
+        &plan,
+        workspace.path(),
+        capabilities,
+        &PipelineRunParams::default(),
+    );
+    let report = result.expect("simultaneous body Source group executes");
+
+    assert_eq!(report.counters.ok_count, 4);
+    for source in ["first.left", "first.right", "second.left", "second.right"] {
+        assert_eq!(report.per_source_record_counts.get(source), Some(&1));
+    }
+    assert_eq!(first.as_string().lines().count(), 3);
+    assert_eq!(second.as_string().lines().count(), 3);
+    let events = events.snapshot();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.starts_with("open:body-"))
+            .count(),
+        4,
+        "two members open for each distinct call scope: {events:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.starts_with("close:body-"))
+            .count(),
+        4,
+        "every opened session closes: {events:?}"
+    );
+}
+
+#[test]
+fn cancellation_after_open_closes_the_active_session_and_group_lease() {
+    let workspace = workspace(CSV_DROP_BODY);
+    let plan = compile(workspace.path());
+    let events = Events::default();
+    let shutdown = ShutdownToken::detached();
+    let capabilities = admitted(
+        &plan,
+        &events,
+        b"id\none\ntwo\n",
+        None,
+        Some(("read", &shutdown)),
+    );
+    let params = PipelineRunParams {
+        shutdown_token: Some(shutdown),
+        ..Default::default()
+    };
+
+    let (result, _, _) = run_with_fixture(&plan, workspace.path(), capabilities, &params);
+    let report = result.expect("cancellation unwinds cleanly");
+    assert!(report.interrupted);
+    let events = events.snapshot();
+    assert!(events.iter().any(|event| event.starts_with("open:body-")));
+    assert!(events.iter().any(|event| event.starts_with("close:body-")));
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| event.starts_with("release:group-"))
+            .count(),
+        plan.dag().source_activation().groups().len(),
+        "all leases release on cancellation: {events:?}"
+    );
+}

--- a/crates/clinker/src/credential_profile.rs
+++ b/crates/clinker/src/credential_profile.rs
@@ -8,7 +8,10 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use clinker_exec::executor::capabilities::{AdmittedRunCapabilities, RunCapabilityErrorKind};
+use clinker_exec::executor::capabilities::{
+    AdmittedActivationGroup, AdmittedRunCapabilities, AdmittedSourceOpener, CapabilityOpenError,
+    CapabilityOpener, CapabilitySession, RunCapabilityErrorKind,
+};
 use clinker_exec::pipeline::memory::{
     ConsumerHandle, ConsumerId, ConsumerSpillError, MemoryArbitrator, MemoryConsumer,
 };
@@ -118,6 +121,171 @@ pub fn admit_uncredentialed_run_capabilities(
             ActivationAdmissionError::InvalidCompiledActivation
         }
     })
+}
+
+/// Admit a credential-free run with real file-resource factories for every
+/// composition-body Source.
+///
+/// The workspace catalog remains at this application edge. Physical paths are
+/// captured inside opaque single-use factories and never enter `CompiledPlan`
+/// or executor topology.
+#[cfg_attr(test, allow(dead_code))]
+pub fn admit_uncredentialed_run_capabilities_with_catalog(
+    plan: &clinker_plan::plan::CompiledPlan,
+    workspace_root: &std::path::Path,
+    catalog: &clinker_plan::resources::WorkspaceCatalog,
+) -> Result<AdmittedRunCapabilities, ActivationAdmissionError> {
+    let activation = plan.dag().source_activation();
+    if !activation.credential_requirement_ids().is_empty()
+        || activation.groups().iter().any(|group| {
+            !group.credential_requirement_ids().is_empty()
+                || group.capacity().credential_handle_units() != 0
+        })
+    {
+        return Err(ActivationAdmissionError::UnsupportedCredentialPreflight);
+    }
+
+    let groups = activation
+        .groups()
+        .iter()
+        .map(|group| {
+            let sources = group
+                .members()
+                .iter()
+                .copied()
+                .map(|member| {
+                    let instance = activation
+                        .instances()
+                        .iter()
+                        .find(|instance| instance.id() == member)
+                        .ok_or(ActivationAdmissionError::InvalidCompiledActivation)?;
+                    let Some(requirement) = instance.resource() else {
+                        return Ok(AdmittedSourceOpener::caller_supplied(member));
+                    };
+                    let resource = catalog
+                        .resolve_resource(requirement.binding.logical_id())
+                        .map_err(|_| ActivationAdmissionError::InvalidCompiledActivation)?;
+                    let descriptor = resource.descriptor();
+                    let compatible = descriptor.kind() == requirement.kind
+                        && requirement
+                            .required_capabilities
+                            .iter()
+                            .all(|required| descriptor.capabilities().contains(required))
+                        && requirement.opener == requirement.kind.opener_kind()
+                        && requirement.lifetime == requirement.kind.lifetime()
+                        && requirement.dataset_identity == resource.dataset_identity();
+                    if !compatible {
+                        return Err(ActivationAdmissionError::InvalidCompiledActivation);
+                    }
+                    let path = workspace_root.join(descriptor.path());
+                    let provenance = format!(
+                        "{}/{}",
+                        requirement.dataset_identity.namespace, requirement.dataset_identity.name
+                    );
+                    Ok(AdmittedSourceOpener::new(
+                        member,
+                        Box::new(FileResourceOpener { path, provenance }),
+                    ))
+                })
+                .collect::<Result<Vec<_>, ActivationAdmissionError>>()?;
+            Ok(AdmittedActivationGroup::uncredentialed(
+                group.id(),
+                group.capacity(),
+                sources,
+            ))
+        })
+        .collect::<Result<Vec<_>, ActivationAdmissionError>>()?;
+
+    AdmittedRunCapabilities::admit(activation, groups)
+        .map_err(|_| ActivationAdmissionError::InvalidCompiledActivation)
+}
+
+struct FileResourceOpener {
+    path: std::path::PathBuf,
+    provenance: String,
+}
+
+impl CapabilityOpener for FileResourceOpener {
+    fn open(self: Box<Self>) -> Result<Box<dyn CapabilitySession>, CapabilityOpenError> {
+        let (slot, guard) =
+            clinker_exec::source::multi_file::FileSlot::open_file(self.provenance, &self.path)
+                .map_err(|_| CapabilityOpenError::Unavailable)?;
+        Ok(Box::new(FileResourceSession {
+            input: Some(clinker_exec::executor::SourceInput::Files(vec![slot])),
+            _guard: guard,
+        }))
+    }
+}
+
+struct FileResourceSession {
+    input: Option<clinker_exec::executor::SourceInput>,
+    // ActiveActivationGroup retains the session until every member worker has
+    // joined, pinning the admitted file object even after its input transfers.
+    _guard: clinker_format::RetainedFileGuard,
+}
+
+impl CapabilitySession for FileResourceSession {
+    fn take_source_input(
+        &mut self,
+    ) -> Result<clinker_exec::executor::SourceInput, CapabilityOpenError> {
+        self.input.take().ok_or(CapabilityOpenError::Unavailable)
+    }
+}
+
+#[cfg(test)]
+mod file_resource_opener_tests {
+    use std::io::{Read, Write};
+
+    use super::*;
+
+    #[test]
+    fn opened_session_keeps_the_admitted_file_after_path_replacement() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let path = workspace.path().join("orders.csv");
+        let displaced = workspace.path().join("orders.admitted.csv");
+        std::fs::File::create(&path)
+            .expect("create admitted file")
+            .write_all(b"id\noriginal\n")
+            .expect("write admitted file");
+
+        let mut session = Box::new(FileResourceOpener {
+            path: path.clone(),
+            provenance: "clinker-resource:file/orders".to_string(),
+        })
+        .open()
+        .expect("group opener establishes the file session");
+
+        std::fs::rename(&path, &displaced).expect("replace path after group open");
+        std::fs::File::create(&path)
+            .expect("create replacement")
+            .write_all(b"id\nreplacement\n")
+            .expect("write replacement");
+
+        let clinker_exec::executor::SourceInput::Files(mut slots) = session
+            .take_source_input()
+            .expect("transfer admitted source input")
+        else {
+            panic!("file resource session must return file slots");
+        };
+        let slot = slots.pop().expect("one admitted file slot");
+        let mut first_pass = String::new();
+        let mut second_pass = String::new();
+        slot.source
+            .open()
+            .expect("first pass")
+            .read_to_string(&mut first_pass)
+            .expect("read first pass");
+        slot.source
+            .open()
+            .expect("second pass")
+            .read_to_string(&mut second_pass)
+            .expect("read second pass");
+
+        assert_eq!(first_pass, "id\noriginal\n");
+        assert_eq!(second_pass, first_pass);
+        assert_ne!(second_pass, "id\nreplacement\n");
+        drop(session);
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -2802,18 +2802,30 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
     // Validate and retain the runtime activation contract immediately after the
     // effective plan exists and before lineage construction, machine lifecycle
     // writes, worker startup, discovery, staging, or the caller-owned reader /
-    // writer setup below. Runtime opener/group consumption lands separately;
-    // this binary does not yet expose a credential-profile surface, so any
-    // nonempty logical credential set or credential-handle capacity fails
-    // closed here.
-    let admitted_run_capabilities = credential_profile::admit_uncredentialed_run_capabilities(
-        &compiled_plan,
+    // writer setup below. Composition-body file-resource openers are prepared
+    // here and consumed later through the opaque executor bundle. This binary
+    // does not yet expose a credential-profile surface, so any nonempty logical
+    // credential set or credential-handle capacity fails closed here.
+    let activation_catalog = clinker_plan::resources::WorkspaceCatalog::load(
+        compile_ctx.workspace_root(),
+        &catalog_config,
     )
     .map_err(|error| {
-        PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
-            "activation admission failed: {error}"
-        )))
+        PipelineError::Config(clinker_plan::config::ConfigError::Validation(
+            error.to_string(),
+        ))
     })?;
+    let admitted_run_capabilities =
+        credential_profile::admit_uncredentialed_run_capabilities_with_catalog(
+            &compiled_plan,
+            compile_ctx.workspace_root(),
+            &activation_catalog,
+        )
+        .map_err(|error| {
+            PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+                "activation admission failed: {error}"
+            )))
+        })?;
 
     // Resolve every emitted source/output identity before discovery, staging,
     // publication-attempt creation, or lineage-sink opening. A missing or

--- a/crates/clinker/tests/activation_admission.rs
+++ b/crates/clinker/tests/activation_admission.rs
@@ -95,3 +95,98 @@ nodes:
         "id\n1\n2\n"
     );
 }
+
+#[test]
+fn catalog_backed_body_source_runs_through_the_real_cli_factory() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    std::fs::create_dir_all(workspace.path().join("compositions")).expect("composition directory");
+    std::fs::create_dir_all(workspace.path().join("data")).expect("data directory");
+    std::fs::write(workspace.path().join("driver.csv"), "seed\ngo\n").expect("driver fixture");
+    std::fs::write(workspace.path().join("data/orders.txt"), "H0001\nD0002\n")
+        .expect("catalog resource");
+    std::fs::write(
+        workspace.path().join("clinker.toml"),
+        r#"[catalog.resources.orders]
+kind = "file"
+path = "data/orders.txt"
+access = "read"
+"#,
+    )
+    .expect("workspace config");
+    std::fs::write(
+        workspace.path().join("compositions/reader.comp.yaml"),
+        r#"_compose:
+  name: reader
+  inputs: {}
+  outputs: { out: read }
+  config_schema: {}
+  resources_schema:
+    input: { kind: file, required: true }
+nodes:
+  - type: source
+    name: read
+    config:
+      name: read
+      type: fixed_width
+      resource: input
+      on_unmapped: { mode: drop }
+      schema:
+        discriminator: { start: 0, width: 1 }
+        records:
+          - id: header
+            tag: H
+            columns: [{ name: batch, type: string, start: 1, width: 4 }]
+          - id: detail
+            tag: D
+            columns: [{ name: id, type: int, start: 1, width: 4 }]
+"#,
+    )
+    .expect("composition fixture");
+    let pipeline = workspace.path().join("pipeline.yaml");
+    std::fs::write(
+        &pipeline,
+        r#"pipeline: { name: admitted_body_source_cli }
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      path: driver.csv
+      schema: [{ name: seed, type: string }]
+  - type: composition
+    name: read_orders
+    input: driver
+    use: compositions/reader.comp.yaml
+    inputs: {}
+    resources: { input: orders }
+  - type: output
+    name: out
+    input: read_orders
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: false
+"#,
+    )
+    .expect("pipeline fixture");
+
+    let output = Command::new(clinker_bin())
+        .current_dir(workspace.path())
+        .arg("run")
+        .arg(&pipeline)
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        output.status.success(),
+        "catalog-backed body Source must run; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let published =
+        std::fs::read_to_string(workspace.path().join("out.csv")).expect("published output");
+    assert!(published.contains("0001"), "{published:?}");
+    assert!(published.contains('2'), "{published:?}");
+    assert!(!published.contains("orders.txt"));
+}

--- a/docs/ai/80_OPEN_QUESTIONS.md
+++ b/docs/ai/80_OPEN_QUESTIONS.md
@@ -84,9 +84,10 @@ The per-value `fixed`-lock half of this entry is resolved; see the archive.)
 - Priority: Medium
 - Filed: 2026-06-15; updated 2026-07-03 (fixed-lock half landed) and 2026-07-24
   (merged question 9).
-- Documentation status: The user guide documents the implemented planning
-  syntax and states explicitly that credentials and runtime activation have
-  not landed.
+- Documentation status: The user guide documents the planning syntax and the
+  implemented credential-free file-resource activation path. It states
+  explicitly that credential-profile selection and credential-bearing
+  activation have not landed.
 - Status: Resolved
 - Decision: D-12 through D-15
 - Evidence: `docs/ai/15_PRODUCTION_CONTRACTS.md` records D-13/D-14 as implemented and D-12/D-15 as partial; the three focused targets named above exercise current source.

--- a/docs/engine/src/extension-seams.md
+++ b/docs/engine/src/extension-seams.md
@@ -132,10 +132,17 @@ run-local lifetime, and stable logical dataset identity. It deliberately drops
 the catalog's physical path and cannot contain a credential choice, secret,
 live handle, I/O state, or thread state. Separate calls to the same composition
 therefore share immutable logical descriptor semantics but have distinct
-Source identities for later activation.
+Source identities at activation.
 
-Runtime credential resolution and opening are still future preflight work; a
-compiled activation requirement is not an opened Source. See the
+For a data run, the CLI resolves each credential-free `file` requirement back
+to the admitted workspace catalog and captures its validated path inside an
+opaque, single-use factory. The executor receives only the sealed activation
+bundle, takes each complete group lease before opening any member, opens every
+member before publishing a bounded Source channel, and retains the sessions
+until that composition scope ends. A partial open, reader failure, shutdown,
+or ordinary completion closes sessions, releases leases, and unregisters the
+channels' memory consumers. Credential-bearing groups still fail preflight:
+there is no credential-profile selection surface yet. See the
 [composition resources and call-site surface contract](https://github.com/rustpunk/clinker/blob/main/docs/ai/15_PRODUCTION_CONTRACTS.md#composition-resources-and-call-site-surface).
 
 ## Approved transitional exceptions

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -757,8 +757,11 @@ form when the pipeline has compositions.
 > resource slot with `resource: <slot>`; a direct `path`, `glob`, `regex`, or
 > `paths` matcher is rejected. The source patch above changes schema/reader
 > configuration but does not select the resource. Planning binds the slot and
-> compiles a call-scoped Source instance, while a data run through that Source
-> still awaits runtime credential resolution and resource opening.
+> compiles a call-scoped Source instance. On a data run, a credential-free
+> `file` binding opens through the CLI-prepared catalog factory and streams via
+> the executor's bounded Source path. Credential-bearing bindings remain
+> unsupported and fail before opening because no profile-selection surface is
+> available.
 
 When a patch changes the effective source config, the run's pipeline identity
 differs from the base and from other patched variants, so their outputs and

--- a/docs/user/src/pipelines/compositions.md
+++ b/docs/user/src/pipelines/compositions.md
@@ -242,8 +242,14 @@ fingerprint. For each authored body Source, planning compiles a distinct
 call-site-scoped instance carrying only the slot, logical identity, resource
 kind, required capabilities, opener family, run lifetime, provenance, and
 stable logical dataset identity. It does not retain the catalog's physical
-path. Runtime credential resolution and handle activation are separate future
-preflight work; this surface neither selects credentials nor opens the file.
+path. During `clinker run`, the CLI resolves that credential-free `file`
+requirement at the workspace edge and transfers an opaque single-use reader
+factory to the executor. The executor acquires the complete compiled group,
+opens all of its Sources before starting any of them, and streams their finite
+records through the ordinary bounded Source path. An open/read failure or
+interruption closes every opened session and releases the group. This surface
+still does not select credentials: a group requiring credentials fails before
+runtime effects because no credential-profile option exists yet.
 
 Ordinary composition calls do not have `outputs:` or `alias:` fields. Either
 key fails with E377 at its authored location. Use `_compose.outputs` for the


### PR DESCRIPTION
## Summary

- open every resource-backed composition Source before its activation group starts and transfer only admitted reader sessions into execution
- execute top-level and nested body Sources through the common format-reader path while preserving schema, unmapped-record, multi-record, and correlation behavior
- keep each activation group's readers and resource leases alive through group completion, reject unsupported credential-bearing resources before execution side effects, and clean up bounded channels and sessions on every exit
- document the now-supported catalog-backed body Source lifecycle

## Verification

- body Source execution integration tests: 5 passed
- activation admission integration tests: 5 passed
- executor and CLI Clippy with warnings denied
- user and engine documentation builds
- AI documentation consistency check
- `cargo fmt --all --check`
- `git diff --check`

## Obligations

Body Sources now use the compiled logical resource identity supplied by the preceding planner change. Resource-open metrics and completed spans are emitted at the actual open boundary with fixed-cardinality fields. Source channels remain bounded and registered with the existing memory accounting, and all sessions are released on success, error, or interruption.

This landing deliberately rejects nonempty credential requirements because the current compiled resource contract does not yet retain a provider mapping. It does not infer credentials or expose a new selector surface.
