### PR TITLE
Test recursive JSON and XML output contracts

### DIFF
--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -273,6 +273,7 @@ fn build_writer_factory(
     // once so the format arms below read them by their original names.
     let include_header = output.include_header;
     let include_engine_stamped = output.include_correlation_keys;
+    let preserve_nulls = output.preserve_nulls.unwrap_or(false);
     let reconstruct_envelope = output.reconstruct_envelope;
     let include_unmapped = output.include_unmapped;
     let join_values = output.join_values.clone().unwrap_or_default();
@@ -333,6 +334,7 @@ fn build_writer_factory(
         OutputFormat::Json(opts) => {
             let mut json_config = build_json_writer_config(opts.as_ref());
             json_config.include_engine_stamped = include_engine_stamped;
+            json_config.preserve_nulls = preserve_nulls;
             json_config.envelope = resolve_envelope_spec(
                 reconstruct_envelope,
                 opts.as_ref().and_then(|o| o.envelope.as_ref()),
@@ -348,6 +350,7 @@ fn build_writer_factory(
         OutputFormat::Xml(opts) => {
             let mut xml_config = build_xml_writer_config(opts.as_ref());
             xml_config.include_engine_stamped = include_engine_stamped;
+            xml_config.preserve_nulls = preserve_nulls;
             // Per-field repeated-element overrides (`repeat_as` / `wrap_in`); a
             // `multiple:` field with no entry emits bare repeats named after the
             // field. The plan-time E362 gate has already validated the block, so

--- a/crates/clinker-exec/tests/json_nested_write_e2e.rs
+++ b/crates/clinker-exec/tests/json_nested_write_e2e.rs
@@ -12,6 +12,9 @@ use std::collections::HashMap;
 
 use clinker_bench_support::io::SharedBuffer;
 use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+use clinker_plan::config::CompileContext;
+use clinker_plan::error::PipelineError;
+use clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH;
 
 fn params() -> PipelineRunParams {
     PipelineRunParams {
@@ -42,6 +45,87 @@ fn run(pipeline: &str, input: &str) -> String {
     )]);
     common::run_config(&config, json_reader(input), writers, &params()).expect("run succeeds");
     String::from_utf8(buf.contents()).expect("utf-8 output")
+}
+
+fn transformed_pipeline(cxl: &str, preserve_nulls: Option<bool>) -> String {
+    let cxl = cxl
+        .lines()
+        .map(|line| format!("        {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let preserve_nulls = preserve_nulls
+        .map(|value| format!("      preserve_nulls: {value}\n"))
+        .unwrap_or_default();
+    r#"
+pipeline:
+  name: json_nested_cxl
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: ./in.csv
+      options:
+        has_header: true
+      schema:
+        - { name: kind, type: string }
+        - { name: key, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        __CXL__
+  - type: output
+    name: out
+    input: construct
+    config:
+      name: out
+      type: json
+      path: ./out.json
+      include_unmapped: false
+__PRESERVE_NULLS__
+      options:
+        format: ndjson
+"#
+    .replace("        __CXL__", &cxl)
+    .replace("__PRESERVE_NULLS__", &preserve_nulls)
+}
+
+fn run_transformed(
+    cxl: &str,
+    input: &str,
+    preserve_nulls: Option<bool>,
+) -> (Result<(), PipelineError>, SharedBuffer) {
+    let pipeline = transformed_pipeline(cxl, preserve_nulls);
+    let config = clinker_plan::config::parse_config(&pipeline).expect("pipeline parses");
+    let output = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(output.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let result =
+        common::run_config(&config, json_reader_for_rows(input), writers, &params()).map(|_| ());
+    (result, output)
+}
+
+fn json_reader_for_rows(input: &str) -> SourceReaders {
+    HashMap::from([(
+        "rows".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.csv",
+            Box::new(std::io::Cursor::new(input.as_bytes().to_vec())),
+        ),
+    )])
+}
+
+fn nested_map_expression(depth: usize, leaf: &str) -> String {
+    format!("{}{leaf}{}", "{n: ".repeat(depth), "}".repeat(depth))
+}
+
+fn nested_json_value(depth: usize, leaf: &str) -> String {
+    format!("{}{leaf}{}", r#"{"n":"#.repeat(depth), "}".repeat(depth))
 }
 
 const PIPELINE: &str = r#"
@@ -81,5 +165,124 @@ fn nested_json_read_and_written_back_keeps_its_shape() {
         written,
         source.as_array().expect("input array")[0],
         "got: {output}"
+    );
+}
+
+#[test]
+fn cxl_created_json_value_at_the_shared_depth_cap_is_byte_exact() {
+    let expression = nested_map_expression(MAX_NESTED_VALUE_DEPTH, r#""leaf""#);
+    let cxl = format!("emit payload = {expression}");
+
+    let (result, output) = run_transformed(&cxl, "kind,key\nok,n\n", None);
+
+    result.expect("depth-cap value writes");
+    assert_eq!(
+        output.as_string(),
+        format!(
+            r#"{{"payload":{}}}"#,
+            nested_json_value(MAX_NESTED_VALUE_DEPTH, r#""leaf""#)
+        )
+    );
+}
+
+#[test]
+fn cxl_created_json_value_over_the_depth_cap_leaves_no_record_bytes() {
+    let expression = nested_map_expression(MAX_NESTED_VALUE_DEPTH + 1, "null");
+    let cxl = format!("emit payload = {expression}");
+
+    let (result, output) = run_transformed(&cxl, "kind,key\ntoo-deep,n\n", None);
+
+    let error = result.expect_err("cap plus one must fail");
+    assert!(
+        matches!(
+            error,
+            PipelineError::Eval(ref source)
+                if matches!(
+                    source.kind,
+                    cxl::eval::EvalErrorKind::ConstructionDepthExceeded { limit }
+                        if limit == MAX_NESTED_VALUE_DEPTH
+                )
+        ),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        output.contents().is_empty(),
+        "a rejected value cannot leave partial JSON"
+    );
+}
+
+#[test]
+fn json_decodes_reserved_looking_literal_keys_exactly_once() {
+    let cxl = r#"emit payload = {"\\@literal": 1, "\\#text": "body", "\\\\name": true}"#;
+
+    let (result, output) = run_transformed(cxl, "kind,key\nok,unused\n", None);
+
+    result.expect("escaped literal keys write");
+    assert_eq!(
+        output.as_string(),
+        r##"{"payload":{"@literal":1,"#text":"body","\\name":true}}"##
+    );
+}
+
+#[test]
+fn static_and_computed_json_key_collisions_both_fail_without_output() {
+    let static_cxl = r#"emit payload = {"@id": 1, "\\@id": 2}"#;
+    let pipeline = transformed_pipeline(static_cxl, None);
+    let config = clinker_plan::config::parse_config(&pipeline).expect("pipeline YAML parses");
+
+    let diagnostics = config
+        .compile(&CompileContext::default())
+        .expect_err("static logical-key collision must fail compilation");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("duplicate map key \"@id\"")),
+        "unexpected diagnostics: {diagnostics:#?}"
+    );
+
+    let computed_cxl = r#"emit payload = {"@id": 1, [key]: 2}"#;
+    let (result, output) = run_transformed(computed_cxl, "kind,key\ndynamic,@id\n", None);
+    let error = result.expect_err("computed logical-key collision must fail evaluation");
+    assert!(
+        matches!(
+            error,
+            PipelineError::Eval(ref source)
+                if matches!(
+                    &source.kind,
+                    cxl::eval::EvalErrorKind::DuplicateMapKey { key } if key == "@id"
+                )
+        ),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        output.contents().is_empty(),
+        "the computed collision cannot reach the JSON writer"
+    );
+}
+
+#[test]
+fn json_null_policy_defaults_to_omit_and_preserves_nested_null_values() {
+    let cxl = "emit payload = {missing: null, items: [null, \"x\"]}\n\
+               emit absent = if kind == \"ok\" then null else \"present\"";
+
+    let (default_result, defaulted) = run_transformed(cxl, "kind,key\nok,unused\n", None);
+    let (drop_result, dropped) = run_transformed(cxl, "kind,key\nok,unused\n", Some(false));
+    let (keep_result, kept) = run_transformed(cxl, "kind,key\nok,unused\n", Some(true));
+
+    default_result.expect("default null policy writes");
+    drop_result.expect("drop-null JSON writes");
+    keep_result.expect("preserve-null JSON writes");
+    assert_eq!(
+        defaulted.contents(),
+        dropped.contents(),
+        "the omitted option must retain the false default"
+    );
+    assert_eq!(
+        dropped.as_string(),
+        r#"{"payload":{"missing":null,"items":[null,"x"]}}"#
+    );
+    assert_eq!(
+        kept.as_string(),
+        r#"{"payload":{"missing":null,"items":[null,"x"]},"absent":null}"#
     );
 }

--- a/crates/clinker-exec/tests/xml_nested_write_e2e.rs
+++ b/crates/clinker-exec/tests/xml_nested_write_e2e.rs
@@ -1,0 +1,314 @@
+//! Executable-boundary coverage for CXL-created values written as native XML.
+//!
+//! These tests deliberately pass through YAML parsing, CXL compilation and
+//! evaluation, executor dispatch, and the real XML writer factory. Assertions
+//! use exact bytes so wrapper, repetition, null, and record-atomicity behavior
+//! cannot drift independently between those layers.
+
+mod common;
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+use clinker_plan::config::CompileContext;
+use clinker_plan::error::PipelineError;
+use clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH;
+
+fn params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "xml-nested-e2e".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+fn transformed_pipeline(cxl: &str, preserve_nulls: Option<bool>, rename_repeats: bool) -> String {
+    let cxl = cxl
+        .lines()
+        .map(|line| format!("        {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let join_values = if rename_repeats {
+        "      join_values:\n        - { field: tags, repeat_as: Tag, wrap_in: Tags }\n"
+    } else {
+        ""
+    };
+    let preserve_nulls = preserve_nulls
+        .map(|value| format!("      preserve_nulls: {value}\n"))
+        .unwrap_or_default();
+    r#"
+pipeline:
+  name: xml_nested_cxl
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: ./in.csv
+      options:
+        has_header: true
+      schema:
+        - { name: kind, type: string }
+        - { name: key, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        __CXL__
+  - type: output
+    name: out
+    input: construct
+    config:
+      name: out
+      type: xml
+      path: ./out.xml
+      include_unmapped: false
+__PRESERVE_NULLS__
+__JOIN_VALUES__      options:
+        root_element: Feed
+        record_element: Entry
+        attribute_prefix: "@"
+"#
+    .replace("        __CXL__", &cxl)
+    .replace("__PRESERVE_NULLS__", &preserve_nulls)
+    .replace("__JOIN_VALUES__", join_values)
+}
+
+fn reader(input: &str) -> SourceReaders {
+    HashMap::from([(
+        "rows".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.csv",
+            Box::new(std::io::Cursor::new(input.as_bytes().to_vec())),
+        ),
+    )])
+}
+
+fn run_transformed(
+    cxl: &str,
+    input: &str,
+    preserve_nulls: Option<bool>,
+    rename_repeats: bool,
+) -> (Result<(), PipelineError>, SharedBuffer) {
+    let pipeline = transformed_pipeline(cxl, preserve_nulls, rename_repeats);
+    let config = clinker_plan::config::parse_config(&pipeline).expect("pipeline parses");
+    let output = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(output.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let result = common::run_config(&config, reader(input), writers, &params()).map(|_| ());
+    (result, output)
+}
+
+fn nested_map_expression(depth: usize, leaf: &str) -> String {
+    format!("{}{leaf}{}", "{n: ".repeat(depth), "}".repeat(depth))
+}
+
+fn nested_xml_value(depth: usize, leaf: &str) -> String {
+    format!("{}{leaf}{}", "<n>".repeat(depth), "</n>".repeat(depth))
+}
+
+fn contains_format_error(error: &PipelineError) -> bool {
+    match error {
+        PipelineError::Format(_) => true,
+        PipelineError::Multiple(errors) => errors.iter().any(contains_format_error),
+        _ => false,
+    }
+}
+
+#[test]
+fn cxl_created_xml_value_at_the_shared_depth_cap_is_byte_exact() {
+    let expression = nested_map_expression(MAX_NESTED_VALUE_DEPTH, r#""leaf""#);
+    let cxl = format!("emit payload = {expression}");
+
+    let (result, output) = run_transformed(&cxl, "kind,key\nok,n\n", None, false);
+
+    result.expect("depth-cap value writes");
+    assert_eq!(
+        output.as_string(),
+        format!(
+            "<Feed><Entry><payload>{}</payload></Entry></Feed>",
+            nested_xml_value(MAX_NESTED_VALUE_DEPTH, "leaf")
+        )
+    );
+}
+
+#[test]
+fn cxl_created_xml_value_over_the_depth_cap_leaves_no_record_bytes() {
+    let expression = nested_map_expression(MAX_NESTED_VALUE_DEPTH + 1, "null");
+    let cxl = format!("emit payload = {expression}");
+
+    let (result, output) = run_transformed(&cxl, "kind,key\ntoo-deep,n\n", None, false);
+
+    let error = result.expect_err("cap plus one must fail");
+    assert!(
+        matches!(
+            error,
+            PipelineError::Eval(ref source)
+                if matches!(
+                    source.kind,
+                    cxl::eval::EvalErrorKind::ConstructionDepthExceeded { limit }
+                        if limit == MAX_NESTED_VALUE_DEPTH
+                )
+        ),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        output.contents().is_empty(),
+        "a rejected value cannot leave partial XML"
+    );
+}
+
+#[test]
+fn xml_repeats_native_children_and_applies_explicit_wrapper_overrides() {
+    let cxl = r##"emit payload = {"@kind": "event", "#text": "before", item: [{"@id": 1, "#text": "alpha"}, {"@id": 2, "#text": "beta"}], tail: "after"}
+emit tags = ["a", "b"]"##;
+
+    let (result, output) = run_transformed(cxl, "kind,key\nok,unused\n", None, true);
+
+    result.expect("recursive and overridden repeats write");
+    assert_eq!(
+        output.as_string(),
+        r#"<Feed><Entry><payload kind="event">before<item id="1">alpha</item><item id="2">beta</item><tail>after</tail></payload><Tags><Tag>a</Tag><Tag>b</Tag></Tags></Entry></Feed>"#
+    );
+}
+
+#[test]
+fn static_and_computed_xml_reserved_key_collisions_have_parity() {
+    let collision_cases = [
+        (
+            r#"emit payload = {"@id": 1, "\\@id": 2}"#,
+            r#"emit payload = {"@id": 1, [key]: 2}"#,
+            r"\@id",
+            "@id",
+        ),
+        (
+            r##"emit payload = {"#text": "one", "\\#text": "two"}"##,
+            r##"emit payload = {"#text": "one", [key]: "two"}"##,
+            r"\#text",
+            "#text",
+        ),
+    ];
+
+    for (static_cxl, computed_cxl, computed_key, logical_key) in collision_cases {
+        let pipeline = transformed_pipeline(static_cxl, None, false);
+        let config = clinker_plan::config::parse_config(&pipeline).expect("pipeline YAML parses");
+        let diagnostics = config
+            .compile(&CompileContext::default())
+            .expect_err("static logical-key collision must fail compilation");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("duplicate map key")),
+            "unexpected diagnostics for {logical_key:?}: {diagnostics:#?}"
+        );
+
+        let input = format!("kind,key\ndynamic,{computed_key}\n");
+        let (result, output) = run_transformed(computed_cxl, &input, None, false);
+        let error = result.expect_err("computed logical-key collision must fail evaluation");
+        assert!(
+            matches!(
+                error,
+                PipelineError::Eval(ref source)
+                    if matches!(
+                        &source.kind,
+                        cxl::eval::EvalErrorKind::DuplicateMapKey { key }
+                            if key == logical_key
+                    )
+            ),
+            "unexpected error for {logical_key:?}: {error:?}"
+        );
+        assert!(
+            output.contents().is_empty(),
+            "a computed collision cannot reach the XML writer"
+        );
+    }
+}
+
+#[test]
+fn value_dependent_unsupported_xml_shapes_fail_before_record_bytes() {
+    let cases = [
+        (
+            "array inside array",
+            "emit payload = if kind == \"bad\" then [[1]] else [1]",
+            "unused",
+        ),
+        (
+            "collection-valued attribute",
+            r#"emit payload = if kind == "bad" then {"@ids": [1]} else {"@ids": 1}"#,
+            "unused",
+        ),
+        (
+            "collection-valued text",
+            r##"emit payload = if kind == "bad" then {"#text": [1]} else {"#text": "ok"}"##,
+            "unused",
+        ),
+        (
+            "computed invalid element name",
+            r#"emit payload = {[key]: 1}"#,
+            "1bad",
+        ),
+    ];
+
+    for (label, cxl, key) in cases {
+        let input = format!("kind,key\nbad,{key}\n");
+        let (result, output) = run_transformed(cxl, &input, None, false);
+        let error = result.expect_err(label);
+        assert!(
+            contains_format_error(&error),
+            "{label} must surface as a format error: {error:?}"
+        );
+        assert!(
+            output.contents().is_empty(),
+            "{label} cannot leave partial XML"
+        );
+    }
+}
+
+#[test]
+fn a_rejected_second_xml_record_leaves_the_first_record_complete() {
+    let cxl = r#"emit payload = if kind == "good" then {item: [1, 2]} else {"@ids": [1]}"#;
+
+    let (result, output) = run_transformed(cxl, "kind,key\ngood,unused\nbad,unused\n", None, false);
+
+    let error = result.expect_err("the second record has an unsupported XML shape");
+    assert!(contains_format_error(&error), "unexpected error: {error:?}");
+    assert_eq!(
+        output.as_string(),
+        "<Feed><Entry><payload><item>1</item><item>2</item></payload></Entry>",
+        "the rejected second record must add no start tag or body bytes"
+    );
+}
+
+#[test]
+fn xml_null_policy_defaults_to_omit_and_never_emits_null_attributes() {
+    let cxl = r#"emit payload = {"@missing": null, empty: null, items: [null, "x"]}
+emit absent = if kind == "ok" then null else "present""#;
+
+    let (default_result, defaulted) = run_transformed(cxl, "kind,key\nok,unused\n", None, false);
+    let (drop_result, dropped) = run_transformed(cxl, "kind,key\nok,unused\n", Some(false), false);
+    let (keep_result, kept) = run_transformed(cxl, "kind,key\nok,unused\n", Some(true), false);
+
+    default_result.expect("default null policy writes");
+    drop_result.expect("drop-null XML writes");
+    keep_result.expect("preserve-null XML writes");
+    assert_eq!(
+        defaulted.contents(),
+        dropped.contents(),
+        "the omitted option must retain the false default"
+    );
+    assert_eq!(
+        dropped.as_string(),
+        "<Feed><Entry><payload><items>x</items></payload></Entry></Feed>"
+    );
+    assert_eq!(
+        kept.as_string(),
+        "<Feed><Entry><payload><empty/><items/><items>x</items></payload><absent/></Entry></Feed>"
+    );
+}

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -188,6 +188,7 @@ single array (`format: array`, the default) or one object per line
     name: enriched
     type: json
     path: "./output/enriched.json"
+    preserve_nulls: false  # omit null columns; native map/array nulls remain values
     options:
       format: ndjson     # array | ndjson
       pretty: false      # indent the emitted objects
@@ -234,15 +235,33 @@ emit payload = {
 }
 ```
 
-The output contains `"payload"` as an object with an `"items"` array. There is
-no implicit stringification or fallback encoding. Canonically escaped neutral
-keys are decoded before JSON writes them: the CXL key spelling `"\\@literal"`
-writes the JSON key `"@literal"`.
+The output contains `"payload"` as an object with an `"items"` array. Native
+maps and arrays are values, so the default `preserve_nulls: false` does not remove null map
+entries or array items inside them; it controls null output columns and null
+leaves created by dotted-column expansion.
 
-Before writing any bytes for a record, the writer validates all nested keys,
-rejects duplicate logical keys, and enforces the shared 64-container depth
-limit. A failed nested value therefore cannot leave a partial JSON record in
-the output.
+JSON and XML share one neutral-map key grammar. After CXL has decoded the string
+literal, an unescaped key is its ordinary logical spelling. Exactly one leading
+backslash marks a literal reserved-looking key only in these three forms:
+`\@name`, `\#text`, or `\\name`. The neutral decoder removes that one marker.
+In CXL source, where the string literal itself must escape the backslash, write
+`"\\@name"`, `"\\#text"`, or `"\\\\name"`. Other leading-backslash
+forms are non-canonical and fail. JSON assigns no structural role to `@name` or
+`#text`, but it still uses this same decoder: `"\\@literal"` writes the JSON
+key `"@literal"`.
+
+Static and computed map keys follow the same rule. Two authored spellings that
+decode to the same logical key are a duplicate and fail rather than selecting a
+winner. Before writing any bytes for a record, the writer validates the entire
+neutral tree. Scalars have depth zero and each map or array adds one container;
+depth 64 is accepted and depth 65 is rejected. A failed nested value therefore
+cannot leave a partial JSON record in the output.
+
+This recursive behavior is native to JSON/NDJSON and XML. Flat, positional, and
+message formats do not silently turn a map or array into JSON text. Use an
+explicit encoding the destination format declares—such as `join_values` for a
+multi-value flat field—or reshape the value before that output. Without one,
+the structured value is rejected before bytes for that record are written.
 
 ### Keeping a literal `.` in a key
 

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -124,6 +124,7 @@ the way back in.
     name: xml_out
     type: xml
     path: "./output/result.xml"
+    preserve_nulls: false              # omit null elements; null attributes always omit
     options:
       root_element: "Root"              # default Root
       record_element: "Record"          # default Record
@@ -181,6 +182,16 @@ writes:
 <payload kind="event">before<item id="1">alpha</item><item id="2">beta</item><tail>after</tail></payload>
 ```
 
+JSON and XML share one neutral-map key grammar. After CXL string decoding,
+ordinary keys are unescaped. Exactly one leading backslash marks a literal key
+only as `\@name`, `\#text`, or `\\name`, and the neutral decoder removes that
+one marker. Because the CXL string literal must encode the backslash too, the
+source spellings are `"\\@name"`, `"\\#text"`, and `"\\\\name"`.
+Other leading-backslash forms are non-canonical and fail. An escape disables
+XML's attribute or text classification; it does not make the decoded spelling a
+legal XML name. For example, a decoded `@literal` still cannot be an element
+name, while JSON can write it as an ordinary object key.
+
 The rules are deliberately strict:
 
 - Attribute and `#text` values must be scalar or null; maps and arrays there
@@ -188,16 +199,34 @@ The rules are deliberately strict:
 - A direct array inside another array is rejected because XML has no child name
   to repeat. Put the inner array under a map key to supply that name.
 - Every decoded ordinary key and attribute name must be a well-formed XML name.
-  A canonical escape (`"\\@literal"`, `"\\#text"`, or `"\\\\name"` in CXL
-  source) disables the structural role, but it does not make an otherwise
-  illegal XML name legal.
-- Duplicate logical keys, malformed escapes, and values deeper than 64
-  containers reject the whole record before its first byte is emitted. XML
-  never silently falls back to JSON text.
+- Static and computed keys use identical decoding. Two spellings that decode to
+  the same logical key—including attribute-looking or `#text` spellings—are a
+  collision and reject rather than selecting a winner.
+- Scalars have depth zero and each map or array adds one container. Depth 64 is
+  accepted; depth 65, malformed escapes, duplicate logical keys, and invalid
+  names reject the whole record before its first byte is emitted. XML never
+  silently falls back to JSON text.
 
-With `preserve_nulls: false`, null child elements and null array items are
-omitted; with it enabled they emit as self-closing elements. Null attributes
-are always omitted.
+With the default `preserve_nulls: false`, null child elements and null array
+items are omitted; with it enabled they emit as self-closing elements. Null
+attributes are always omitted.
+
+The XML writer is deliberately two-pass per record. Its first borrowed pass
+validates the complete schema/value shape, XML names, and scalar roles before
+writing any bytes for that record. Its second pass streams directly from the
+original record. Authored strings remain borrowed; other scalars are formatted
+in a fixed 128-byte stack scratch buffer. The writer does not clone or
+materialize a second nested tree, and it retains no record values or rendered
+scalar capacity between calls. Its only memoized preparation heap state is the
+schema-derived element plan, whose size is independent of record value widths;
+recursive calls are capped at 64 containers. This is separate from the XML
+reader's optional envelope pre-scan described below.
+
+Native recursion belongs to XML and JSON/NDJSON. Flat, positional, and message
+formats do not stringify maps or arrays implicitly. Declare an encoding that
+the destination supports—such as `join_values` for a multi-value flat
+field—or reshape the value before that output; otherwise the structured value
+is rejected before bytes for that record are written.
 
 ### Writing multi-value fields (repeated elements)
 


### PR DESCRIPTION
## Summary

- exercise recursive JSON and XML output through complete compiled pipelines, including the shared depth boundary, neutral-key decoding, static and computed collisions, XML attributes/text/repeats, and record-level failure atomicity
- propagate the authored `preserve_nulls` option into the native JSON and XML writer configurations while leaving flat and message writers unchanged
- document the exact recursive key grammar, null behavior, failure boundary, and bounded XML emission model

## Verification

- JSON recursive output integration tests: 6 passed
- XML recursive output integration tests: 7 passed
- nested executor parity test: 1 passed
- format symmetry tests: 10 passed
- focused Clippy with warnings denied
- user documentation build
- `cargo fmt --all --check`
- `git diff --check`

## Obligations

The tests cover value and failure behavior without adding runtime state. The registry change only carries an existing compiled option to the native writers, and the preceding XML writer change keeps preparation bounded by schema plus fixed stack scratch. No new execution lifecycle, routing rule, or dataset boundary is introduced, so telemetry and lineage mappings are unchanged.
