### PR TITLE
Make run capacity and bounded preview operational

### DIFF
--- a/crates/clinker-exec/src/executor/context.rs
+++ b/crates/clinker-exec/src/executor/context.rs
@@ -2,13 +2,120 @@
 //! `StableEvalContext` and the static/source-scoped var maps it carries.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
 
 use clinker_record::{PipelineCounters, Value};
 use indexmap::IndexMap;
 
 use clinker_plan::config::PipelineConfig;
 use cxl::eval::{StableEvalContext, WallClock};
+
+use super::{PreviewPolicy, RunPolicy};
+
+/// One run's shared Source limiter and preview policy.
+///
+/// Requiring this pair at Source activation and top-level ingestion keeps the
+/// same limiter and preview decision on every real Source work path.
+#[derive(Clone)]
+pub(crate) struct SourceRuntimePolicy {
+    work: SourceWorkCapacity,
+    preview: PreviewPolicy,
+}
+
+impl SourceRuntimePolicy {
+    pub(super) fn new(run_policy: RunPolicy) -> Self {
+        Self {
+            work: SourceWorkCapacity::new(run_policy.thread_capacity()),
+            preview: run_policy.preview(),
+        }
+    }
+
+    pub(super) const fn preview(&self) -> PreviewPolicy {
+        self.preview
+    }
+
+    pub(super) fn acquire(
+        &self,
+        shutdown: Option<&crate::pipeline::shutdown::ShutdownToken>,
+    ) -> Option<SourceWorkPermit> {
+        self.work.acquire(shutdown)
+    }
+}
+
+/// Run-scoped permit pool for actual Source read work.
+///
+/// Source threads remain independently owned so bounded channel backpressure
+/// and deterministic drain order are unchanged. A permit is held only across
+/// `RecordSource::schema` or `RecordSource::next_record`, never across a
+/// channel send, which prevents a full later-source channel from blocking an
+/// earlier source from acquiring capacity. The pool stores two counters
+/// regardless of the configured limit; it retains no input-sized state.
+#[derive(Clone)]
+struct SourceWorkCapacity {
+    state: Arc<SourceWorkState>,
+}
+
+struct SourceWorkState {
+    available: Mutex<usize>,
+    wake: Condvar,
+}
+
+impl SourceWorkCapacity {
+    pub(super) fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            state: Arc::new(SourceWorkState {
+                available: Mutex::new(capacity.get()),
+                wake: Condvar::new(),
+            }),
+        }
+    }
+
+    pub(super) fn acquire(
+        &self,
+        shutdown: Option<&crate::pipeline::shutdown::ShutdownToken>,
+    ) -> Option<SourceWorkPermit> {
+        let mut available = self
+            .state
+            .available
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        loop {
+            if shutdown.is_some_and(crate::pipeline::shutdown::ShutdownToken::is_requested) {
+                return None;
+            }
+            if *available > 0 {
+                *available -= 1;
+                return Some(SourceWorkPermit {
+                    state: Arc::clone(&self.state),
+                });
+            }
+            let (next, _) = self
+                .state
+                .wake
+                .wait_timeout(available, Duration::from_millis(25))
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            available = next;
+        }
+    }
+}
+
+pub(super) struct SourceWorkPermit {
+    state: Arc<SourceWorkState>,
+}
+
+impl Drop for SourceWorkPermit {
+    fn drop(&mut self) {
+        let mut available = self
+            .state
+            .available
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *available = available.saturating_add(1);
+        self.state.wake.notify_one();
+    }
+}
 
 /// Build the pipeline-stable evaluation context.
 ///
@@ -174,6 +281,38 @@ fn arcs_reachable_from(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn source_work_capacity_one_blocks_a_second_and_two_admits_it() {
+        let capacity = SourceWorkCapacity::new(NonZeroUsize::MIN);
+        let first = capacity.acquire(None).expect("first permit");
+
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let contender = capacity.clone();
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).expect("announce acquire");
+            let permit = contender.acquire(None).expect("third permit");
+            acquired_tx.send(()).expect("announce permit");
+            permit
+        });
+
+        started_rx.recv().expect("contender started");
+        assert!(
+            acquired_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "a second Source work unit must wait at capacity one"
+        );
+        drop(first);
+        acquired_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("released capacity wakes one waiter");
+        drop(worker.join().expect("join contender"));
+
+        let capacity = SourceWorkCapacity::new(NonZeroUsize::new(2).unwrap());
+        let first = capacity.acquire(None).expect("first of two permits");
+        let second = capacity.acquire(None).expect("second of two permits");
+        drop((first, second));
+    }
 
     /// Pipeline `src(in.csv) -> body(transform) -> framed(envelope) -> m(merge)`.
     /// The Merge consumes the Envelope's output. The qualified-source arc map

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1141,6 +1141,8 @@ pub(crate) struct ExecutorContext<'a> {
     /// time when the pipeline run began.
     pub(crate) source_ingestion_timestamp: chrono::NaiveDateTime,
     pub(crate) strategy: ErrorStrategy,
+    /// One resolved policy shared with Source readers and the final report.
+    pub(crate) run_policy: crate::executor::RunPolicy,
 
     // Owned mutable per-walk state.
     pub(crate) node_buffers: HashMap<NodeBufferKey, NodeBuffer>,
@@ -4579,6 +4581,16 @@ pub(crate) fn dispatch_plan_node(
         }
 
         PlanNode::Output { .. } => {
+            if matches!(
+                ctx.run_policy.preview(),
+                crate::executor::PreviewPolicy::ConfigOnly
+            ) {
+                return Err(PipelineError::Internal {
+                    op: "run-policy",
+                    node: node.name().to_string(),
+                    detail: "config-only policy reached Output dispatch".to_string(),
+                });
+            }
             crate::executor::output_dispatch::dispatch_output(ctx, current_dag, node_idx, &node)?;
         }
 

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -20,6 +20,8 @@ use clinker_format::{Column, SourceSchema};
 use clinker_plan::config::PipelineConfig;
 use clinker_plan::error::PipelineError;
 
+use super::context::SourceRuntimePolicy;
+
 /// Whether a format reads its input more than once.
 ///
 /// The envelope pre-scan of a multi-pass format re-opens the source, so its
@@ -404,6 +406,7 @@ pub(super) fn ingest_source(
     stream: crate::executor::source_stream::SourceIngestChannel,
     shutdown_token: Option<crate::pipeline::shutdown::ShutdownToken>,
     progress: Option<crate::progress::RunProgress>,
+    source_runtime: SourceRuntimePolicy,
 ) -> Result<IngestTaskOutcome, PipelineError> {
     use clinker_plan::config::PipelineNode;
 
@@ -422,7 +425,14 @@ pub(super) fn ingest_source(
                 src_cfg.name
             )))
         })?;
-    ingest_source_body(body, input, stream, shutdown_token, progress)
+    ingest_source_body(
+        body,
+        input,
+        stream,
+        shutdown_token,
+        progress,
+        source_runtime,
+    )
 }
 
 /// Ingest one retained Source body through the common finite reader path.
@@ -436,6 +446,7 @@ pub(super) fn ingest_source_body(
     stream: crate::executor::source_stream::SourceIngestChannel,
     shutdown_token: Option<crate::pipeline::shutdown::ShutdownToken>,
     progress: Option<crate::progress::RunProgress>,
+    source_runtime: SourceRuntimePolicy,
 ) -> Result<IngestTaskOutcome, PipelineError> {
     let src_cfg = body.source.clone();
     // Branch once on transport. The file arm builds the
@@ -461,12 +472,18 @@ pub(super) fn ingest_source_body(
             let src_reader = wrap_source_body_with_schema_coercion(raw_reader, &body)?;
             // The file arm reaches the shared driver through the blanket
             // `RecordSource for Box<dyn FormatReader>` impl.
-            drive_record_source(src_cfg, Box::new(src_reader), stream, shutdown_token)
+            drive_record_source(
+                src_cfg,
+                Box::new(src_reader),
+                stream,
+                shutdown_token,
+                source_runtime,
+            )
         }
         // A non-file transport reads no files, so it credits none. The run's
         // file denominator was already withdrawn for this shape.
         crate::source::SourceInput::Records(src_reader) => {
-            drive_record_source(src_cfg, src_reader, stream, shutdown_token)
+            drive_record_source(src_cfg, src_reader, stream, shutdown_token, source_runtime)
         }
     }
 }
@@ -481,6 +498,7 @@ fn drive_record_source(
     src_reader: Box<dyn crate::source::RecordSource>,
     stream: crate::executor::source_stream::SourceIngestChannel,
     shutdown_token: Option<crate::pipeline::shutdown::ShutdownToken>,
+    source_runtime: SourceRuntimePolicy,
 ) -> Result<IngestTaskOutcome, PipelineError> {
     {
         let mut src_reader = src_reader;
@@ -492,7 +510,15 @@ fn drive_record_source(
         if let Some(token) = shutdown_token {
             src_reader.set_shutdown_token(token);
         }
+        // Schema work shares the run capacity, but an already-requested
+        // shutdown is handled by the established graceful-stop check at the
+        // top of the record loop. Turning it into a schema error here would
+        // change a clean interruption into a failed run.
+        let schema_permit = source_runtime
+            .acquire(None)
+            .ok_or(PipelineError::Interrupted)?;
         let reader_schema = src_reader.schema()?;
+        drop(schema_permit);
 
         // Widen the reader schema with `$source.file`, `$source.name`,
         // and `$source.event_time` engine-stamped tail columns. The
@@ -571,6 +597,7 @@ fn drive_record_source(
         let preserve_empty_physical_files = stream.has_order_barrier();
         let mut stream = stream;
         let mut total_count: u64 = 0;
+        let mut read_attempts: u64 = 0;
         let mut watermark_observations: Vec<(Arc<str>, i64)> = Vec::new();
         // First successfully decoded body record for the current physical
         // file, kept together with the exact identity minted for it. A
@@ -613,7 +640,21 @@ fn drive_record_source(
                 interrupted = true;
                 break;
             }
-            match src_reader.next_record() {
+            if source_runtime
+                .preview()
+                .records_per_source()
+                .is_some_and(|limit| read_attempts >= limit.get())
+            {
+                break;
+            }
+            let Some(read_permit) = source_runtime.acquire(shutdown_for_poll.as_ref()) else {
+                interrupted = true;
+                break;
+            };
+            read_attempts = read_attempts.saturating_add(1);
+            let next_record = src_reader.next_record();
+            drop(read_permit);
+            match next_record {
                 Ok(Some(record)) => {
                     total_count =
                         total_count
@@ -1874,7 +1915,17 @@ nodes:
             handle,
             <clinker_plan::plan::PlanNodeId as clinker_plan::plan::EntityRef>::new(0),
         );
-        drive_record_source(src_cfg, reader, stream, None).expect("drive");
+        drive_record_source(
+            src_cfg,
+            reader,
+            stream,
+            None,
+            SourceRuntimePolicy::new(crate::executor::RunPolicy::new(
+                std::num::NonZeroUsize::MIN,
+                crate::executor::PreviewPolicy::Disabled,
+            )),
+        )
+        .expect("drive");
         rx.iter()
             .map(|event| match event {
                 crate::executor::source_stream::SourceStreamEvent::Attempt {
@@ -1913,6 +1964,71 @@ nodes:
                 },
             })
             .collect()
+    }
+
+    #[test]
+    fn preview_stops_before_the_next_record_call_at_its_per_source_limit() {
+        struct CountingReader {
+            schema: Arc<Schema>,
+            calls: Arc<std::sync::atomic::AtomicU64>,
+        }
+
+        impl crate::source::RecordSource for CountingReader {
+            fn schema(&mut self) -> Result<Arc<Schema>, clinker_format::FormatError> {
+                Ok(Arc::clone(&self.schema))
+            }
+
+            fn next_record(
+                &mut self,
+            ) -> Result<Option<clinker_record::Record>, clinker_format::FormatError> {
+                let value = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(Some(clinker_record::Record::new(
+                    Arc::clone(&self.schema),
+                    vec![Value::Integer(value as i64)],
+                )))
+            }
+        }
+
+        let calls = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let schema = SchemaBuilder::with_capacity(1).with_field("id").build();
+        let reader: Box<dyn crate::source::RecordSource> = Box::new(CountingReader {
+            schema,
+            calls: Arc::clone(&calls),
+        });
+        let src_cfg = pathless_source_config();
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let (stream, rx) = crate::executor::source_stream::SourceIngestChannel::new(
+            crate::executor::source_stream::SourceIngestChannel::DEFAULT_CAPACITY,
+            handle,
+            <clinker_plan::plan::PlanNodeId as clinker_plan::plan::EntityRef>::new(0),
+        );
+        drive_record_source(
+            src_cfg,
+            reader,
+            stream,
+            None,
+            SourceRuntimePolicy::new(crate::executor::RunPolicy::new(
+                std::num::NonZeroUsize::MIN,
+                crate::executor::PreviewPolicy::RecordsPerSource(
+                    std::num::NonZeroU64::new(2).unwrap(),
+                ),
+            )),
+        )
+        .expect("bounded preview");
+        let records = rx
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    crate::executor::source_stream::SourceStreamEvent::Attempt {
+                        event: crate::executor::source_stream::SourceAttemptEvent::Record(..),
+                        ..
+                    }
+                )
+            })
+            .count();
+        assert_eq!(records, 2);
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -45,7 +45,7 @@ pub(crate) mod watermark;
 pub(crate) mod window_runtime;
 
 pub use batch_handoff::DEFAULT_BATCH_SIZE;
-use context::build_stable_eval_context;
+use context::{SourceRuntimePolicy, build_stable_eval_context};
 #[cfg(feature = "test-utils")]
 #[doc(hidden)]
 pub use dispatch::DispatchFaultGuard;
@@ -53,7 +53,7 @@ pub use dlq::DlqEntry;
 pub(crate) use dlq::TypeErrorEvent;
 use ingest::{IngestTaskOutcome, ingest_source};
 use params::sum_cpu_io_totals;
-pub use params::{ExecutionReport, PipelineRunParams};
+pub use params::{ExecutionReport, PipelineRunParams, PreviewPolicy, RunPolicy};
 pub use registry::WriterRegistry;
 pub(crate) use registry::build_format_writer;
 pub(crate) use route::CompiledRoute;
@@ -193,6 +193,14 @@ struct DagExecInputs<'a> {
     /// Per-run parameters: execution / batch ids, channel variable
     /// overrides, shutdown token.
     params: &'a PipelineRunParams,
+    /// Resolved scheduler/preview policy for this run.
+    run_policy: RunPolicy,
+}
+
+struct RunExecutionContext<'a> {
+    params: &'a PipelineRunParams,
+    run_policy: RunPolicy,
+    compile_ctx: clinker_plan::config::CompileContext,
 }
 
 /// Owned, run-scoped resources moved through `execute_dag` into
@@ -282,7 +290,29 @@ fn run_capability_error(error: capabilities::RunCapabilityError) -> PipelineErro
     )))
 }
 
+fn build_kernel_pool(
+    run_policy: RunPolicy,
+) -> Result<std::sync::Arc<rayon::ThreadPool>, PipelineError> {
+    let builder = rayon::ThreadPoolBuilder::new().num_threads(run_policy.thread_capacity().get());
+    Ok(std::sync::Arc::new(builder.build().map_err(|error| {
+        PipelineError::ThreadPool(error.to_string())
+    })?))
+}
+
 impl PipelineExecutor {
+    fn configured_run_policy(config: &PipelineConfig) -> RunPolicy {
+        let configured = config
+            .pipeline
+            .concurrency
+            .as_ref()
+            .and_then(|concurrency| concurrency.threads)
+            .and_then(std::num::NonZeroUsize::new);
+        let capacity = configured.unwrap_or_else(|| {
+            std::thread::available_parallelism().unwrap_or(std::num::NonZeroUsize::MIN)
+        });
+        RunPolicy::new(capacity, PreviewPolicy::Disabled)
+    }
+
     /// `&CompiledPlan`-consuming public entry point.
     ///
     /// Accepts the typed `CompiledPlan` handle returned by
@@ -403,21 +433,58 @@ impl PipelineExecutor {
         readers: SourceReaders,
         writers: W,
         params: &PipelineRunParams,
+        compile_ctx: clinker_plan::config::CompileContext,
+    ) -> Result<ExecutionReport, PipelineError> {
+        let run_policy = Self::configured_run_policy(plan.config());
+        Self::run_admitted_plan_with_readers_writers_in_context_with_policy(
+            plan,
+            capabilities,
+            readers,
+            writers,
+            params,
+            run_policy,
+            compile_ctx,
+        )
+    }
+
+    /// Run with one already-resolved scheduler and preview policy.
+    ///
+    /// CLI callers use this entry so the capacity reported after execution is
+    /// the same nonzero value that sizes real kernel and Source-read work.
+    pub fn run_admitted_plan_with_readers_writers_in_context_with_policy<
+        W: Into<WriterRegistry>,
+    >(
+        plan: &clinker_plan::plan::CompiledPlan,
+        capabilities: capabilities::AdmittedRunCapabilities,
+        readers: SourceReaders,
+        writers: W,
+        params: &PipelineRunParams,
+        run_policy: RunPolicy,
         mut compile_ctx: clinker_plan::config::CompileContext,
     ) -> Result<ExecutionReport, PipelineError> {
+        if matches!(run_policy.preview(), PreviewPolicy::ConfigOnly) {
+            return Err(PipelineError::Internal {
+                op: "run-policy",
+                node: "pipeline".to_string(),
+                detail: "config-only policy must stop before executor entry".to_string(),
+            });
+        }
         capabilities
             .ensure_matches(plan.dag().source_activation())
             .map_err(run_capability_error)?;
         compile_ctx.cxl_modules = plan.cxl_modules().clone();
+        let source_runtime = SourceRuntimePolicy::new(run_policy);
         let source_activation = source_activation::SourceActivationController::new(
             plan.dag().source_activation().clone(),
             capabilities,
+            source_runtime,
         );
         Self::run_with_readers_writers_in_context_and_activation(
             plan.config(),
             readers,
             writers.into(),
             params,
+            run_policy,
             compile_ctx,
             Some(source_activation),
         )
@@ -437,16 +504,22 @@ impl PipelineExecutor {
             .ensure_matches(plan.dag().source_activation())
             .map_err(run_capability_error)?;
         compile_ctx.cxl_modules = plan.cxl_modules().clone();
+        let run_policy = Self::configured_run_policy(plan.config());
+        let source_runtime = SourceRuntimePolicy::new(run_policy);
         let source_activation = source_activation::SourceActivationController::new(
             plan.dag().source_activation().clone(),
             capabilities,
+            source_runtime,
         );
         Self::run_with_readers_writers_with_arbitrator_and_activation(
             plan.config(),
             readers,
             writers,
-            params,
-            compile_ctx,
+            RunExecutionContext {
+                params,
+                run_policy,
+                compile_ctx,
+            },
             memory_budget,
             Some(source_activation),
         )
@@ -511,11 +584,13 @@ impl PipelineExecutor {
         params: &PipelineRunParams,
         compile_ctx: clinker_plan::config::CompileContext,
     ) -> Result<ExecutionReport, PipelineError> {
+        let run_policy = Self::configured_run_policy(config);
         Self::run_with_readers_writers_in_context_and_activation(
             config,
             readers,
             writers,
             params,
+            run_policy,
             compile_ctx,
             None,
         )
@@ -526,6 +601,7 @@ impl PipelineExecutor {
         readers: SourceReaders,
         writers: WriterRegistry,
         params: &PipelineRunParams,
+        run_policy: RunPolicy,
         compile_ctx: clinker_plan::config::CompileContext,
         source_activation: Option<source_activation::SourceActivationController>,
     ) -> Result<ExecutionReport, PipelineError> {
@@ -569,8 +645,11 @@ impl PipelineExecutor {
             config,
             readers,
             writers,
-            params,
-            compile_ctx,
+            RunExecutionContext {
+                params,
+                run_policy,
+                compile_ctx,
+            },
             memory_budget,
             source_activation,
         )
@@ -595,12 +674,16 @@ impl PipelineExecutor {
         compile_ctx: clinker_plan::config::CompileContext,
         memory_budget: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
     ) -> Result<ExecutionReport, PipelineError> {
+        let run_policy = Self::configured_run_policy(config);
         Self::run_with_readers_writers_with_arbitrator_and_activation(
             config,
             readers,
             writers,
-            params,
-            compile_ctx,
+            RunExecutionContext {
+                params,
+                run_policy,
+                compile_ctx,
+            },
             memory_budget,
             None,
         )
@@ -610,17 +693,36 @@ impl PipelineExecutor {
         config: &PipelineConfig,
         mut readers: SourceReaders,
         writers: WriterRegistry,
-        params: &PipelineRunParams,
-        compile_ctx: clinker_plan::config::CompileContext,
+        run: RunExecutionContext<'_>,
         memory_budget: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
         source_activation: Option<source_activation::SourceActivationController>,
     ) -> Result<ExecutionReport, PipelineError> {
+        let RunExecutionContext {
+            params,
+            run_policy,
+            compile_ctx,
+        } = run;
         let started_at = Utc::now();
         let output_staging = writers.output_staging.clone();
         let auto_commit_staged = writers.auto_commit_staged;
 
         let source_configs: Vec<_> = config.source_configs().cloned().collect();
-        let output_configs: Vec<_> = config.output_configs().cloned().collect();
+        let mut output_configs: Vec<_> = config.output_configs().cloned().collect();
+        if !run_policy.preview().publishes_configured_outputs() {
+            if auto_commit_staged || output_staging.has_run_attempt() {
+                return Err(PipelineError::Internal {
+                    op: "run-policy",
+                    node: "pipeline".to_string(),
+                    detail: "preview received a publication-capable writer registry".to_string(),
+                });
+            }
+            // Preview uses the authored format but one explicit preview
+            // destination. Split policy names configured Sink paths, so it is
+            // disabled on this run-local clone before writer construction.
+            for output in &mut output_configs {
+                output.split = None;
+            }
+        }
         if source_configs.is_empty() {
             return Err(PipelineError::Config(
                 clinker_plan::config::ConfigError::Validation(
@@ -802,6 +904,10 @@ impl PipelineExecutor {
         // twice, so the count would overrun the total.
         let mut files_total: Option<u64> = Some(0);
         let mut bytes_total: Option<u64> = Some(0);
+        let source_runtime = source_activation.as_ref().map_or_else(
+            || SourceRuntimePolicy::new(run_policy),
+            source_activation::SourceActivationController::source_runtime,
+        );
         for src_cfg in &source_configs {
             let Some(source_input) = readers.get(&src_cfg.name) else {
                 continue; // The loop below reports the missing reader.
@@ -955,6 +1061,7 @@ impl PipelineExecutor {
             // it (dropped-receiver stop suffices).
             let ingest_shutdown = params.shutdown_token.clone();
             let ingest_progress = params.progress.clone();
+            let ingest_source_runtime = source_runtime.clone();
             // One OS thread per Source. Spawned before the DAG dispatch
             // drains so the producers fill the bounded channels while the
             // consumer dispatch loop runs concurrently. Joined after
@@ -969,6 +1076,7 @@ impl PipelineExecutor {
                         stream,
                         ingest_shutdown,
                         ingest_progress,
+                        ingest_source_runtime,
                     )
                 })
                 .map_err(|e| PipelineError::Internal {
@@ -987,6 +1095,7 @@ impl PipelineExecutor {
                 composition_bodies: validated_plan.composition_bodies(),
                 statistics: validated_plan.statistics(),
                 params,
+                run_policy,
             },
             DagExecResources {
                 source_activation,
@@ -1231,6 +1340,7 @@ impl PipelineExecutor {
             composition_bodies,
             statistics,
             params,
+            run_policy,
         } = inputs;
         let DagExecResources {
             source_activation,
@@ -1249,7 +1359,12 @@ impl PipelineExecutor {
         // removes it on drop — the path and the liveness guard cannot diverge.
         let spill_root_path: Arc<std::path::Path> = Arc::from(spill_root.path());
 
-        let output_configs: Vec<_> = config.output_configs().cloned().collect();
+        let mut output_configs: Vec<_> = config.output_configs().cloned().collect();
+        if !run_policy.preview().publishes_configured_outputs() {
+            for output in &mut output_configs {
+                output.split = None;
+            }
+        }
         let pipeline_start_time = chrono::Local::now().naive_local();
 
         // Pipeline-stable evaluation context. Built once here, reused
@@ -1383,13 +1498,24 @@ impl PipelineExecutor {
         // matching Transform `NodeIndex`es so the Transform arm can
         // dispatch into the streaming branch instead of consuming a
         // pre-drained Vec from `node_buffers`.
-        let (extra_fused_sources, fused_transforms) =
+        let (extra_fused_sources, mut fused_transforms) =
             clinker_plan::plan::execution::compute_transform_fused_sources(
                 plan,
                 &fused_sources,
                 &init_phase_set,
             );
         fused_sources.extend(extra_fused_sources);
+        let preview_streaming_contracts = run_policy
+            .preview()
+            .records_per_source()
+            .map(|_| fused_transforms.clone());
+        if run_policy.preview().records_per_source().is_some() {
+            // Preview drains Sources in deterministic DAG/declaration order.
+            // Interleave/fused receivers deliberately race ready inputs, which
+            // is correct for a real run but not for a reproducible preview.
+            fused_sources.clear();
+            fused_transforms.clear();
+        }
 
         // Streaming Aggregate-ingest edges (issue #299). Each entry is a
         // `producer → Aggregate` edge whose ingest streams: the producer
@@ -1403,7 +1529,10 @@ impl PipelineExecutor {
         let streaming_aggregate_ingest_edges: HashMap<
             petgraph::graph::NodeIndex,
             petgraph::graph::NodeIndex,
-        > = if config.any_source_has_correlation_key() || any_document_dlq {
+        > = if config.any_source_has_correlation_key()
+            || any_document_dlq
+            || run_policy.preview().records_per_source().is_some()
+        {
             HashMap::new()
         } else {
             clinker_plan::plan::execution::compute_streaming_aggregate_ingest_edges(
@@ -1425,7 +1554,10 @@ impl PipelineExecutor {
         let streaming_combine_probe_edges: HashMap<
             petgraph::graph::NodeIndex,
             petgraph::graph::NodeIndex,
-        > = if config.any_source_has_correlation_key() || any_document_dlq {
+        > = if config.any_source_has_correlation_key()
+            || any_document_dlq
+            || run_policy.preview().records_per_source().is_some()
+        {
             HashMap::new()
         } else {
             clinker_plan::plan::execution::compute_streaming_combine_probe_edges(
@@ -1437,23 +1569,10 @@ impl PipelineExecutor {
 
         // Shared Rayon pool for the CPU-bound owned-input kernels (sort,
         // grace-hash partition build, IEJoin, sort-merge). Sized off the
-        // pipeline's `concurrency.threads` knob; `0`/absent defers to
-        // Rayon's default (one worker per logical CPU). Built once per
+        // run's resolved nonzero thread capacity. Built once per
         // run and shared via `Arc` so every kernel `install` reuses the
         // same worker set rather than spinning up a pool per operator.
-        let kernel_pool = {
-            let mut builder = rayon::ThreadPoolBuilder::new();
-            if let Some(n) = config.pipeline.concurrency.as_ref().and_then(|c| c.threads)
-                && n > 0
-            {
-                builder = builder.num_threads(n);
-            }
-            std::sync::Arc::new(
-                builder
-                    .build()
-                    .map_err(|e| PipelineError::ThreadPool(e.to_string()))?,
-            )
-        };
+        let kernel_pool = build_kernel_pool(run_policy)?;
 
         // Streaming-Output setup (issue #72). For every fused
         // `Merge.interleave → single Output` chain that satisfies the
@@ -1465,10 +1584,18 @@ impl PipelineExecutor {
         // `JoinHandle`s are stored on the context so the dispatcher can
         // join them at end-of-DAG and fold the per-thread counter /
         // timer / error accounting back into the context.
+        // Preview preserves the plan's compiled writer boundary even though it
+        // disables race-driven producer fusion above. A certified streaming
+        // writer then drains the producer's deterministic materialized order;
+        // treating that boundary as records-only would violate the compiled
+        // plan instead of making the preview deterministic.
+        let streaming_contracts = preview_streaming_contracts
+            .as_ref()
+            .unwrap_or(&fused_transforms);
         let streaming_specs = compute_streaming_output_specs(
             plan,
             config,
-            &fused_transforms,
+            streaming_contracts,
             &init_phase_set,
             &output_configs,
             &writers,
@@ -1544,6 +1671,7 @@ impl PipelineExecutor {
             source_count_per_source,
             source_ingestion_timestamp,
             strategy,
+            run_policy,
 
             node_buffers: HashMap::new(),
             node_buffer_consumer_ids: HashMap::new(),
@@ -2023,6 +2151,18 @@ mod tests {
     //! in-crate symbols.
 
     use super::*;
+
+    #[test]
+    fn run_policy_capacity_sizes_the_kernel_pool() {
+        for capacity in [1, 2] {
+            let policy = RunPolicy::new(
+                std::num::NonZeroUsize::new(capacity).unwrap(),
+                PreviewPolicy::Disabled,
+            );
+            let pool = build_kernel_pool(policy).expect("build kernel pool");
+            assert_eq!(pool.current_num_threads(), policy.thread_capacity().get());
+        }
+    }
 
     #[test]
     fn route_dispatch_mismatch_returns_typed_error() {

--- a/crates/clinker-exec/src/executor/params.rs
+++ b/crates/clinker-exec/src/executor/params.rs
@@ -2,12 +2,73 @@
 //! execution report.
 
 use std::collections::BTreeMap;
+use std::num::{NonZeroU64, NonZeroUsize};
 
 use chrono::{DateTime, Utc};
 use clinker_record::{PipelineCounters, Value};
 use indexmap::IndexMap;
 
 use super::{DlqEntry, stage_metrics};
+
+/// Whether an admitted run executes normally or reads a bounded preview.
+///
+/// The per-source bound is nonzero by construction and is checked immediately
+/// before each `RecordSource::next_record` call. This keeps a preview from
+/// reading one row ahead of the limit, including for composition-body Sources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewPolicy {
+    /// Execute the complete finite pipeline and publish configured outputs.
+    Disabled,
+    /// Compile and preflight only. This mode never enters the executor.
+    ConfigOnly,
+    /// Execute at most this many records from each declared Source.
+    RecordsPerSource(NonZeroU64),
+}
+
+impl PreviewPolicy {
+    /// Return the read bound for a bounded preview.
+    pub fn records_per_source(self) -> Option<NonZeroU64> {
+        match self {
+            Self::RecordsPerSource(limit) => Some(limit),
+            Self::Disabled | Self::ConfigOnly => None,
+        }
+    }
+
+    /// Whether configured output publication is permitted.
+    pub fn publishes_configured_outputs(self) -> bool {
+        matches!(self, Self::Disabled)
+    }
+}
+
+/// Fully resolved execution policy shared by scheduler, readers, and report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RunPolicy {
+    thread_capacity: NonZeroUsize,
+    preview: PreviewPolicy,
+}
+
+impl RunPolicy {
+    /// Construct a policy from already-validated, nonzero CLI/config values.
+    pub const fn new(thread_capacity: NonZeroUsize, preview: PreviewPolicy) -> Self {
+        Self {
+            thread_capacity,
+            preview,
+        }
+    }
+
+    /// Independent cap for CPU workers and concurrent Source read calls.
+    ///
+    /// This is not a combined operating-system thread limit: Source workers
+    /// remain distinct from the Rayon kernel pool.
+    pub const fn thread_capacity(self) -> NonZeroUsize {
+        self.thread_capacity
+    }
+
+    /// Preview/publication behavior for this run.
+    pub const fn preview(self) -> PreviewPolicy {
+        self.preview
+    }
+}
 
 /// Runtime parameters for a pipeline execution (not derived from config YAML).
 #[derive(Default)]

--- a/crates/clinker-exec/src/executor/source_activation.rs
+++ b/crates/clinker-exec/src/executor/source_activation.rs
@@ -11,6 +11,7 @@ use clinker_plan::plan::execution::{
 };
 
 use super::capabilities::{ActiveActivationGroup, AdmittedRunCapabilities, RunCapabilityError};
+use super::context::SourceRuntimePolicy;
 use super::ingest::{IngestTaskOutcome, ingest_source_body};
 use super::source_stream::{SourceConsumer, SourceIngestChannel, SourceStreamEvent};
 use crate::pipeline::memory::{ConsumerHandle, ConsumerId, MemoryArbitrator};
@@ -43,15 +44,25 @@ pub(crate) struct SourceActivationController {
     plan: SourceActivationPlan,
     capabilities: AdmittedRunCapabilities,
     active: BTreeMap<SourceActivationGroupId, ActiveGroupRuntime>,
+    source_runtime: SourceRuntimePolicy,
 }
 
 impl SourceActivationController {
-    pub(crate) fn new(plan: SourceActivationPlan, capabilities: AdmittedRunCapabilities) -> Self {
+    pub(crate) fn new(
+        plan: SourceActivationPlan,
+        capabilities: AdmittedRunCapabilities,
+        source_runtime: SourceRuntimePolicy,
+    ) -> Self {
         Self {
             plan,
             capabilities,
             active: BTreeMap::new(),
+            source_runtime,
         }
+    }
+
+    pub(crate) fn source_runtime(&self) -> SourceRuntimePolicy {
+        self.source_runtime.clone()
     }
 
     /// Activate the complete group containing `instance`, exactly once.
@@ -133,11 +144,18 @@ impl SourceActivationController {
                 .consumers
                 .push((source_name.clone(), (consumer_id, handle)));
             let worker_shutdown = shutdown.clone();
+            let source_runtime = self.source_runtime.clone();
             let spawn = std::thread::Builder::new()
                 .name(format!("clinker-body-source-{source_name}"))
                 .spawn(move || {
-                    let mut outcome =
-                        ingest_source_body(body, input, stream, worker_shutdown, None)?;
+                    let mut outcome = ingest_source_body(
+                        body,
+                        input,
+                        stream,
+                        worker_shutdown,
+                        None,
+                        source_runtime,
+                    )?;
                     outcome.source_name = logical_source_name;
                     Ok(outcome)
                 });

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -508,6 +508,28 @@ pub enum MachineFormat {
     NdjsonV1,
 }
 
+/// Closed logging levels accepted by `clinker run`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<LogLevel> for tracing_subscriber::filter::LevelFilter {
+    fn from(level: LogLevel) -> Self {
+        match level {
+            LogLevel::Error => Self::ERROR,
+            LogLevel::Warn => Self::WARN,
+            LogLevel::Info => Self::INFO,
+            LogLevel::Debug => Self::DEBUG,
+            LogLevel::Trace => Self::TRACE,
+        }
+    }
+}
+
 /// Arguments for `clinker run`.
 #[derive(Parser, Debug)]
 pub struct RunArgs {
@@ -518,13 +540,9 @@ pub struct RunArgs {
     #[arg(long = "memory-limit", help_heading = "Execution")]
     pub mem_limit: Option<String>,
 
-    /// Thread pool size, default num_cpus
+    /// CPU-kernel and Source-read capacity (independent caps), default CPUs
     #[arg(long, help_heading = "Execution")]
-    pub threads: Option<usize>,
-
-    /// Max DLQ records before abort, 0 = unlimited
-    #[arg(long, default_value = "0", help_heading = "Execution")]
-    pub error_threshold: u64,
+    pub threads: Option<std::num::NonZeroUsize>,
 
     /// Pipeline batch_id, default generated UUID v7
     #[arg(long, help_heading = "Execution")]
@@ -575,15 +593,30 @@ pub struct RunArgs {
     pub lineage_events: Option<PathBuf>,
 
     /// Validate config and CXL without processing data
-    #[arg(long, help_heading = "Validation")]
+    #[arg(
+        long,
+        help_heading = "Validation",
+        conflicts_with_all = ["machine", "explain", "lineage", "lineage_events"]
+    )]
     pub dry_run: bool,
 
     /// Process only first N records per input (requires --dry-run)
-    #[arg(short = 'n', long, help_heading = "Validation")]
-    pub dry_run_n: Option<u64>,
+    #[arg(
+        short = 'n',
+        long,
+        help_heading = "Validation",
+        requires = "dry_run",
+        conflicts_with_all = ["machine", "explain", "lineage", "lineage_events"]
+    )]
+    pub dry_run_n: Option<std::num::NonZeroU64>,
 
     /// Write dry-run output to file instead of stdout
-    #[arg(long, help_heading = "Validation")]
+    #[arg(
+        long,
+        help_heading = "Validation",
+        requires = "dry_run_n",
+        conflicts_with_all = ["machine", "explain", "lineage", "lineage_events"]
+    )]
     pub dry_run_output: Option<PathBuf>,
 
     /// CXL module search path
@@ -611,8 +644,8 @@ pub struct RunArgs {
     pub force: bool,
 
     /// Log level: error, warn, info, debug, trace
-    #[arg(long, default_value = "info", help_heading = "Output")]
-    pub log_level: String,
+    #[arg(long, default_value = "info", value_enum, help_heading = "Output")]
+    pub log_level: LogLevel,
 
     /// Directory to spool per-execution JSON metrics files.
     /// Overrides CLINKER_METRICS_SPOOL_DIR env var and pipeline.metrics.spool_dir in YAML.
@@ -637,6 +670,76 @@ pub struct RunArgs {
     /// overlays apply.
     #[arg(long = "no-auto-groups", help_heading = "Configuration")]
     pub no_auto_groups: bool,
+}
+
+/// Cloneable handle to the one explicit preview destination.
+///
+/// Multiple terminal nodes may format into the preview stream, but no handle
+/// points at an authored output path. The mutex is bounded run state (one
+/// writer regardless of input volume) and serialization keeps preview bytes in
+/// deterministic dispatch order.
+#[derive(Clone)]
+struct SharedPreviewWriter(std::sync::Arc<std::sync::Mutex<Box<dyn std::io::Write + Send>>>);
+
+impl std::io::Write for SharedPreviewWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .write(bytes)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .flush()
+    }
+}
+
+fn preview_writer_registry(
+    destination: Option<&std::path::Path>,
+    config: &clinker_plan::config::PipelineConfig,
+    dag: &clinker_plan::plan::execution::ExecutionPlanDag,
+    source_files: &std::collections::HashMap<String, Vec<std::path::PathBuf>>,
+) -> Result<clinker_exec::executor::WriterRegistry, PipelineError> {
+    let destination: Box<dyn std::io::Write + Send> = match destination {
+        Some(path) => Box::new(std::fs::File::create(path).map_err(PipelineError::Io)?),
+        None => Box::new(std::io::stdout()),
+    };
+    let shared = SharedPreviewWriter(std::sync::Arc::new(std::sync::Mutex::new(destination)));
+    let mut single = std::collections::HashMap::new();
+    let mut fan_out = std::collections::HashMap::new();
+    for output in config.output_configs() {
+        if output_is_fan_out(dag, &output.name) {
+            let upstream = upstream_source_for_output(dag, &output.name);
+            let mut per_file = std::collections::HashMap::new();
+            for path in upstream
+                .as_ref()
+                .and_then(|source| source_files.get(source))
+                .into_iter()
+                .flatten()
+            {
+                per_file.insert(
+                    std::sync::Arc::from(path.to_string_lossy().into_owned()),
+                    Box::new(shared.clone()) as Box<dyn std::io::Write + Send>,
+                );
+            }
+            fan_out.insert(output.name.clone(), per_file);
+        } else {
+            single.insert(
+                output.name.clone(),
+                Box::new(shared.clone()) as Box<dyn std::io::Write + Send>,
+            );
+        }
+    }
+    Ok(clinker_exec::executor::WriterRegistry {
+        single,
+        fan_out,
+        fan_out_paths: std::collections::HashMap::new(),
+        output_staging: Default::default(),
+        auto_commit_staged: false,
+    })
 }
 
 impl RunArgs {
@@ -1010,16 +1113,23 @@ fn main() -> ExitCode {
                 u8::try_from(error.exit_code()).unwrap_or(1)
             };
             let _ = error.print();
+            if std::env::args_os().any(|arg| {
+                arg == "--error-threshold"
+                    || arg
+                        .to_str()
+                        .is_some_and(|value| value.starts_with("--error-threshold="))
+            }) {
+                eprintln!(
+                    "Correction: configure `error_handling.type_error_threshold` in pipeline YAML:\nerror_handling:\n  type_error_threshold: 0.05"
+                );
+            }
             return ExitCode::from(exit_code);
         }
     };
 
     match &cli.command {
         Commands::Run(args) => {
-            let filter = args
-                .log_level
-                .parse::<tracing_subscriber::filter::LevelFilter>()
-                .unwrap_or(tracing_subscriber::filter::LevelFilter::INFO);
+            let filter = tracing_subscriber::filter::LevelFilter::from(args.log_level);
             // Diagnostics move to stderr exactly when standard output is
             // carrying data a consumer parses: the machine stream, a lineage
             // export addressed to `-`, or an explain document in one of the
@@ -1028,6 +1138,7 @@ fn main() -> ExitCode {
             // stdout, where the run's own completion summary is reported and
             // where callers already expect to read it.
             let stdout_carries_data = args.machine.is_some()
+                || (args.dry_run_n.is_some() && args.dry_run_output.is_none())
                 || matches!(args.explain, Some(ExplainFormat::Json | ExplainFormat::Dot))
                 || [args.lineage.as_deref(), args.lineage_events.as_deref()]
                     .into_iter()
@@ -2294,6 +2405,7 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
             ),
         ));
     }
+    let run_policy = resolve_run_policy(args, &pipeline_config);
 
     let mut compile_ctx =
         clinker_plan::config::CompileContext::with_pipeline_dir(workspace_root, pipeline_dir);
@@ -2716,15 +2828,6 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
         return Ok(0);
     }
 
-    // Validate -n only valid with --dry-run
-    if args.dry_run_n.is_some() && !args.dry_run {
-        return Err(PipelineError::Config(
-            clinker_plan::config::ConfigError::Validation(
-                "-n/--dry-run-n requires --dry-run flag".to_string(),
-            ),
-        ));
-    }
-
     // Resolve spool directory (CLI > env > YAML)
     let yaml_spool = pipeline_config
         .pipeline
@@ -2872,7 +2975,10 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
         }
     }
 
-    if args.dry_run && args.dry_run_n.is_none() {
+    if matches!(
+        run_policy.preview(),
+        clinker_exec::executor::PreviewPolicy::ConfigOnly
+    ) {
         // Compile-validation mode (no -n): the plan and any channel/group
         // overlay are fully checked, but runtime source discovery, reader and
         // writer setup, and record processing do not begin. Compilation may
@@ -2910,6 +3016,12 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
         .map(MachineEmitter::start_execution_progress)
         .transpose()
         .map_err(PipelineError::Io)?;
+    #[cfg(feature = "otlp")]
+    if run_policy.preview().records_per_source().is_some() {
+        // Preview is an authoring check, not a published pipeline run. It
+        // produces no run-lifecycle telemetry and reserves no signal arena.
+        otlp_runtime = None;
+    }
     #[cfg(feature = "otlp")]
     let telemetry_handles = otlp_runtime
         .as_ref()
@@ -3230,6 +3342,46 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
             source_name,
             clinker_exec::executor::SourceInput::Files(slots),
         );
+    }
+
+    if run_policy.preview().records_per_source().is_some() {
+        // The preview registry is admitted before the normal publication
+        // branch and contains no authored destination, attempt ledger, split
+        // path, or auto-commit capability. Output dispatch can therefore use
+        // the authored formats without opening or publishing any configured
+        // Sink path.
+        let registry = preview_writer_registry(
+            args.dry_run_output.as_deref(),
+            &pipeline_config,
+            compiled_plan.dag(),
+            &source_files_by_name,
+        )?;
+        let preview_params = clinker_exec::executor::PipelineRunParams {
+            execution_id: execution_id.clone(),
+            batch_id: batch_id.clone(),
+            pipeline_vars: effective_runtime_variables.pipeline_vars.clone(),
+            static_vars: effective_runtime_variables.static_vars.clone(),
+            source_vars: effective_runtime_variables.source_vars.clone(),
+            record_vars: effective_runtime_variables.record_vars.clone(),
+            telemetry_producer: None,
+            progress: None,
+            shutdown_token: Some(shutdown_token.clone()),
+            spill_root_dir: spill_root_dir.clone(),
+            spill_disk_cap_bytes,
+            spill_compress: storage_config.spill.compress,
+        };
+        let report =
+            PipelineExecutor::run_admitted_plan_with_readers_writers_in_context_with_policy(
+                &compiled_plan,
+                admitted_run_capabilities,
+                readers,
+                registry,
+                &preview_params,
+                run_policy,
+                compile_ctx.without_overlay_ops(),
+            )?;
+        source_stager.cleanup(true);
+        return Ok(if report.dlq_entries.is_empty() { 0 } else { 2 });
     }
 
     // Every output writes to a hidden destination-local leaf admitted through
@@ -3554,14 +3706,16 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
     // post-overlay config — so the context it recompiles under must NOT carry
     // the overlay ops again (they would double-apply and collide). For a plain
     // run this is identical to `compile_ctx.clone()` (the op stream is empty).
-    let execution_result = PipelineExecutor::run_admitted_plan_with_readers_writers_in_context(
-        &compiled_plan,
-        admitted_run_capabilities,
-        readers,
-        registry,
-        &run_params,
-        compile_ctx.without_overlay_ops(),
-    );
+    let execution_result =
+        PipelineExecutor::run_admitted_plan_with_readers_writers_in_context_with_policy(
+            &compiled_plan,
+            admitted_run_capabilities,
+            readers,
+            registry,
+            &run_params,
+            run_policy,
+            compile_ctx.without_overlay_ops(),
+        );
     // The periodic worker only ever writes discardable observations. A lost
     // snapshot is not run-controlling evidence: the protocol's required
     // records are the lifecycle transitions and the terminal, and those still
@@ -4027,7 +4181,7 @@ fn run(args: &RunArgs, machine: Option<&MachineEmitter>) -> Result<u8, PipelineE
             records_null_dropped: counters.null_dropped_count,
             execution_mode: report.execution_summary.clone(),
             peak_rss_bytes: report.peak_rss_bytes,
-            thread_count: num_threads(args),
+            thread_count: run_policy.thread_capacity().get(),
             input_files: pipeline_config
                 .source_configs()
                 .map(|i| i.path_str().to_string())
@@ -4221,9 +4375,27 @@ fn run_metrics(cmd: &MetricsCommands) -> Result<(), std::io::Error> {
     }
 }
 
-/// Resolve thread count from CLI args or default to `num_cpus`.
-fn num_threads(args: &RunArgs) -> usize {
-    args.threads.unwrap_or_else(num_cpus::get)
+/// Resolve one nonzero capacity and one preview mode before runtime effects.
+fn resolve_run_policy(
+    args: &RunArgs,
+    config: &clinker_plan::config::PipelineConfig,
+) -> clinker_exec::executor::RunPolicy {
+    let yaml_capacity = config
+        .pipeline
+        .concurrency
+        .as_ref()
+        .and_then(|concurrency| concurrency.threads)
+        .and_then(std::num::NonZeroUsize::new);
+    let thread_capacity = args.threads.or(yaml_capacity).unwrap_or_else(|| {
+        std::num::NonZeroUsize::new(num_cpus::get()).unwrap_or(std::num::NonZeroUsize::MIN)
+    });
+    let preview = match (args.dry_run, args.dry_run_n) {
+        (false, None) => clinker_exec::executor::PreviewPolicy::Disabled,
+        (true, None) => clinker_exec::executor::PreviewPolicy::ConfigOnly,
+        (true, Some(limit)) => clinker_exec::executor::PreviewPolicy::RecordsPerSource(limit),
+        (false, Some(_)) => unreachable!("clap requires --dry-run with --dry-run-n"),
+    };
+    clinker_exec::executor::RunPolicy::new(thread_capacity, preview)
 }
 
 /// Render a "Resolved Outputs" block listing each output's expanded
@@ -7904,7 +8076,7 @@ mod tests {
     fn test_cli_run_log_level_default() {
         let cli = Cli::try_parse_from(["clinker", "run", "pipeline.yaml"]).unwrap();
         match cli.command {
-            Commands::Run(args) => assert_eq!(args.log_level, "info"),
+            Commands::Run(args) => assert_eq!(args.log_level, LogLevel::Info),
             _ => panic!("expected Run command"),
         }
     }
@@ -8047,12 +8219,10 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_run_error_threshold_zero() {
-        let cli = Cli::try_parse_from(["clinker", "run", "p.yaml"]).unwrap();
-        match cli.command {
-            Commands::Run(args) => assert_eq!(args.error_threshold, 0),
-            _ => panic!("expected Run command"),
-        }
+    fn test_cli_run_error_threshold_is_retired() {
+        let error = Cli::try_parse_from(["clinker", "run", "p.yaml", "--error-threshold", "10"])
+            .expect_err("the retired flag must not parse");
+        assert!(error.to_string().contains("--error-threshold"));
     }
 
     #[test]
@@ -8174,7 +8344,7 @@ mod tests {
         match cli.command {
             Commands::Run(args) => {
                 assert!(args.dry_run);
-                assert_eq!(args.dry_run_n, Some(10));
+                assert_eq!(args.dry_run_n.map(std::num::NonZeroU64::get), Some(10));
             }
             _ => panic!("expected Run command"),
         }
@@ -8196,7 +8366,7 @@ mod tests {
         match cli.command {
             Commands::Run(args) => {
                 assert!(args.dry_run);
-                assert_eq!(args.dry_run_n, Some(5));
+                assert_eq!(args.dry_run_n.map(std::num::NonZeroU64::get), Some(5));
                 assert_eq!(args.dry_run_output, Some(PathBuf::from("out.csv")));
             }
             _ => panic!("expected Run command"),

--- a/crates/clinker/tests/run_flag_contract.rs
+++ b/crates/clinker/tests/run_flag_contract.rs
@@ -1,0 +1,201 @@
+use std::fs;
+use std::process::{Command, Output};
+
+fn clinker() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_clinker"))
+}
+
+fn run_in(root: &std::path::Path, args: &[&str]) -> Output {
+    clinker()
+        .current_dir(root)
+        .args(args)
+        .output()
+        .expect("run clinker")
+}
+
+fn csv_pipeline(source: &str, output: &str) -> String {
+    format!(
+        r#"pipeline:
+  name: run_flag_contract
+nodes:
+  - type: source
+    name: input
+    config:
+      name: input
+      type: csv
+      path: {source}
+      schema:
+        - {{ name: id, type: int }}
+  - type: output
+    name: final
+    input: input
+    config:
+      name: final
+      type: csv
+      path: {output}
+"#
+    )
+}
+
+#[test]
+fn tracer_config_only_opens_no_source_or_output() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(
+        dir.path().join("pipeline.yaml"),
+        csv_pipeline("missing.csv", "configured.csv"),
+    )
+    .expect("write pipeline");
+
+    let output = run_in(dir.path(), &["run", "pipeline.yaml", "--dry-run"]);
+
+    assert!(
+        output.status.success(),
+        "config-only dry run failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!dir.path().join("configured.csv").exists());
+}
+
+#[test]
+fn tracer_preview_caps_each_source_and_never_publishes_configured_output() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(dir.path().join("a.csv"), "id\n1\n2\n3\n").expect("write source a");
+    fs::write(dir.path().join("b.csv"), "id\n10\n20\n30\n").expect("write source b");
+    fs::write(
+        dir.path().join("pipeline.yaml"),
+        r#"pipeline:
+  name: run_flag_contract_preview
+nodes:
+  - type: source
+    name: a
+    config:
+      name: a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: b
+    config:
+      name: b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+  - type: merge
+    name: combined
+    inputs: [a, b]
+  - type: output
+    name: final
+    input: combined
+    config:
+      name: final
+      type: csv
+      path: configured.csv
+"#,
+    )
+    .expect("write pipeline");
+
+    let output = run_in(
+        dir.path(),
+        &[
+            "run",
+            "pipeline.yaml",
+            "--dry-run",
+            "-n",
+            "2",
+            "--dry-run-output",
+            "preview.csv",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "bounded preview failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("preview.csv")).expect("preview bytes"),
+        "id\n1\n2\n10\n20\n"
+    );
+    assert!(!dir.path().join("configured.csv").exists());
+}
+
+#[test]
+fn tracer_invalid_policy_values_and_adjacency_fail_before_config_access() {
+    for args in [
+        vec!["run", "missing.yaml", "--threads", "0"],
+        vec!["run", "missing.yaml", "--dry-run", "-n", "0"],
+        vec!["run", "missing.yaml", "--dry-run-output", "preview.csv"],
+    ] {
+        let output = clinker().args(&args).output().expect("run clinker");
+        assert_eq!(output.status.code(), Some(2), "args: {args:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("No such file") && !stderr.contains("not found"),
+            "policy error must precede config access for {args:?}: {stderr}"
+        );
+    }
+}
+
+#[test]
+fn tracer_log_level_is_closed_and_retired_error_threshold_has_yaml_correction() {
+    let invalid_level = clinker()
+        .args(["run", "missing.yaml", "--log-level", "verbose"])
+        .output()
+        .expect("run clinker");
+    assert_eq!(invalid_level.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&invalid_level.stderr).contains("--log-level"));
+
+    let retired = clinker()
+        .args(["run", "missing.yaml", "--error-threshold", "10"])
+        .output()
+        .expect("run clinker");
+    assert_eq!(retired.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&retired.stderr);
+    assert!(stderr.contains("--error-threshold"));
+    assert!(stderr.contains("error_handling.type_error_threshold"));
+}
+
+#[test]
+fn tracer_thread_capacity_is_the_value_reported_after_real_execution() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(dir.path().join("input.csv"), "id\n1\n").expect("write source");
+    fs::write(
+        dir.path().join("pipeline.yaml"),
+        csv_pipeline("input.csv", "configured.csv"),
+    )
+    .expect("write pipeline");
+    fs::create_dir(dir.path().join("spool")).expect("create spool");
+
+    let output = run_in(
+        dir.path(),
+        &[
+            "run",
+            "pipeline.yaml",
+            "--threads",
+            "2",
+            "--metrics-spool-dir",
+            "spool",
+        ],
+    );
+    assert!(
+        output.status.success(),
+        "real run failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let spool = fs::read_dir(dir.path().join("spool"))
+        .expect("read spool")
+        .next()
+        .expect("one spool entry")
+        .expect("spool entry")
+        .path();
+    let metrics: clinker_exec::metrics::ExecutionMetrics =
+        serde_json::from_str(&fs::read_to_string(spool).expect("read metrics"))
+            .expect("parse metrics");
+    assert_eq!(metrics.thread_count, 2);
+}

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -21,32 +21,34 @@ clinker run [OPTIONS] <CONFIG>
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--memory-limit <SIZE>` | YAML `memory.limit`, else `512M` | Memory budget for the execution. Uses the same grammar as the YAML `memory.limit`: a byte count with an optional binary (1024-based) `K`/`M`/`G` suffix (`K` = 1024 bytes, `M` = 1024², `G` = 1024³), where a bare integer is bytes. Other forms — a decimal `GB`, an explicit `GiB`, or a fractional value such as `1.5G` — are rejected. When the limit is approached, aggregation operators spill to disk rather than crashing. When passed, this value overrides any `memory.limit` set in the pipeline YAML; when omitted, the YAML value applies (or the `512M` default when the YAML is also silent). An empty or whitespace-only value — as an ops wrapper produces when it forwards an unset variable, e.g. `--memory-limit "$CLINKER_MEM"` with `CLINKER_MEM` unset — is treated the same as omitting the flag. A non-empty malformed value (for example the decimal `4GB` rather than the binary `4G`) is rejected at the CLI boundary with an error naming `--memory-limit` and echoing the value, so a typo fails loudly instead of silently falling back to the default and shrinking a larger YAML budget. Because the flag simply populates `pipeline.memory.limit`, a startup budget error (`E312`) for a value you passed via `--memory-limit` refers to that same limit. |
-| `--threads <N>` | number of CPUs | Size of the executor thread pool. The selected value is also recorded in execution metrics. |
-| `--error-threshold <N>` | `0` | **Accepted but not enforced in the current binary.** Parsing this flag does not stop a run after that many DLQ records. AUTH-05 and D-45 require the CLI audit to wire it or replace it with a nonzero tombstone. |
+| `--threads <N>` | YAML `pipeline.concurrency.threads`, else number of CPUs | Positive capacity applied independently to the Rayon CPU-kernel pool and to concurrent Source schema/read work across top-level and composition-body Sources. It is not a total operating-system thread limit: Source workers and the Rayon pool remain distinct. The selected value is recorded in execution metrics. Zero is rejected before the config is opened. |
 | `--batch-id <ID>` | UUID v7 | Logical-batch correlation available as `pipeline.batch_id`, in `{batch_id}` output-path templates, machine events, and opt-in output provenance sidecars. Supplying it does not override the fresh UUIDv7 execution ID and does not provide deduplication, resume, or exactly-once behavior. It is not currently a field in the metrics-spool payload. |
 | `--machine ndjson-v1` | -- | Opt into the `clinker.run` schema-1 lifecycle on stdout. Requires a non-empty `--batch-id`; conflicts with plan/dry-run output and with `--lineage -` or `--lineage-events -`. File-based lineage remains compatible: a plan-only `--lineage <FILE>` export shares this stream's identity and closes it with an explicit empty publication inventory, since it runs no attempt. Every line is one compact JSON object; human diagnostics move to stderr. Consumers must concurrently drain both pipes, reject unsupported schema majors, accept only additive schema-1 fields, and reconcile exactly one supported terminal with the actual process status and current-attempt artifact evidence. EOF, malformed output, forced termination, or a missing/duplicate terminal is incomplete, never success. See [Running Clinker Directly or Under a Supervisor](orchestrator-contract.md). |
 | `--explain [FORMAT]` | `text` | Print the execution plan and exit without processing data. Accepted formats: `text`, `json`, `dot`. With `json` or `dot`, standard output carries only the document and human diagnostics move to stderr, so a consumer can redirect stdout straight into a parser; with `text` they stay together on stdout. See [Explain Plans](explain.md). |
 | `--lineage <PATH>` | -- | Preflight the workspace lineage identity policy, build column lineage, and write it as OpenLineage NDJSON, then exit without processing data. Give a file path, or `-` for stdout. The export is the whole invocation, so one that cannot be delivered exits non-zero rather than reporting success: a destination the exporter cannot write exits `4`, and an event the `[observability.lineage]` byte caps reject exits `1`. Each diagnostic names the destination, states which of the two failed, and prints the configuration change where one applies. A failed export leaves no partial file behind, so a following upload step cannot pick up a stale one. Both this flag and `--lineage-events` need the `lineage` capability, which the released binary has; a build compiled without it refuses the flag at validation rather than exiting zero having emitted nothing (see [Optional capabilities](../getting-started/installation.md#optional-capabilities)). See [Column Lineage](lineage.md). |
 | `--lineage-events <PATH>` | -- | Preflight the workspace lineage identity policy, run the pipeline, and emit live OpenLineage run events (a `START` at run begin, then a terminal `COMPLETE` / `FAIL` / `ABORT` with real timing and row counts) as NDJSON to a file path, or `-` for stdout. Cannot be combined with `--lineage`, `--explain`, `--dry-run`, or `-n`. With `-`, normal run output can interleave with the event stream; use a file for clean NDJSON. See [Live run events](lineage.md#live-run-events). |
-| `--dry-run` | -- | With no `-n`, loads and validates the pipeline configuration, prints resolved outputs, and exits before full plan compilation or data access. It does **not** currently type-check CXL or validate DAG wiring; use `--explain` for the current no-data compile check. |
-| `-n, --dry-run-n <N>` | -- | **Current limitation:** requires an explicit `--dry-run`, but the current binary does not apply the `N` limit and instead continues into a normal full run. Do not use this as a bounded preview. AUTH-05 and D-45 require this behavior to be wired or rejected. |
-| `--dry-run-output <FILE>` | -- | **Accepted but unused in the current binary.** It does not redirect output. AUTH-05 requires it to be wired or replaced with a nonzero tombstone. |
+| `--dry-run` | -- | With no `-n`, performs complete config, overlay, CXL, schema, DAG, resource, and publication-configuration validation, prints resolved outputs, and exits without opening or reading a Source and without opening or publishing a Sink. |
+| `-n, --dry-run-n <N>` | -- | Bounded preview. Requires `--dry-run` and a positive `N`. Clinker checks the limit before every read and reads at most `N` records from each declared Source, including Sources inside composition bodies. Records drain in stable plan order to the explicit preview stream; configured Sink paths are never opened or published. Preview emits no live run telemetry or lineage lifecycle. |
+| `--dry-run-output <FILE>` | stdout | Destination for bounded-preview bytes. Requires `--dry-run-n`; without it, the option is rejected before config access. All preview Sinks write through this one explicit destination using their configured formats. |
 | `--rules-path <DIR>` | selected workspace's `rules/` | Select the CXL module rules root for this run. Precedence is explicit CLI value, then `pipeline.rules_path`, then `[catalog].rules_root`, then the workspace-relative `rules/` default. A relative value is anchored to the workspace selected by `--base-dir` or workspace discovery, not the process working directory. One root is selected; Clinker does not search multiple roots. See [Modules and `use`](../cxl/modules.md#rules-root-selection) and the [typed workspace catalog](../pipelines/channels.md#typed-workspace-catalog). |
 | `--base-dir <DIR>` | -- | Base directory for resolving relative paths in the YAML config. Defaults to the directory containing the config file. |
 | `--allow-absolute-paths` | -- | Permit absolute file paths in the pipeline YAML. By default, absolute paths are rejected to encourage portable configs. |
 | `--env <NAME>` | -- | Sets `CLINKER_ENV` in the current process before the pipeline loads. The current run path does not otherwise consume that value for channel selection; select a channel explicitly with `--channel`. |
 | `--quiet` | -- | Suppresses the “applied overlay” summary. Other stdout, tracing, warnings, and errors are not uniformly silenced. |
 | `--force` | -- | Overrides an output's `if_exists: error` policy and permits overwrite. Outputs using the default `if_exists: overwrite` already overwrite without this flag; `unique_suffix` keeps its own collision behavior. |
-| `--log-level <LEVEL>` | `info` | Logging verbosity: `error`, `warn`, `info`, `debug`, or `trace`. **Current limitation:** an unrecognized value is silently treated as `info` instead of being rejected; AUTH-05 requires strict CLI typing. |
+| `--log-level <LEVEL>` | `info` | Closed logging level: `error`, `warn`, `info`, `debug`, or `trace`. Any other spelling is rejected. |
 | `--metrics-spool-dir <DIR>` | -- | Directory for per-execution metrics files. See [Metrics & Monitoring](metrics.md). |
 | `--channel <ID>` | -- | Apply a logical id from `[catalog.channels]`. The selected file must also have a `[catalog.pipelines]` id listed in the channel manifest. Matching groups are target-bounded before labels narrow them. |
 | `--group <NAME>` | -- | Force-include a group overlay by name (repeatable). The selected pipeline or one of its admitted compositions must appear in the group's explicit `targets:` set. Use `clinker channels resolve` to preview the effective plan. |
 | `--no-auto-groups` | -- | Suppress selector-derived group membership; only groups named with `--group` apply. |
 
-The limitations called out above are the current parser/runtime behavior, not
-recommended contracts. Decision D-45 requires every visible option to be
-wired and behavior-tested, or replaced by a nonzero tombstone with a
-paste-ready alternative under AUTH-05.
+`--error-threshold` is retired and rejected. Configure the typed pipeline
+policy instead; the CLI diagnostic prints this paste-ready replacement:
+
+```yaml
+error_handling:
+  type_error_threshold: 0.05
+```
 
 ### Credential profile foundation
 
@@ -86,6 +88,9 @@ clinker run pipeline.yaml --memory-limit 512M --force --log-level warn
 
 # Validate without processing
 clinker run pipeline.yaml --dry-run
+
+# Preview at most 25 records from each declared Source without publishing Sinks
+clinker run pipeline.yaml --dry-run -n 25 --dry-run-output preview.csv
 
 # Compile and explain without reading data
 clinker run pipeline.yaml --explain text


### PR DESCRIPTION
## Summary

- derive one typed run policy from the CLI and pipeline configuration, reject zero capacities, size the Rayon kernel pool from it, apply the same cap independently to concurrent top-level and composition-body Source reads, and report that established value
- keep config-only dry runs effect-free, and implement bounded previews that check the per-Source limit before every record read, drain Sources deterministically, write only to the explicit preview destination, and never create or publish configured output attempts
- make log levels a closed CLI value and retire the inert `--error-threshold` spelling with a paste-ready YAML correction
- document the exact capacity, preview, conflict, output, and retirement behavior

## Verification

- run flag integration tests: 5 passed
- executor library tests: 995 passed
- body Source execution tests: 5 passed
- exact no-read-ahead preview test
- Source capacity tests at 1 and 2 permits
- Rayon pool sizing tests at 1 and 2 workers
- CLI binary unit tests: 107 passed
- workspace all-target check
- affected-crate ordinary and all-target Clippy with warnings denied
- user documentation build and rendered-link check
- `cargo fmt --all --check`
- `git diff --check`

The broad `clinker` integration run reached 101 passing targets before an existing composition fixture failed strict body-Source resource admission during `--explain`. That fixture is outside this change and fails before run-policy execution.

## Obligations

Preview uses the existing bounded Source channels and retains no input-sized collection. The shared Source limiter stores fixed counters independent of input volume, so no additional memory consumer is required. Config-only and bounded preview emit no live run telemetry or lineage lifecycle, and normal execution retains its existing telemetry and lineage behavior. No new dataset boundary or row-value derivation is introduced.
