### PR TITLE
Deliver nested values end to end

### DIFF
--- a/crates/clinker-channel/src/selector.rs
+++ b/crates/clinker-channel/src/selector.rs
@@ -237,6 +237,34 @@ fn reject_non_label(expr: &Expr) -> Result<(), SelectorError> {
             reject_non_label(rhs)
         }
         Expr::Unary { operand, .. } => reject_non_label(operand),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                reject_non_label(element)?;
+            }
+            Ok(())
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    reject_non_label(key)?;
+                }
+                reject_non_label(&entry.value)?;
+            }
+            Ok(())
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            reject_non_label(source)?;
+            reject_non_label(item)?;
+            if let Some(predicate) = predicate {
+                reject_non_label(predicate)?;
+            }
+            Ok(())
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -555,6 +583,20 @@ mod tests {
         // recursive walk must still find it.
         let err = LabelSelector::compile(r#"region == "west" and $source.row == 1"#).unwrap_err();
         assert!(matches!(err, SelectorError::ForbiddenReference(_)));
+    }
+
+    #[test]
+    fn forbidden_reference_inside_nested_constructor_is_rejected() {
+        for source in [
+            r#"{ok: true, leak: $source.row} == {ok: true, leak: 1}"#,
+            r#"[item for item in [1, $record.secret]] == [1]"#,
+        ] {
+            let err = LabelSelector::compile(source).unwrap_err();
+            assert!(
+                matches!(err, SelectorError::ForbiddenReference(_)),
+                "expected nested forbidden reference in {source:?}, got {err:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/clinker-exec/src/aggregation/error.rs
+++ b/crates/clinker-exec/src/aggregation/error.rs
@@ -30,6 +30,19 @@ pub enum AggregateEvalError {
     /// reported via this variant rather than panicking.
     #[error("unsupported aggregate residual construct: {what}")]
     UnsupportedResidual { what: &'static str },
+    #[error("aggregate residual type mismatch: expected {expected}, got {got}")]
+    TypeMismatch {
+        expected: &'static str,
+        got: &'static str,
+    },
+    #[error("duplicate map key '{key}' in aggregate residual")]
+    DuplicateMapKey { key: String },
+    #[error("invalid nested map key '{key}' in aggregate residual: {message}")]
+    InvalidNestedKey { key: String, message: String },
+    #[error("aggregate residual nested-value construction exceeds {limit} bytes")]
+    ConstructionLimitExceeded { limit: usize },
+    #[error("aggregate residual nested-value construction exceeds depth {limit}")]
+    ConstructionDepthExceeded { limit: usize },
 }
 
 /// Errors raised by the hash aggregator hot loop. The 16.3.13 dispatch

--- a/crates/clinker-exec/src/aggregation/mod.rs
+++ b/crates/clinker-exec/src/aggregation/mod.rs
@@ -42,6 +42,7 @@ pub use spill::{AggSpillFile, SpillState};
 
 pub(crate) use hash::{empty_global_fold_row, finalize_group_inner, group_by_sort_fields};
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -50,7 +51,7 @@ use clinker_record::accumulator::{AccumulatorEnum, AccumulatorRow};
 use clinker_record::group_key::value_to_group_key;
 use clinker_record::schema::Schema;
 use clinker_record::{GroupByKey, Record, Value};
-use cxl::ast::{BinOp, Expr, LiteralValue, UnaryOp};
+use cxl::ast::{BinOp, Expr, LiteralValue, MapKey, UnaryOp};
 use cxl::eval::{CompiledScalar, EvalContext, EvalError, ProgramEvaluator, compare_values};
 use cxl::plan::{AggregateBinding, BindingArg, CompiledAggregate};
 
@@ -99,6 +100,55 @@ pub fn eval_expr_in_agg_scope(
     expr: &Expr,
     scope: &AggregateEvalScope<'_>,
 ) -> Result<Value, AggregateEvalError> {
+    let mut env = HashMap::new();
+    let mut constructed_bytes = 0;
+    let mut construction_depth = 0;
+    eval_expr_in_agg_scope_inner(
+        expr,
+        scope,
+        &mut env,
+        &mut constructed_bytes,
+        &mut construction_depth,
+    )
+}
+
+const MAX_AGG_CONSTRUCTED_BYTES: usize = 10 * 1024 * 1024;
+
+fn charge_aggregate_construction(
+    constructed_bytes: &mut usize,
+    bytes: usize,
+) -> Result<(), AggregateEvalError> {
+    let next = constructed_bytes.checked_add(bytes).ok_or(
+        AggregateEvalError::ConstructionLimitExceeded {
+            limit: MAX_AGG_CONSTRUCTED_BYTES,
+        },
+    )?;
+    if next > MAX_AGG_CONSTRUCTED_BYTES {
+        return Err(AggregateEvalError::ConstructionLimitExceeded {
+            limit: MAX_AGG_CONSTRUCTED_BYTES,
+        });
+    }
+    *constructed_bytes = next;
+    Ok(())
+}
+
+fn enter_aggregate_construction(depth: &mut usize) -> Result<(), AggregateEvalError> {
+    if *depth >= clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+        return Err(AggregateEvalError::ConstructionDepthExceeded {
+            limit: clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH,
+        });
+    }
+    *depth += 1;
+    Ok(())
+}
+
+fn eval_expr_in_agg_scope_inner(
+    expr: &Expr,
+    scope: &AggregateEvalScope<'_>,
+    env: &mut HashMap<String, Value>,
+    constructed_bytes: &mut usize,
+    construction_depth: &mut usize,
+) -> Result<Value, AggregateEvalError> {
     match expr {
         Expr::AggSlot { slot, .. } => {
             scope
@@ -119,19 +169,206 @@ pub fn eval_expr_in_agg_scope(
                 key_count: scope.key.len(),
             }),
         Expr::Literal { value, .. } => Ok(literal_to_value(value)),
+        Expr::ArrayLiteral { elements, .. } => {
+            enter_aggregate_construction(construction_depth)?;
+            let result = (|| {
+                charge_aggregate_construction(
+                    constructed_bytes,
+                    elements.len() * std::mem::size_of::<Value>(),
+                )?;
+                let mut values = Vec::with_capacity(elements.len());
+                for element in elements {
+                    let value = eval_expr_in_agg_scope_inner(
+                        element,
+                        scope,
+                        env,
+                        constructed_bytes,
+                        construction_depth,
+                    )?;
+                    charge_aggregate_construction(constructed_bytes, value.heap_size())?;
+                    values.push(value);
+                }
+                Ok(Value::Array(values))
+            })();
+            *construction_depth -= 1;
+            result
+        }
+        Expr::MapLiteral { entries, .. } => {
+            enter_aggregate_construction(construction_depth)?;
+            let result = (|| {
+                let entry_bytes = std::mem::size_of::<Box<str>>()
+                    + std::mem::size_of::<Value>()
+                    + std::mem::size_of::<u64>()
+                    + std::mem::size_of::<usize>();
+                charge_aggregate_construction(constructed_bytes, entries.len() * entry_bytes)?;
+                let mut values: indexmap::IndexMap<Box<str>, Value> =
+                    indexmap::IndexMap::with_capacity(entries.len());
+                for entry in entries {
+                    let key: Box<str> = match &entry.key {
+                        MapKey::Static(key) => key.clone(),
+                        MapKey::Computed(key) => match eval_expr_in_agg_scope_inner(
+                            key,
+                            scope,
+                            env,
+                            constructed_bytes,
+                            construction_depth,
+                        )? {
+                            Value::String(key) => key.as_str().into(),
+                            other => {
+                                return Err(AggregateEvalError::TypeMismatch {
+                                    expected: "non-null String map key",
+                                    got: other.type_name(),
+                                });
+                            }
+                        },
+                    };
+                    charge_aggregate_construction(constructed_bytes, key.len())?;
+                    let decoded =
+                        clinker_record::nested_key::NestedKey::decode(&key).map_err(|error| {
+                            AggregateEvalError::InvalidNestedKey {
+                                key: key.to_string(),
+                                message: error.to_string(),
+                            }
+                        })?;
+                    let logical_key = decoded.text.as_ref();
+                    if values.keys().any(|prior| {
+                        clinker_record::nested_key::NestedKey::decode(prior)
+                            .expect("previous keys were validated before insertion")
+                            .text
+                            == logical_key
+                    }) {
+                        return Err(AggregateEvalError::DuplicateMapKey {
+                            key: logical_key.to_string(),
+                        });
+                    }
+                    let value = eval_expr_in_agg_scope_inner(
+                        &entry.value,
+                        scope,
+                        env,
+                        constructed_bytes,
+                        construction_depth,
+                    )?;
+                    charge_aggregate_construction(constructed_bytes, value.heap_size())?;
+                    values.insert(key, value);
+                }
+                Ok(Value::Map(Box::new(values)))
+            })();
+            *construction_depth -= 1;
+            result
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            enter_aggregate_construction(construction_depth)?;
+            let source = eval_expr_in_agg_scope_inner(
+                source,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            );
+            let source = match source {
+                Ok(source) => source,
+                Err(error) => {
+                    *construction_depth -= 1;
+                    return Err(error);
+                }
+            };
+            let Value::Array(source_values) = source else {
+                *construction_depth -= 1;
+                return Err(AggregateEvalError::TypeMismatch {
+                    expected: "Array comprehension source",
+                    got: source.type_name(),
+                });
+            };
+            charge_aggregate_construction(
+                constructed_bytes,
+                source_values.len() * std::mem::size_of::<Value>(),
+            )?;
+            let previous = env.remove(binding.as_ref());
+            let result = (|| {
+                let mut values = Vec::with_capacity(source_values.len());
+                for source_value in source_values {
+                    env.insert(binding.to_string(), source_value);
+                    if let Some(predicate) = predicate {
+                        match eval_expr_in_agg_scope_inner(
+                            predicate,
+                            scope,
+                            env,
+                            constructed_bytes,
+                            construction_depth,
+                        )? {
+                            Value::Bool(true) => {}
+                            Value::Bool(false) => continue,
+                            other => {
+                                return Err(AggregateEvalError::TypeMismatch {
+                                    expected: "Bool comprehension predicate",
+                                    got: other.type_name(),
+                                });
+                            }
+                        }
+                    }
+                    let value = eval_expr_in_agg_scope_inner(
+                        item,
+                        scope,
+                        env,
+                        constructed_bytes,
+                        construction_depth,
+                    )?;
+                    charge_aggregate_construction(constructed_bytes, value.heap_size())?;
+                    values.push(value);
+                }
+                Ok(Value::Array(values))
+            })();
+            if let Some(previous) = previous {
+                env.insert(binding.to_string(), previous);
+            } else {
+                env.remove(binding.as_ref());
+            }
+            *construction_depth -= 1;
+            result
+        }
         Expr::Binary { op, lhs, rhs, .. } => {
-            let l = eval_expr_in_agg_scope(lhs, scope)?;
-            let r = eval_expr_in_agg_scope(rhs, scope)?;
+            let l = eval_expr_in_agg_scope_inner(
+                lhs,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
+            let r = eval_expr_in_agg_scope_inner(
+                rhs,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
             eval_binary(*op, l, r)
         }
         Expr::Unary { op, operand, .. } => {
-            let v = eval_expr_in_agg_scope(operand, scope)?;
+            let v = eval_expr_in_agg_scope_inner(
+                operand,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
             eval_unary(*op, v)
         }
         Expr::Coalesce { lhs, rhs, .. } => {
-            let l = eval_expr_in_agg_scope(lhs, scope)?;
+            let l = eval_expr_in_agg_scope_inner(
+                lhs,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
             if matches!(l, Value::Null) {
-                eval_expr_in_agg_scope(rhs, scope)
+                eval_expr_in_agg_scope_inner(rhs, scope, env, constructed_bytes, construction_depth)
             } else {
                 Ok(l)
             }
@@ -142,17 +379,33 @@ pub fn eval_expr_in_agg_scope(
             else_branch,
             ..
         } => {
-            let c = eval_expr_in_agg_scope(condition, scope)?;
+            let c = eval_expr_in_agg_scope_inner(
+                condition,
+                scope,
+                env,
+                constructed_bytes,
+                construction_depth,
+            )?;
             if matches!(c, Value::Bool(true)) {
-                eval_expr_in_agg_scope(then_branch, scope)
+                eval_expr_in_agg_scope_inner(
+                    then_branch,
+                    scope,
+                    env,
+                    constructed_bytes,
+                    construction_depth,
+                )
             } else if let Some(e) = else_branch {
-                eval_expr_in_agg_scope(e, scope)
+                eval_expr_in_agg_scope_inner(e, scope, env, constructed_bytes, construction_depth)
             } else {
                 Ok(Value::Null)
             }
         }
         Expr::Now { .. } => Err(AggregateEvalError::UnsupportedResidual { what: "now" }),
-        Expr::FieldRef { .. } | Expr::QualifiedFieldRef { .. } => {
+        Expr::FieldRef { name, .. } => env
+            .get(name.as_ref())
+            .cloned()
+            .ok_or(AggregateEvalError::UnsupportedResidual { what: "field-ref" }),
+        Expr::QualifiedFieldRef { .. } => {
             Err(AggregateEvalError::UnsupportedResidual { what: "field-ref" })
         }
         Expr::PipelineAccess { .. }
@@ -1170,9 +1423,99 @@ impl<Op: AccumulatorOp> StreamingAggregator<Op> {
 mod accumulator_op_tests {
     use super::*;
     use clinker_record::accumulator::{AccumulatorEnum, AggregateType};
+    use cxl::ast::Statement;
+    use cxl::parser::Parser;
+
+    fn parsed_emit_expr(source: &str) -> Expr {
+        let parsed = Parser::parse(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let Statement::Emit { expr, .. } = parsed.ast.statements.into_iter().next().unwrap() else {
+            panic!("expected emit statement");
+        };
+        expr
+    }
 
     fn state_with_row(row: AccumulatorRow) -> AggregatorGroupState {
         AggregatorGroupState::new(row)
+    }
+
+    #[test]
+    fn aggregate_residual_nested_constructors_preserve_order_and_bindings() {
+        let expr = parsed_emit_expr(
+            "emit payload = {items: [item * 2 for item in [3, -1, 2] if item > 0], tail: null}",
+        );
+        let value = eval_expr_in_agg_scope(
+            &expr,
+            &AggregateEvalScope {
+                key: &[],
+                slots: &[],
+            },
+        )
+        .unwrap();
+        let Value::Map(map) = value else {
+            panic!("expected map");
+        };
+        assert_eq!(
+            map.keys().map(|key| key.as_ref()).collect::<Vec<_>>(),
+            vec!["items", "tail"]
+        );
+        assert_eq!(
+            map["items"],
+            Value::Array(vec![Value::Integer(6), Value::Integer(4)])
+        );
+    }
+
+    #[test]
+    fn aggregate_residual_rejects_duplicate_logical_computed_key() {
+        let expr = parsed_emit_expr(r#"emit payload = {"@id": 1, ["\\@id"]: 2}"#);
+        let error = eval_expr_in_agg_scope(
+            &expr,
+            &AggregateEvalScope {
+                key: &[],
+                slots: &[],
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            AggregateEvalError::DuplicateMapKey { ref key } if key == "@id"
+        ));
+    }
+
+    #[test]
+    fn aggregate_residual_enforces_construction_depth_and_byte_caps() {
+        let source = format!(
+            "emit payload = {}null{}",
+            "[".repeat(clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH + 1),
+            "]".repeat(clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH + 1)
+        );
+        let expr = parsed_emit_expr(&source);
+        let error = eval_expr_in_agg_scope(
+            &expr,
+            &AggregateEvalScope {
+                key: &[],
+                slots: &[],
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            AggregateEvalError::ConstructionDepthExceeded { limit }
+                if limit == clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH
+        ));
+
+        let mut bytes = 0;
+        charge_aggregate_construction(&mut bytes, MAX_AGG_CONSTRUCTED_BYTES).unwrap();
+        assert!(matches!(
+            charge_aggregate_construction(&mut bytes, 1),
+            Err(AggregateEvalError::ConstructionLimitExceeded { limit })
+                if limit == MAX_AGG_CONSTRUCTED_BYTES
+        ));
+        assert_eq!(bytes, MAX_AGG_CONSTRUCTED_BYTES);
     }
 
     // ----- merge_group_sidecars -----

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -273,6 +273,7 @@ fn build_writer_factory(
     // once so the format arms below read them by their original names.
     let include_header = output.include_header;
     let include_engine_stamped = output.include_correlation_keys;
+    let preserve_nulls = output.preserve_nulls.unwrap_or(false);
     let reconstruct_envelope = output.reconstruct_envelope;
     let include_unmapped = output.include_unmapped;
     let join_values = output.join_values.clone().unwrap_or_default();
@@ -333,6 +334,7 @@ fn build_writer_factory(
         OutputFormat::Json(opts) => {
             let mut json_config = build_json_writer_config(opts.as_ref());
             json_config.include_engine_stamped = include_engine_stamped;
+            json_config.preserve_nulls = preserve_nulls;
             json_config.envelope = resolve_envelope_spec(
                 reconstruct_envelope,
                 opts.as_ref().and_then(|o| o.envelope.as_ref()),
@@ -348,6 +350,7 @@ fn build_writer_factory(
         OutputFormat::Xml(opts) => {
             let mut xml_config = build_xml_writer_config(opts.as_ref());
             xml_config.include_engine_stamped = include_engine_stamped;
+            xml_config.preserve_nulls = preserve_nulls;
             // Per-field repeated-element overrides (`repeat_as` / `wrap_in`); a
             // `multiple:` field with no entry emits bare repeats named after the
             // field. The plan-time E362 gate has already validated the block, so

--- a/crates/clinker-exec/src/pipeline/combine.rs
+++ b/crates/clinker-exec/src/pipeline/combine.rs
@@ -412,7 +412,7 @@ pub enum CombineError {
     /// Key-expression evaluation failed. `side` is `"driving"` or
     /// `"build"` so the executor can produce an accurate diagnostic.
     KeyEvalFailed {
-        source: EvalError,
+        source: Box<EvalError>,
         side: &'static str,
     },
 
@@ -447,7 +447,7 @@ impl std::fmt::Display for CombineError {
 impl std::error::Error for CombineError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            CombineError::KeyEvalFailed { source, .. } => Some(source),
+            CombineError::KeyEvalFailed { source, .. } => Some(source.as_ref()),
             _ => None,
         }
     }
@@ -712,7 +712,7 @@ impl CombineHashTable {
             let keys = extractor
                 .extract(ctx, &rec)
                 .map_err(|e| CombineError::KeyEvalFailed {
-                    source: e,
+                    source: Box::new(e),
                     side: "build",
                 })?;
 

--- a/crates/clinker-exec/tests/json_nested_write_e2e.rs
+++ b/crates/clinker-exec/tests/json_nested_write_e2e.rs
@@ -12,6 +12,9 @@ use std::collections::HashMap;
 
 use clinker_bench_support::io::SharedBuffer;
 use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+use clinker_plan::config::CompileContext;
+use clinker_plan::error::PipelineError;
+use clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH;
 
 fn params() -> PipelineRunParams {
     PipelineRunParams {
@@ -42,6 +45,87 @@ fn run(pipeline: &str, input: &str) -> String {
     )]);
     common::run_config(&config, json_reader(input), writers, &params()).expect("run succeeds");
     String::from_utf8(buf.contents()).expect("utf-8 output")
+}
+
+fn transformed_pipeline(cxl: &str, preserve_nulls: Option<bool>) -> String {
+    let cxl = cxl
+        .lines()
+        .map(|line| format!("        {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let preserve_nulls = preserve_nulls
+        .map(|value| format!("      preserve_nulls: {value}\n"))
+        .unwrap_or_default();
+    r#"
+pipeline:
+  name: json_nested_cxl
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: ./in.csv
+      options:
+        has_header: true
+      schema:
+        - { name: kind, type: string }
+        - { name: key, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        __CXL__
+  - type: output
+    name: out
+    input: construct
+    config:
+      name: out
+      type: json
+      path: ./out.json
+      include_unmapped: false
+__PRESERVE_NULLS__
+      options:
+        format: ndjson
+"#
+    .replace("        __CXL__", &cxl)
+    .replace("__PRESERVE_NULLS__", &preserve_nulls)
+}
+
+fn run_transformed(
+    cxl: &str,
+    input: &str,
+    preserve_nulls: Option<bool>,
+) -> (Result<(), PipelineError>, SharedBuffer) {
+    let pipeline = transformed_pipeline(cxl, preserve_nulls);
+    let config = clinker_plan::config::parse_config(&pipeline).expect("pipeline parses");
+    let output = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(output.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let result =
+        common::run_config(&config, json_reader_for_rows(input), writers, &params()).map(|_| ());
+    (result, output)
+}
+
+fn json_reader_for_rows(input: &str) -> SourceReaders {
+    HashMap::from([(
+        "rows".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.csv",
+            Box::new(std::io::Cursor::new(input.as_bytes().to_vec())),
+        ),
+    )])
+}
+
+fn nested_map_expression(depth: usize, leaf: &str) -> String {
+    format!("{}{leaf}{}", "{n: ".repeat(depth), "}".repeat(depth))
+}
+
+fn nested_json_value(depth: usize, leaf: &str) -> String {
+    format!("{}{leaf}{}", r#"{"n":"#.repeat(depth), "}".repeat(depth))
 }
 
 const PIPELINE: &str = r#"
@@ -81,5 +165,124 @@ fn nested_json_read_and_written_back_keeps_its_shape() {
         written,
         source.as_array().expect("input array")[0],
         "got: {output}"
+    );
+}
+
+#[test]
+fn cxl_created_json_value_at_the_shared_depth_cap_is_byte_exact() {
+    let expression = nested_map_expression(MAX_NESTED_VALUE_DEPTH, r#""leaf""#);
+    let cxl = format!("emit payload = {expression}");
+
+    let (result, output) = run_transformed(&cxl, "kind,key\nok,n\n", None);
+
+    result.expect("depth-cap value writes");
+    assert_eq!(
+        output.as_string(),
+        format!(
+            r#"{{"payload":{}}}"#,
+            nested_json_value(MAX_NESTED_VALUE_DEPTH, r#""leaf""#)
+        )
+    );
+}
+
+#[test]
+fn cxl_created_json_value_over_the_depth_cap_leaves_no_record_bytes() {
+    let expression = nested_map_expression(MAX_NESTED_VALUE_DEPTH + 1, "null");
+    let cxl = format!("emit payload = {expression}");
+
+    let (result, output) = run_transformed(&cxl, "kind,key\ntoo-deep,n\n", None);
+
+    let error = result.expect_err("cap plus one must fail");
+    assert!(
+        matches!(
+            error,
+            PipelineError::Eval(ref source)
+                if matches!(
+                    source.kind,
+                    cxl::eval::EvalErrorKind::ConstructionDepthExceeded { limit }
+                        if limit == MAX_NESTED_VALUE_DEPTH
+                )
+        ),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        output.contents().is_empty(),
+        "a rejected value cannot leave partial JSON"
+    );
+}
+
+#[test]
+fn json_decodes_reserved_looking_literal_keys_exactly_once() {
+    let cxl = r#"emit payload = {"\\@literal": 1, "\\#text": "body", "\\\\name": true}"#;
+
+    let (result, output) = run_transformed(cxl, "kind,key\nok,unused\n", None);
+
+    result.expect("escaped literal keys write");
+    assert_eq!(
+        output.as_string(),
+        r##"{"payload":{"@literal":1,"#text":"body","\\name":true}}"##
+    );
+}
+
+#[test]
+fn static_and_computed_json_key_collisions_both_fail_without_output() {
+    let static_cxl = r#"emit payload = {"@id": 1, "\\@id": 2}"#;
+    let pipeline = transformed_pipeline(static_cxl, None);
+    let config = clinker_plan::config::parse_config(&pipeline).expect("pipeline YAML parses");
+
+    let diagnostics = config
+        .compile(&CompileContext::default())
+        .expect_err("static logical-key collision must fail compilation");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("duplicate map key \"@id\"")),
+        "unexpected diagnostics: {diagnostics:#?}"
+    );
+
+    let computed_cxl = r#"emit payload = {"@id": 1, [key]: 2}"#;
+    let (result, output) = run_transformed(computed_cxl, "kind,key\ndynamic,@id\n", None);
+    let error = result.expect_err("computed logical-key collision must fail evaluation");
+    assert!(
+        matches!(
+            error,
+            PipelineError::Eval(ref source)
+                if matches!(
+                    &source.kind,
+                    cxl::eval::EvalErrorKind::DuplicateMapKey { key } if key == "@id"
+                )
+        ),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        output.contents().is_empty(),
+        "the computed collision cannot reach the JSON writer"
+    );
+}
+
+#[test]
+fn json_null_policy_defaults_to_omit_and_preserves_nested_null_values() {
+    let cxl = "emit payload = {missing: null, items: [null, \"x\"]}\n\
+               emit absent = if kind == \"ok\" then null else \"present\"";
+
+    let (default_result, defaulted) = run_transformed(cxl, "kind,key\nok,unused\n", None);
+    let (drop_result, dropped) = run_transformed(cxl, "kind,key\nok,unused\n", Some(false));
+    let (keep_result, kept) = run_transformed(cxl, "kind,key\nok,unused\n", Some(true));
+
+    default_result.expect("default null policy writes");
+    drop_result.expect("drop-null JSON writes");
+    keep_result.expect("preserve-null JSON writes");
+    assert_eq!(
+        defaulted.contents(),
+        dropped.contents(),
+        "the omitted option must retain the false default"
+    );
+    assert_eq!(
+        dropped.as_string(),
+        r#"{"payload":{"missing":null,"items":[null,"x"]}}"#
+    );
+    assert_eq!(
+        kept.as_string(),
+        r#"{"payload":{"missing":null,"items":[null,"x"]},"absent":null}"#
     );
 }

--- a/crates/clinker-exec/tests/nested_cxl_write_e2e.rs
+++ b/crates/clinker-exec/tests/nested_cxl_write_e2e.rs
@@ -1,0 +1,98 @@
+//! Production-path proof for CXL native nested construction: pipeline YAML is
+//! parsed and compiled, a real transform evaluates maps/arrays/comprehensions,
+//! and both recursive writers receive the resulting neutral value.
+
+mod common;
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+
+const PIPELINE: &str = r##"
+pipeline:
+  name: nested_cxl_write
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: ./in.csv
+      options:
+        has_header: true
+      schema:
+        - { name: first, type: string }
+        - { name: second, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        emit payload = {
+          "@kind": "event",
+          "#text": "before",
+          item: [{"@id": item, "#text": item.to_string()} for item in [first.to_int(), second.to_int()] if item > 0],
+          tail: "after"
+        }
+  - type: output
+    name: json_out
+    input: construct
+    config:
+      name: json_out
+      type: json
+      path: ./out.json
+      include_unmapped: false
+      options:
+        format: ndjson
+  - type: output
+    name: xml_out
+    input: construct
+    config:
+      name: xml_out
+      type: xml
+      path: ./out.xml
+      include_unmapped: false
+"##;
+
+#[test]
+fn cxl_nested_values_reach_json_and_xml_writers_exactly() {
+    let config = clinker_plan::config::parse_config(PIPELINE).expect("pipeline parses");
+    let readers: SourceReaders = HashMap::from([(
+        "rows".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.csv",
+            Box::new(std::io::Cursor::new(b"first,second\n2,-1\n".to_vec())),
+        ),
+    )]);
+    let json = SharedBuffer::new();
+    let xml = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        (
+            "json_out".to_string(),
+            Box::new(json.clone()) as Box<dyn std::io::Write + Send>,
+        ),
+        (
+            "xml_out".to_string(),
+            Box::new(xml.clone()) as Box<dyn std::io::Write + Send>,
+        ),
+    ]);
+    let params = PipelineRunParams {
+        execution_id: "nested-cxl-e2e".into(),
+        batch_id: "batch-1".into(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    common::run_config(&config, readers, writers, &params).expect("pipeline runs");
+
+    assert_eq!(
+        json.as_string(),
+        "{\"payload\":{\"@kind\":\"event\",\"#text\":\"before\",\"item\":[{\"@id\":2,\"#text\":\"2\"}],\"tail\":\"after\"}}"
+    );
+    assert_eq!(
+        xml.as_string(),
+        "<Root><Record><payload kind=\"event\">before<item id=\"2\">2</item><tail>after</tail></payload></Record></Root>"
+    );
+}

--- a/crates/clinker-exec/tests/xml_nested_write_e2e.rs
+++ b/crates/clinker-exec/tests/xml_nested_write_e2e.rs
@@ -1,0 +1,314 @@
+//! Executable-boundary coverage for CXL-created values written as native XML.
+//!
+//! These tests deliberately pass through YAML parsing, CXL compilation and
+//! evaluation, executor dispatch, and the real XML writer factory. Assertions
+//! use exact bytes so wrapper, repetition, null, and record-atomicity behavior
+//! cannot drift independently between those layers.
+
+mod common;
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+use clinker_plan::config::CompileContext;
+use clinker_plan::error::PipelineError;
+use clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH;
+
+fn params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "xml-nested-e2e".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+fn transformed_pipeline(cxl: &str, preserve_nulls: Option<bool>, rename_repeats: bool) -> String {
+    let cxl = cxl
+        .lines()
+        .map(|line| format!("        {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let join_values = if rename_repeats {
+        "      join_values:\n        - { field: tags, repeat_as: Tag, wrap_in: Tags }\n"
+    } else {
+        ""
+    };
+    let preserve_nulls = preserve_nulls
+        .map(|value| format!("      preserve_nulls: {value}\n"))
+        .unwrap_or_default();
+    r#"
+pipeline:
+  name: xml_nested_cxl
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: ./in.csv
+      options:
+        has_header: true
+      schema:
+        - { name: kind, type: string }
+        - { name: key, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        __CXL__
+  - type: output
+    name: out
+    input: construct
+    config:
+      name: out
+      type: xml
+      path: ./out.xml
+      include_unmapped: false
+__PRESERVE_NULLS__
+__JOIN_VALUES__      options:
+        root_element: Feed
+        record_element: Entry
+        attribute_prefix: "@"
+"#
+    .replace("        __CXL__", &cxl)
+    .replace("__PRESERVE_NULLS__", &preserve_nulls)
+    .replace("__JOIN_VALUES__", join_values)
+}
+
+fn reader(input: &str) -> SourceReaders {
+    HashMap::from([(
+        "rows".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.csv",
+            Box::new(std::io::Cursor::new(input.as_bytes().to_vec())),
+        ),
+    )])
+}
+
+fn run_transformed(
+    cxl: &str,
+    input: &str,
+    preserve_nulls: Option<bool>,
+    rename_repeats: bool,
+) -> (Result<(), PipelineError>, SharedBuffer) {
+    let pipeline = transformed_pipeline(cxl, preserve_nulls, rename_repeats);
+    let config = clinker_plan::config::parse_config(&pipeline).expect("pipeline parses");
+    let output = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(output.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let result = common::run_config(&config, reader(input), writers, &params()).map(|_| ());
+    (result, output)
+}
+
+fn nested_map_expression(depth: usize, leaf: &str) -> String {
+    format!("{}{leaf}{}", "{n: ".repeat(depth), "}".repeat(depth))
+}
+
+fn nested_xml_value(depth: usize, leaf: &str) -> String {
+    format!("{}{leaf}{}", "<n>".repeat(depth), "</n>".repeat(depth))
+}
+
+fn contains_format_error(error: &PipelineError) -> bool {
+    match error {
+        PipelineError::Format(_) => true,
+        PipelineError::Multiple(errors) => errors.iter().any(contains_format_error),
+        _ => false,
+    }
+}
+
+#[test]
+fn cxl_created_xml_value_at_the_shared_depth_cap_is_byte_exact() {
+    let expression = nested_map_expression(MAX_NESTED_VALUE_DEPTH, r#""leaf""#);
+    let cxl = format!("emit payload = {expression}");
+
+    let (result, output) = run_transformed(&cxl, "kind,key\nok,n\n", None, false);
+
+    result.expect("depth-cap value writes");
+    assert_eq!(
+        output.as_string(),
+        format!(
+            "<Feed><Entry><payload>{}</payload></Entry></Feed>",
+            nested_xml_value(MAX_NESTED_VALUE_DEPTH, "leaf")
+        )
+    );
+}
+
+#[test]
+fn cxl_created_xml_value_over_the_depth_cap_leaves_no_record_bytes() {
+    let expression = nested_map_expression(MAX_NESTED_VALUE_DEPTH + 1, "null");
+    let cxl = format!("emit payload = {expression}");
+
+    let (result, output) = run_transformed(&cxl, "kind,key\ntoo-deep,n\n", None, false);
+
+    let error = result.expect_err("cap plus one must fail");
+    assert!(
+        matches!(
+            error,
+            PipelineError::Eval(ref source)
+                if matches!(
+                    source.kind,
+                    cxl::eval::EvalErrorKind::ConstructionDepthExceeded { limit }
+                        if limit == MAX_NESTED_VALUE_DEPTH
+                )
+        ),
+        "unexpected error: {error:?}"
+    );
+    assert!(
+        output.contents().is_empty(),
+        "a rejected value cannot leave partial XML"
+    );
+}
+
+#[test]
+fn xml_repeats_native_children_and_applies_explicit_wrapper_overrides() {
+    let cxl = r##"emit payload = {"@kind": "event", "#text": "before", item: [{"@id": 1, "#text": "alpha"}, {"@id": 2, "#text": "beta"}], tail: "after"}
+emit tags = ["a", "b"]"##;
+
+    let (result, output) = run_transformed(cxl, "kind,key\nok,unused\n", None, true);
+
+    result.expect("recursive and overridden repeats write");
+    assert_eq!(
+        output.as_string(),
+        r#"<Feed><Entry><payload kind="event">before<item id="1">alpha</item><item id="2">beta</item><tail>after</tail></payload><Tags><Tag>a</Tag><Tag>b</Tag></Tags></Entry></Feed>"#
+    );
+}
+
+#[test]
+fn static_and_computed_xml_reserved_key_collisions_have_parity() {
+    let collision_cases = [
+        (
+            r#"emit payload = {"@id": 1, "\\@id": 2}"#,
+            r#"emit payload = {"@id": 1, [key]: 2}"#,
+            r"\@id",
+            "@id",
+        ),
+        (
+            r##"emit payload = {"#text": "one", "\\#text": "two"}"##,
+            r##"emit payload = {"#text": "one", [key]: "two"}"##,
+            r"\#text",
+            "#text",
+        ),
+    ];
+
+    for (static_cxl, computed_cxl, computed_key, logical_key) in collision_cases {
+        let pipeline = transformed_pipeline(static_cxl, None, false);
+        let config = clinker_plan::config::parse_config(&pipeline).expect("pipeline YAML parses");
+        let diagnostics = config
+            .compile(&CompileContext::default())
+            .expect_err("static logical-key collision must fail compilation");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("duplicate map key")),
+            "unexpected diagnostics for {logical_key:?}: {diagnostics:#?}"
+        );
+
+        let input = format!("kind,key\ndynamic,{computed_key}\n");
+        let (result, output) = run_transformed(computed_cxl, &input, None, false);
+        let error = result.expect_err("computed logical-key collision must fail evaluation");
+        assert!(
+            matches!(
+                error,
+                PipelineError::Eval(ref source)
+                    if matches!(
+                        &source.kind,
+                        cxl::eval::EvalErrorKind::DuplicateMapKey { key }
+                            if key == logical_key
+                    )
+            ),
+            "unexpected error for {logical_key:?}: {error:?}"
+        );
+        assert!(
+            output.contents().is_empty(),
+            "a computed collision cannot reach the XML writer"
+        );
+    }
+}
+
+#[test]
+fn value_dependent_unsupported_xml_shapes_fail_before_record_bytes() {
+    let cases = [
+        (
+            "array inside array",
+            "emit payload = if kind == \"bad\" then [[1]] else [1]",
+            "unused",
+        ),
+        (
+            "collection-valued attribute",
+            r#"emit payload = if kind == "bad" then {"@ids": [1]} else {"@ids": 1}"#,
+            "unused",
+        ),
+        (
+            "collection-valued text",
+            r##"emit payload = if kind == "bad" then {"#text": [1]} else {"#text": "ok"}"##,
+            "unused",
+        ),
+        (
+            "computed invalid element name",
+            r#"emit payload = {[key]: 1}"#,
+            "1bad",
+        ),
+    ];
+
+    for (label, cxl, key) in cases {
+        let input = format!("kind,key\nbad,{key}\n");
+        let (result, output) = run_transformed(cxl, &input, None, false);
+        let error = result.expect_err(label);
+        assert!(
+            contains_format_error(&error),
+            "{label} must surface as a format error: {error:?}"
+        );
+        assert!(
+            output.contents().is_empty(),
+            "{label} cannot leave partial XML"
+        );
+    }
+}
+
+#[test]
+fn a_rejected_second_xml_record_leaves_the_first_record_complete() {
+    let cxl = r#"emit payload = if kind == "good" then {item: [1, 2]} else {"@ids": [1]}"#;
+
+    let (result, output) = run_transformed(cxl, "kind,key\ngood,unused\nbad,unused\n", None, false);
+
+    let error = result.expect_err("the second record has an unsupported XML shape");
+    assert!(contains_format_error(&error), "unexpected error: {error:?}");
+    assert_eq!(
+        output.as_string(),
+        "<Feed><Entry><payload><item>1</item><item>2</item></payload></Entry>",
+        "the rejected second record must add no start tag or body bytes"
+    );
+}
+
+#[test]
+fn xml_null_policy_defaults_to_omit_and_never_emits_null_attributes() {
+    let cxl = r#"emit payload = {"@missing": null, empty: null, items: [null, "x"]}
+emit absent = if kind == "ok" then null else "present""#;
+
+    let (default_result, defaulted) = run_transformed(cxl, "kind,key\nok,unused\n", None, false);
+    let (drop_result, dropped) = run_transformed(cxl, "kind,key\nok,unused\n", Some(false), false);
+    let (keep_result, kept) = run_transformed(cxl, "kind,key\nok,unused\n", Some(true), false);
+
+    default_result.expect("default null policy writes");
+    drop_result.expect("drop-null XML writes");
+    keep_result.expect("preserve-null XML writes");
+    assert_eq!(
+        defaulted.contents(),
+        dropped.contents(),
+        "the omitted option must retain the false default"
+    );
+    assert_eq!(
+        dropped.as_string(),
+        "<Feed><Entry><payload><items>x</items></payload></Entry></Feed>"
+    );
+    assert_eq!(
+        kept.as_string(),
+        "<Feed><Entry><payload><empty/><items/><items>x</items></payload><absent/></Entry></Feed>"
+    );
+}

--- a/crates/clinker-format/AGENTS.md
+++ b/crates/clinker-format/AGENTS.md
@@ -76,7 +76,9 @@ Existing dev/bench dependencies are expected: `criterion` and
 - JSON/XML envelope pre-scans retain only declared `$doc.*` paths and enforce `max_index_bytes`.
 - Reader/writer wrappers must delegate hooks such as `current_source_file`, `prepare_document`, `take_envelope_events`, `advance_to_next_file`, `begin_document`, `end_document`, and `bytes_written`.
 - `FormatError::StructuralCount` is the only format error class marked for document-DLQ reclassification; other corruption remains fatal.
-- Non-JSON writers reject `Value::Map` payloads instead of inventing scalar encodings.
+- JSON and XML write `Value::Map` payloads recursively with their documented
+  native key rules; scalar-only writers reject maps instead of inventing an
+  encoding.
 - EDI/HL7 positional ceilings re-exported from readers must stay aligned with planner validation.
 - `SplittingWriter` is a rotation orchestrator; format-specific headers, preambles, and footers belong in writer factories and concrete writers.
 

--- a/crates/clinker-format/src/json/writer.rs
+++ b/crates/clinker-format/src/json/writer.rs
@@ -166,6 +166,15 @@ impl<W: Write> JsonWriter<W> {
     fn serialize_record(&mut self, record: &Record) -> Result<(), FormatError> {
         use serde::Serialize as _;
         self.ensure_plan(record)?;
+        for (index, value) in record.values().iter().enumerate() {
+            if !self.config.include_engine_stamped && record.schema().is_engine_stamped(index) {
+                continue;
+            }
+            clinker_record::nested_key::validate_nested_depth(value)
+                .map_err(|error| FormatError::Json(error.to_string()))?;
+            clinker_record::nested_key::validate_nested_keys(value)
+                .map_err(|error| FormatError::Json(error.to_string()))?;
+        }
         // Disjoint field borrows: serializing reads the plan (`plan_cache`)
         // while writing into `scratch`.
         let Self {
@@ -480,10 +489,21 @@ pub(crate) fn clinker_to_json(val: &Value) -> Result<serde_json::Value, FormatEr
         Value::DateTime(dt) => Jv::String(dt.to_string()),
         Value::Array(arr) => Jv::Array(arr.iter().map(clinker_to_json).collect::<Result<_, _>>()?),
         Value::Map(m) => {
-            let obj = m
-                .iter()
-                .map(|(k, v)| Ok((k.to_string(), clinker_to_json(v)?)))
-                .collect::<Result<_, FormatError>>()?;
+            let mut obj = serde_json::Map::with_capacity(m.len());
+            for (raw_key, value) in m.iter() {
+                let key = clinker_record::nested_key::NestedKey::decode(raw_key)
+                    .map_err(|error| FormatError::Json(error.to_string()))?;
+                let logical_key = key.text.into_owned();
+                if obj
+                    .insert(logical_key.clone(), clinker_to_json(value)?)
+                    .is_some()
+                {
+                    return Err(FormatError::Json(format!(
+                        "duplicate logical nested key {:?}",
+                        logical_key
+                    )));
+                }
+            }
             Jv::Object(obj)
         }
     })
@@ -702,7 +722,9 @@ impl serde::Serialize for ValueSer<'_> {
             Value::Map(m) => {
                 let mut map = serializer.serialize_map(Some(m.len()))?;
                 for (k, v) in m.iter() {
-                    map.serialize_entry(k.as_ref(), &ValueSer(v))?;
+                    let key = clinker_record::nested_key::NestedKey::decode(k)
+                        .map_err(S::Error::custom)?;
+                    map.serialize_entry(key.text.as_ref(), &ValueSer(v))?;
                 }
                 map.end()
             }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -25,6 +25,7 @@ use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 
 use clinker_record::field_path::{self, FieldPathError};
+use clinker_record::nested_key::{NestedKey, validate_nested_depth, validate_nested_keys};
 use clinker_record::{DocumentContext, Record, Schema, Value};
 
 use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
@@ -140,8 +141,8 @@ impl<W: Write> XmlWriter<W> {
 
     /// Fill the reusable `fill` buffer with this record's rendered field values
     /// and per-field presence, in the same iterator order the plan indexes.
-    /// Runs before any bytes are emitted, so a `Value::Map` field (rejected by
-    /// [`write_value_text`]) fails the record without leaving partial output.
+    /// Runs before any bytes are emitted, so malformed recursive values fail
+    /// the record without leaving partial output.
     fn fill_values(&mut self, record: &Record) -> Result<(), FormatError> {
         let Self {
             plan_cache,
@@ -152,14 +153,29 @@ impl<W: Write> XmlWriter<W> {
         let cache = plan_cache.as_ref().expect("plan built before fill_values");
         let flags = &cache.field_is_attr;
         let preserve = config.preserve_nulls;
+        let attribute_prefix = &config.attribute_prefix;
         fill.reset(flags.len());
         if config.include_engine_stamped {
             for (i, (name, val)) in record.iter_all_fields().enumerate() {
-                fill_slot(&mut fill.slots[i], flags[i], preserve, name, val)?;
+                fill_slot(
+                    &mut fill.slots[i],
+                    flags[i],
+                    preserve,
+                    attribute_prefix,
+                    name,
+                    val,
+                )?;
             }
         } else {
             for (i, (name, val)) in record.iter_user_fields().enumerate() {
-                fill_slot(&mut fill.slots[i], flags[i], preserve, name, val)?;
+                fill_slot(
+                    &mut fill.slots[i],
+                    flags[i],
+                    preserve,
+                    attribute_prefix,
+                    name,
+                    val,
+                )?;
             }
         }
         Ok(())
@@ -187,13 +203,38 @@ impl<W: Write> XmlWriter<W> {
         if let Some((field, ref v)) = count_value {
             pairs.push((field, v));
         }
-        let tree = build_field_tree(&pairs, config.preserve_nulls, &config.attribute_prefix)?;
+        let names = pairs.iter().map(|(name, _)| *name).collect::<Vec<_>>();
+        let (plan, field_is_attr) = build_tree_plan(&names, config)?;
+        let mut fill = FillBuf::new();
+        fill.reset(pairs.len());
+        for (index, (name, value)) in pairs.iter().enumerate() {
+            fill_slot(
+                &mut fill.slots[index],
+                field_is_attr[index],
+                config.preserve_nulls,
+                &config.attribute_prefix,
+                name,
+                value,
+            )?;
+        }
+        let values = pairs.iter().map(|(_, value)| *value).collect::<Vec<_>>();
         let mut start = BytesStart::new(wrapper);
-        push_attributes(&mut start, &tree.attrs);
+        for attr in &plan.root.attrs {
+            if fill.emits(attr.field) {
+                push_one_attribute(&mut start, &attr.name, fill.text(attr.field));
+            }
+        }
         writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
-        write_field_tree(writer, &tree.children)?;
+        emit_body(
+            writer,
+            &plan.root,
+            &fill,
+            &values,
+            config.preserve_nulls,
+            &config.attribute_prefix,
+        )?;
         let end = BytesEnd::new(wrapper);
         writer
             .write_event(Event::End(end))
@@ -220,70 +261,23 @@ impl<W: Write> XmlWriter<W> {
     }
 }
 
-/// Recursively write a field tree as nested XML elements. Takes the emitter
-/// directly rather than `&mut self`, so a caller can render an envelope section
-/// while holding a disjoint borrow of the framer.
-fn write_field_tree<W: Write>(
-    writer: &mut XmlEmitter<W>,
-    nodes: &[FieldNode],
-) -> Result<(), FormatError> {
-    for node in nodes {
-        match node {
-            FieldNode::Leaf { name, text } => {
-                if text.is_empty() {
-                    // Self-closing empty element (for preserve_nulls: true)
-                    let elem = BytesStart::new(name.as_str());
-                    writer
-                        .write_event(Event::Empty(elem))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                } else {
-                    let start = BytesStart::new(name.as_str());
-                    writer
-                        .write_event(Event::Start(start))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    let text_event = BytesText::new(text);
-                    writer
-                        .write_event(Event::Text(text_event))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    let end = BytesEnd::new(name.as_str());
-                    writer
-                        .write_event(Event::End(end))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                }
-            }
-            FieldNode::Branch { name, body } => {
-                let mut start = BytesStart::new(name.as_str());
-                push_attributes(&mut start, &body.attrs);
-                if body.children.is_empty() {
-                    // Attribute-only branch: nothing nests inside, so the
-                    // element self-closes carrying its attributes.
-                    writer
-                        .write_event(Event::Empty(start))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                } else {
-                    writer
-                        .write_event(Event::Start(start))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    write_field_tree(writer, &body.children)?;
-                    let end = BytesEnd::new(name.as_str());
-                    writer
-                        .write_event(Event::End(end))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
 impl<W: Write + Send> FormatWriter for XmlWriter<W> {
     fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
         // Both the plan build and the value fill run before the record start
         // tag is emitted: attribute-classified fields must be known when the
-        // tag opens, and a rejected field (map payload, malformed attribute
+        // tag opens, and a rejected field (malformed nested value or attribute
         // name) must not leave a dangling half-written record behind.
         self.ensure_plan(record)?;
         self.fill_values(record)?;
+
+        // The plan indexes emitted schema fields positionally. Borrow the
+        // corresponding values for the recursive collection emitter; this
+        // vector is bounded by schema width and does not clone record data.
+        let emitted_values: Vec<&Value> = if self.config.include_engine_stamped {
+            record.iter_all_fields().map(|(_, value)| value).collect()
+        } else {
+            record.iter_user_fields().map(|(_, value)| value).collect()
+        };
 
         self.write_header()?;
 
@@ -307,7 +301,14 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
         }
         writer.write_event(Event::Start(start)).map_err(xml_err)?;
 
-        emit_body(writer, &plan.root, fill)?;
+        emit_body(
+            writer,
+            &plan.root,
+            fill,
+            &emitted_values,
+            config.preserve_nulls,
+            &config.attribute_prefix,
+        )?;
 
         writer
             .write_event(Event::End(BytesEnd::new(&*config.record_element)))
@@ -381,83 +382,14 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
     }
 }
 
-// ── Field tree for dotted name → nested element expansion ────────────
-
 /// Wrap a field-name grammar failure as this writer's error.
 fn field_path_error(source: FieldPathError) -> FormatError {
     FormatError::field_path("XML", source)
 }
 
-/// One element's content: the attributes attached to its start tag plus its
-/// child nodes. The whole body is materialized before the element's start
-/// tag is emitted, because attributes have to be known at that point.
-#[derive(Default)]
-struct ElementBody {
-    attrs: Vec<(String, String)>,
-    children: Vec<FieldNode>,
-}
-
-enum FieldNode {
-    Leaf { name: String, text: String },
-    Branch { name: String, body: ElementBody },
-}
-
-/// Build an element body from dotted field names. Fields with shared
-/// prefixes are grouped under a single parent branch
-/// (`Address.City` + `Address.State` → one `Address` branch with two leaf
-/// children), and a field whose final segment carries the attribute prefix
-/// becomes an attribute of its enclosing element instead of a child
-/// (`@id` → attribute on the returned body, `Address.@type` → attribute on
-/// the `Address` branch).
-///
-/// Null attribute fields are dropped even under `preserve_nulls` — a null
-/// element round-trips as a self-closing tag, but an attribute has no
-/// present-but-empty form that reads back as null.
-///
-/// Returns `FormatError::UnserializableMapValue` if any field carries
-/// a `Value::Map` payload — XML elements have no canonical scalar
-/// serialization for a map, and `value_to_text` raises from the Map
-/// arm directly. Returns `FormatError::Xml` for a malformed attribute
-/// path (a prefixed segment with children nested under it, or a bare
-/// prefix with no attribute name).
-fn build_field_tree(
-    fields: &[(&str, &Value)],
-    preserve_nulls: bool,
-    attribute_prefix: &str,
-) -> Result<ElementBody, FormatError> {
-    field_path::check_expandable(fields.iter().map(|&(name, _)| name)).map_err(field_path_error)?;
-    let mut root = ElementBody::default();
-
-    for &(name, val) in fields {
-        let path = field_path::decode(name).map_err(field_path_error)?;
-        if val.is_null() && (!preserve_nulls || is_attribute_path(&path, attribute_prefix)) {
-            continue;
-        }
-        let text = value_to_text(name, val)?;
-        insert_field(&mut root, name, &path, &text, attribute_prefix)?;
-    }
-
-    Ok(root)
-}
-
-/// Push name/value attributes onto an element's start tag, escaping each
-/// value.
-///
-/// quick-xml's `(&str, &str)` attribute conversion escapes only the five
-/// predefined entities, leaving literal tab / CR / LF untouched — a
-/// conformant parser then collapses those to spaces (XML attribute-value
-/// normalization), silently altering values that carry literal whitespace.
-/// They are written as character references instead, which both clinker's
-/// reader and any conformant parser resolve back to the exact bytes.
-fn push_attributes(start: &mut BytesStart, attrs: &[(String, String)]) {
-    for (key, value) in attrs {
-        push_one_attribute(start, key, value);
-    }
-}
-
 /// Push a single name/value attribute onto an element's start tag, escaping the
-/// value (see [`push_attributes`] for why literal whitespace is emitted as
-/// character references).
+/// value. Literal whitespace is emitted as character references so a
+/// conformant parser does not normalize it to spaces.
 fn push_one_attribute(start: &mut BytesStart, key: &str, value: &str) {
     start.push_attribute(Attribute {
         key: QName(key.as_bytes()),
@@ -489,15 +421,6 @@ fn escape_attribute_value(raw: &str) -> String {
         }
     }
     escaped
-}
-
-/// True when the path's final segment is attribute-classified — i.e. a
-/// non-empty prefix marks it as an attribute of its enclosing element.
-fn is_attribute_path(path: &[Cow<'_, str>], attribute_prefix: &str) -> bool {
-    !attribute_prefix.is_empty()
-        && path
-            .last()
-            .is_some_and(|segment| segment.starts_with(attribute_prefix))
 }
 
 /// True when `c` may begin an XML 1.0 `Name` (the `NameStartChar`
@@ -570,86 +493,12 @@ fn check_xml_name(name: &str, context: &str) -> Result<(), FormatError> {
     }
 }
 
-/// Insert a decoded field path into the tree, creating branches as needed.
-/// An attribute-prefixed segment must be the path's final segment (an
-/// attribute is a leaf — nothing can nest under it); `field` is the full
-/// original field name, carried for error messages.
-fn insert_field(
-    body: &mut ElementBody,
-    field: &str,
-    path: &[Cow<'_, str>],
-    text: &str,
-    attribute_prefix: &str,
-) -> Result<(), FormatError> {
-    let (segment, rest) = path
-        .split_first()
-        .expect("a decoded field path has at least one segment");
-    if !rest.is_empty() {
-        if !attribute_prefix.is_empty() && segment.starts_with(attribute_prefix) {
-            return Err(FormatError::Xml(format!(
-                "field '{field}': attribute-prefixed segment '{segment}' \
-                 cannot have fields nested under it — an XML attribute is a leaf"
-            )));
-        }
-        check_xml_name(segment, &format!("field '{field}': element"))?;
-        // Find or create a branch for `segment`
-        let branch = body.children.iter_mut().find(
-            |n| matches!(n, FieldNode::Branch { name, .. } if name.as_str() == segment.as_ref()),
-        );
-        if let Some(FieldNode::Branch {
-            body: branch_body, ..
-        }) = branch
-        {
-            insert_field(branch_body, field, rest, text, attribute_prefix)
-        } else {
-            let mut branch_body = ElementBody::default();
-            insert_field(&mut branch_body, field, rest, text, attribute_prefix)?;
-            body.children.push(FieldNode::Branch {
-                name: segment.to_string(),
-                body: branch_body,
-            });
-            Ok(())
-        }
-    } else if !attribute_prefix.is_empty() && segment.starts_with(attribute_prefix) {
-        let attr_name = &segment[attribute_prefix.len()..];
-        if attr_name.is_empty() {
-            return Err(FormatError::Xml(format!(
-                "field '{field}': attribute prefix '{attribute_prefix}' \
-                 carries no attribute name"
-            )));
-        }
-        if !is_valid_xml_name(attr_name) {
-            return Err(FormatError::Xml(format!(
-                "field '{field}': attribute name '{attr_name}' is not a \
-                 well-formed XML name"
-            )));
-        }
-        body.attrs.push((attr_name.to_string(), text.to_string()));
-        Ok(())
-    } else {
-        check_xml_name(segment, &format!("field '{field}': element"))?;
-        body.children.push(FieldNode::Leaf {
-            name: segment.to_string(),
-            text: text.to_string(),
-        });
-        Ok(())
-    }
-}
-
 /// Convert a clinker Value to XML text content.
 ///
-/// This renders a single scalar into one element body. A top-level
-/// `Value::Array` at a record element field is a `multiple:` field, emitted as
-/// repeated child elements before reaching here (see [`fill_slot`] and
-/// [`emit_repeated_leaf`]) — so an array reaching this scalar renderer is a
-/// NESTED collection (an array or map inside a `multiple:` field), which has no
-/// element-body serialization. A `Value::Map` likewise has none. Both return
-/// `FormatError::UnserializableMapValue` / `FormatError::UnserializableArrayValue`
-/// carrying the offending column rather than being silently flattened, which
-/// would hide a routing bug (e.g. a `$widened` sidecar reaching the writer
-/// without `include_unmapped: true` expansion). The envelope-section path also
-/// renders through here, so a section field carrying a collection is rejected
-/// the same way.
+/// This renders one scalar for an element body, attribute, or `#text` entry.
+/// Recursive callers dispatch arrays and maps before reaching this helper; the
+/// collection error arms are defensive invariant checks rather than a fallback
+/// serialization.
 fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
     let mut buf = String::new();
     write_value_text(&mut buf, col, val)?;
@@ -657,9 +506,7 @@ fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
 }
 
 /// Render a clinker Value as XML text content into `buf` (appending). Shares
-/// its logic with [`value_to_text`] so the record fast path and the envelope
-/// section path stay byte-identical. `Value::Map` and `Value::Array` are
-/// rejected exactly as `value_to_text` documents.
+/// its logic with [`value_to_text`] so every scalar path stays byte-identical.
 fn write_value_text(buf: &mut String, col: &str, val: &Value) -> Result<(), FormatError> {
     use std::fmt::Write as _;
     match val {
@@ -766,14 +613,25 @@ struct PlanCache {
 
 /// Build the tree plan for a record's schema. Walks the fields in iterator
 /// order (position = field index) and classifies each into the element tree,
-/// validating attribute names up front. Mirrors [`build_field_tree`]'s shape
-/// exactly so output stays byte-identical.
+/// validating attribute names up front.
 fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCache, FormatError> {
     let names: Vec<&str> = if config.include_engine_stamped {
         record.iter_all_fields().map(|(name, _)| name).collect()
     } else {
         record.iter_user_fields().map(|(name, _)| name).collect()
     };
+    let (plan, field_is_attr) = build_tree_plan(&names, config)?;
+    Ok(PlanCache {
+        schema: Arc::clone(record.schema()),
+        plan,
+        field_is_attr,
+    })
+}
+
+fn build_tree_plan(
+    names: &[&str],
+    config: &XmlWriterConfig,
+) -> Result<(TreePlan, Vec<bool>), FormatError> {
     field_path::check_expandable(names.iter().copied()).map_err(field_path_error)?;
     let mut root = PlanBody::default();
     let mut field_is_attr = vec![false; names.len()];
@@ -789,11 +647,7 @@ fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCac
             &mut field_is_attr,
         )?;
     }
-    Ok(PlanCache {
-        schema: Arc::clone(record.schema()),
-        plan: TreePlan { root },
-        field_is_attr,
-    })
+    Ok((TreePlan { root }, field_is_attr))
 }
 
 /// Insert a decoded field path into the plan, creating branches as needed —
@@ -931,16 +785,13 @@ struct FillBuf {
 
 #[derive(Default)]
 struct FillSlot {
-    /// Scalar rendering. Empty when the field is null-dropped or holds an array.
+    /// Scalar rendering. Empty when the field is null-dropped or holds a
+    /// recursively structured value.
     text: String,
-    /// Per-element renderings when the field's value is a `Value::Array`. The
-    /// live entries are `parts[..part_count]`; the `Vec` and each inner `String`
-    /// retain their capacity across records, like `text` does.
-    parts: Vec<String>,
-    part_count: usize,
-    /// True when this slot holds an array — the repeated-element emit path reads
-    /// `parts` rather than `text`.
-    is_array: bool,
+    /// True for a native array or map. The emitter then borrows the original
+    /// record value after the validation pass instead of materializing a
+    /// second owned tree.
+    is_structured: bool,
     emits: bool,
 }
 
@@ -967,12 +818,8 @@ impl FillBuf {
         &self.slots[field].text
     }
 
-    /// The per-element renderings for an array field, or `None` for a scalar.
-    /// A returned slice is always non-empty: an empty array sets `emits = false`,
-    /// so callers gate on `emits` before reaching here.
-    fn parts(&self, field: usize) -> Option<&[String]> {
-        let slot = &self.slots[field];
-        slot.is_array.then_some(&slot.parts[..slot.part_count])
+    fn is_structured(&self, field: usize) -> bool {
+        self.slots[field].is_structured
     }
 }
 
@@ -983,38 +830,23 @@ impl FillBuf {
 /// preserved null element renders to the empty string, emitted as a self-closing
 /// tag).
 ///
-/// A `Value::Array` at an ELEMENT field is a `multiple:` field: each element is
-/// rendered into `parts` for the repeated-element emit path, and an empty array
-/// drops the field (`emits = false`) so it emits nothing. An array at an
-/// ATTRIBUTE field is rejected — an XML attribute holds a single value and
-/// cannot repeat.
+/// Arrays and maps at element fields are fully validated here before the record
+/// start tag is written, then emitted recursively from the borrowed value.
+/// Attributes remain scalar-only.
 fn fill_slot(
     slot: &mut FillSlot,
     is_attr: bool,
     preserve_nulls: bool,
+    attribute_prefix: &str,
     name: &str,
     val: &Value,
 ) -> Result<(), FormatError> {
-    slot.is_array = false;
-    slot.part_count = 0;
+    slot.is_structured = false;
     match val {
         Value::Array(items) if !is_attr => {
-            // BACKSTOP GAP: this treats ANY top-level array at an element field
-            // as a `multiple:` field and emits repeated elements, because the
-            // writer is not given the declared-`multiple:` column set — its
-            // config carries only the `join_values` override subset, not every
-            // declared-multiple field. A misrouted runtime array on a column
-            // that is NOT declared `multiple:` (e.g. a stray `match: collect`
-            // result) is therefore emitted as repeats rather than failing loud
-            // with `UnserializableArrayValue`. A NESTED array (array-inside-a-
-            // field) is still caught by `write_value_text` in `fill_parts`;
-            // only the top-level non-multiple case slips through. Restoring the
-            // loud backstop needs the plan to thread the declared-multiple set
-            // into `XmlWriterConfig` — the same missing plumbing the CSV writer
-            // has at https://github.com/rustpunk/clinker/issues/853.
-            slot.is_array = true;
+            validate_xml_nested_value(val, name, attribute_prefix)?;
+            slot.is_structured = true;
             slot.text.clear();
-            fill_parts(slot, name, items)?;
             slot.emits = !items.is_empty();
         }
         Value::Array(_) => {
@@ -1022,6 +854,19 @@ fn fill_slot(
                 "field '{name}': an XML attribute cannot hold multiple values — a \
                  `multiple:` field maps to repeated elements, not an attribute"
             )));
+        }
+        Value::Map(_) if is_attr => {
+            return Err(FormatError::UnserializableMapValue {
+                format: "XML",
+                column: name.to_string(),
+            });
+        }
+        Value::Map(_) => {
+            validate_xml_nested_value(val, name, attribute_prefix)?;
+            slot.is_structured = true;
+            slot.text.clear();
+            // A map has a named container even when it has no children.
+            slot.emits = true;
         }
         _ => {
             let skip = if is_attr {
@@ -1039,31 +884,86 @@ fn fill_slot(
     Ok(())
 }
 
-/// Render each element of a `multiple:` field's array into the slot's `parts`,
-/// reusing the existing `String` capacity. A nested collection element (an array
-/// or map inside the field) has no element body and is rejected by
-/// [`write_value_text`], the same misroute detection the scalar path applies.
-fn fill_parts(slot: &mut FillSlot, name: &str, items: &[Value]) -> Result<(), FormatError> {
-    if slot.parts.len() < items.len() {
-        slot.parts.resize_with(items.len(), String::new);
+/// Validate every recursive XML decision before any bytes for the record are
+/// written. Neutral maps preserve insertion order; unescaped reserved keys
+/// become attributes or text, while escaped keys remain ordinary element
+/// names. Arrays repeat their containing element name and therefore cannot be
+/// nested directly inside another array without an intervening map key.
+fn validate_xml_nested_value(
+    value: &Value,
+    field: &str,
+    attribute_prefix: &str,
+) -> Result<(), FormatError> {
+    validate_nested_depth(value)
+        .map_err(|error| FormatError::Xml(format!("field '{field}': {error}")))?;
+    validate_nested_keys(value)
+        .map_err(|error| FormatError::Xml(format!("field '{field}': {error}")))?;
+
+    fn visit(value: &Value, field: &str, attribute_prefix: &str) -> Result<(), FormatError> {
+        match value {
+            Value::Array(items) => {
+                for item in items {
+                    if matches!(item, Value::Array(_)) {
+                        return Err(FormatError::UnserializableArrayValue {
+                            format: "XML",
+                            column: field.to_string(),
+                        });
+                    }
+                    visit(item, field, attribute_prefix)?;
+                }
+            }
+            Value::Map(entries) => {
+                for (raw_key, child) in entries.iter() {
+                    let key = NestedKey::decode(raw_key).expect("keys validated above");
+                    let is_attribute = !key.escaped
+                        && !attribute_prefix.is_empty()
+                        && key.text.starts_with(attribute_prefix);
+                    let is_text = !key.escaped && key.text == "#text";
+                    if is_attribute {
+                        let name = &key.text[attribute_prefix.len()..];
+                        if name.is_empty() {
+                            return Err(FormatError::Xml(format!(
+                                "field '{field}': attribute prefix '{attribute_prefix}' carries no attribute name"
+                            )));
+                        }
+                        check_xml_name(name, &format!("field '{field}': nested attribute"))?;
+                        if matches!(child, Value::Array(_) | Value::Map(_)) {
+                            return Err(FormatError::Xml(format!(
+                                "field '{field}': nested XML attribute '{}' must hold a scalar value",
+                                key.text
+                            )));
+                        }
+                    } else if is_text {
+                        if matches!(child, Value::Array(_) | Value::Map(_)) {
+                            return Err(FormatError::Xml(format!(
+                                "field '{field}': nested XML #text must hold a scalar value"
+                            )));
+                        }
+                    } else {
+                        check_xml_name(&key.text, &format!("field '{field}': nested element"))?;
+                        visit(child, field, attribute_prefix)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
     }
-    for (i, item) in items.iter().enumerate() {
-        slot.parts[i].clear();
-        write_value_text(&mut slot.parts[i], name, item)?;
-    }
-    slot.part_count = items.len();
-    Ok(())
+
+    visit(value, field, attribute_prefix)
 }
 
 /// Emit a body's child nodes (its start-tag attributes are handled by the
 /// caller). A branch is emitted only when it has at least one emitting
 /// attribute or child, and self-closes when it has no emitting children —
-/// matching the pruning `build_field_tree` performs by never inserting a
-/// dropped field.
+/// matching the null-pruning rules used while filling each leaf.
 fn emit_body<W: Write>(
     writer: &mut XmlEmitter<W>,
     body: &PlanBody,
     fill: &FillBuf,
+    values: &[&Value],
+    preserve_nulls: bool,
+    attribute_prefix: &str,
 ) -> Result<(), FormatError> {
     for child in &body.children {
         match child {
@@ -1075,8 +975,15 @@ fn emit_body<W: Write>(
                 if !fill.emits(*field) {
                     continue;
                 }
-                if let Some(parts) = fill.parts(*field) {
-                    emit_repeated_leaf(writer, name, repeat, parts)?;
+                if fill.is_structured(*field) {
+                    emit_structured_leaf(
+                        writer,
+                        name,
+                        repeat,
+                        values[*field],
+                        preserve_nulls,
+                        attribute_prefix,
+                    )?;
                     continue;
                 }
                 let text = fill.text(*field);
@@ -1122,7 +1029,7 @@ fn emit_body<W: Write>(
                 }
                 if has_children {
                     writer.write_event(Event::Start(start)).map_err(xml_err)?;
-                    emit_body(writer, body, fill)?;
+                    emit_body(writer, body, fill, values, preserve_nulls, attribute_prefix)?;
                     writer
                         .write_event(Event::End(BytesEnd::new(name.as_str())))
                         .map_err(xml_err)?;
@@ -1133,6 +1040,160 @@ fn emit_body<W: Write>(
         }
     }
     Ok(())
+}
+
+/// Emit one schema leaf whose value is a native map or array. Array items reuse
+/// the leaf (or configured `repeat_as`) name; a map is one structured item.
+fn emit_structured_leaf<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    leaf_name: &str,
+    repeat: &Option<XmlRepeat>,
+    value: &Value,
+    preserve_nulls: bool,
+    attribute_prefix: &str,
+) -> Result<(), FormatError> {
+    let item_name = repeat.as_ref().map_or(leaf_name, |r| r.item_name.as_str());
+    let wrap_in = repeat.as_ref().and_then(|r| r.wrap_in.as_deref());
+    if let Some(container) = wrap_in {
+        writer
+            .write_event(Event::Start(BytesStart::new(container)))
+            .map_err(xml_err)?;
+    }
+
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                emit_named_value(writer, item_name, item, preserve_nulls, attribute_prefix)?;
+            }
+        }
+        Value::Map(_) => {
+            emit_named_value(writer, item_name, value, preserve_nulls, attribute_prefix)?
+        }
+        _ => unreachable!("structured slots contain only maps and arrays"),
+    }
+
+    if let Some(container) = wrap_in {
+        writer
+            .write_event(Event::End(BytesEnd::new(container)))
+            .map_err(xml_err)?;
+    }
+    Ok(())
+}
+
+/// Emit a named native value recursively. Validation has already established
+/// legal names, scalar-only attributes/text, canonical keys, and bounded depth.
+fn emit_named_value<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    name: &str,
+    value: &Value,
+    preserve_nulls: bool,
+    attribute_prefix: &str,
+) -> Result<(), FormatError> {
+    match value {
+        Value::Null if !preserve_nulls => Ok(()),
+        Value::Null => writer
+            .write_event(Event::Empty(BytesStart::new(name)))
+            .map_err(xml_err),
+        Value::Array(items) => {
+            for item in items {
+                emit_named_value(writer, name, item, preserve_nulls, attribute_prefix)?;
+            }
+            Ok(())
+        }
+        Value::Map(entries) => {
+            let mut start = BytesStart::new(name);
+            for (raw_key, child) in entries.iter() {
+                let key = NestedKey::decode(raw_key).expect("keys validated before emission");
+                let is_attribute = !key.escaped
+                    && !attribute_prefix.is_empty()
+                    && key.text.starts_with(attribute_prefix);
+                if is_attribute && !child.is_null() {
+                    let attr_name = &key.text[attribute_prefix.len()..];
+                    let text = value_to_text(raw_key, child)?;
+                    push_one_attribute(&mut start, attr_name, &text);
+                }
+            }
+
+            if !map_has_content(entries, preserve_nulls, attribute_prefix) {
+                return writer.write_event(Event::Empty(start)).map_err(xml_err);
+            }
+            writer.write_event(Event::Start(start)).map_err(xml_err)?;
+            for (raw_key, child) in entries.iter() {
+                let key = NestedKey::decode(raw_key).expect("keys validated before emission");
+                let is_attribute = !key.escaped
+                    && !attribute_prefix.is_empty()
+                    && key.text.starts_with(attribute_prefix);
+                if is_attribute {
+                    continue;
+                }
+                if !key.escaped && key.text == "#text" {
+                    if !child.is_null() {
+                        let text = value_to_text(raw_key, child)?;
+                        if !text.is_empty() {
+                            writer
+                                .write_event(Event::Text(BytesText::new(&text)))
+                                .map_err(xml_err)?;
+                        }
+                    }
+                    continue;
+                }
+                emit_named_value(writer, &key.text, child, preserve_nulls, attribute_prefix)?;
+            }
+            writer
+                .write_event(Event::End(BytesEnd::new(name)))
+                .map_err(xml_err)
+        }
+        _ => {
+            let text = value_to_text(name, value)?;
+            if text.is_empty() {
+                writer
+                    .write_event(Event::Empty(BytesStart::new(name)))
+                    .map_err(xml_err)
+            } else {
+                writer
+                    .write_event(Event::Start(BytesStart::new(name)))
+                    .map_err(xml_err)?;
+                writer
+                    .write_event(Event::Text(BytesText::new(&text)))
+                    .map_err(xml_err)?;
+                writer
+                    .write_event(Event::End(BytesEnd::new(name)))
+                    .map_err(xml_err)
+            }
+        }
+    }
+}
+
+fn map_has_content(
+    entries: &indexmap::IndexMap<Box<str>, Value>,
+    preserve_nulls: bool,
+    attribute_prefix: &str,
+) -> bool {
+    entries.iter().any(|(raw_key, child)| {
+        let key = NestedKey::decode(raw_key).expect("keys validated before emission");
+        let is_attribute =
+            !key.escaped && !attribute_prefix.is_empty() && key.text.starts_with(attribute_prefix);
+        if is_attribute {
+            return false;
+        }
+        if !key.escaped && key.text == "#text" {
+            return match child {
+                Value::Null => false,
+                Value::String(text) => !text.is_empty(),
+                _ => true,
+            };
+        }
+        value_emits(child, preserve_nulls)
+    })
+}
+
+fn value_emits(value: &Value, preserve_nulls: bool) -> bool {
+    match value {
+        Value::Null => preserve_nulls,
+        Value::Array(items) => items.iter().any(|item| value_emits(item, preserve_nulls)),
+        Value::Map(_) => true,
+        _ => true,
+    }
 }
 
 /// Emit a `multiple:` field's values as repeated child elements. `parts` holds
@@ -1443,30 +1504,78 @@ mod tests {
         assert_eq!(r2.get("name"), Some(&Value::String("Bob".into())));
     }
 
-    /// XML writer rejects `Value::Map` payloads with
-    /// `FormatError::UnserializableMapValue`. The pre-walk in
-    /// `write_fields` catches the misroute before the value-to-text
-    /// function silently JSON-encodes the map inside an element.
+    /// Native maps use reserved `@...` and `#text` keys while ordinary keys
+    /// become child elements. Arrays repeat their containing child name and
+    /// preserve author insertion order.
     #[test]
-    fn test_xml_writer_rejects_map_value() {
+    fn test_xml_writer_emits_recursive_map_and_array_values() {
         use indexmap::IndexMap;
         let schema = Arc::new(Schema::new(vec!["id".into(), "payload".into()]));
-        let mut sidecar: IndexMap<Box<str>, Value> = IndexMap::new();
-        sidecar.insert("a".into(), Value::Integer(1));
+
+        let mut first: IndexMap<Box<str>, Value> = IndexMap::new();
+        first.insert("@id".into(), Value::Integer(1));
+        first.insert("#text".into(), Value::String("alpha".into()));
+        let mut second: IndexMap<Box<str>, Value> = IndexMap::new();
+        second.insert("@id".into(), Value::Integer(2));
+        second.insert("#text".into(), Value::String("beta".into()));
+
+        let mut payload: IndexMap<Box<str>, Value> = IndexMap::new();
+        payload.insert("@kind".into(), Value::String("event".into()));
+        payload.insert("#text".into(), Value::String("before".into()));
+        payload.insert(
+            "item".into(),
+            Value::Array(vec![
+                Value::Map(Box::new(first)),
+                Value::Map(Box::new(second)),
+            ]),
+        );
+        payload.insert("tail".into(), Value::String("after".into()));
         let record = Record::new(
             Arc::clone(&schema),
-            vec![Value::Integer(7), Value::Map(Box::new(sidecar))],
+            vec![Value::Integer(7), Value::Map(Box::new(payload))],
         );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(
+            output,
+            "<Root><Record><id>7</id><payload kind=\"event\">before<item id=\"1\">alpha</item><item id=\"2\">beta</item><tail>after</tail></payload></Record></Root>"
+        );
+    }
+
+    #[test]
+    fn test_xml_writer_rejects_duplicate_decoded_map_keys_before_output() {
+        use indexmap::IndexMap;
+        let schema = Arc::new(Schema::new(vec!["payload".into()]));
+        let mut payload: IndexMap<Box<str>, Value> = IndexMap::new();
+        payload.insert("@id".into(), Value::Integer(1));
+        payload.insert("\\@id".into(), Value::Integer(2));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Map(Box::new(payload))]);
         let mut buf = Vec::new();
         let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
         let err = writer.write_record(&record).unwrap_err();
-        match err {
-            FormatError::UnserializableMapValue { format, column } => {
-                assert_eq!(format, "XML");
-                assert_eq!(column, "payload");
-            }
-            other => panic!("expected UnserializableMapValue, got {other:?}"),
-        }
+        assert!(
+            matches!(&err, FormatError::Xml(message) if message.contains("duplicate logical nested key \"@id\"")),
+            "unexpected error: {err:?}"
+        );
+        drop(writer);
+        assert!(buf.is_empty(), "rejected record must emit no partial XML");
+    }
+
+    #[test]
+    fn test_xml_writer_rejects_collection_valued_nested_attribute_before_output() {
+        use indexmap::IndexMap;
+        let schema = Arc::new(Schema::new(vec!["payload".into()]));
+        let mut payload: IndexMap<Box<str>, Value> = IndexMap::new();
+        payload.insert("@ids".into(), Value::Array(vec![Value::Integer(1)]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Map(Box::new(payload))]);
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Xml(message) if message.contains("attribute '@ids' must hold a scalar")),
+            "unexpected error: {err:?}"
+        );
+        drop(writer);
+        assert!(buf.is_empty(), "rejected record must emit no partial XML");
     }
 
     /// Build a `[id, tags]` record whose `tags` field carries `values`.
@@ -2411,6 +2520,37 @@ mod tests {
         let out = String::from_utf8(buf).unwrap();
         assert!(
             out.contains(r#"<header version="1.1"><batch_id>A</batch_id></header>"#),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn xml_envelope_section_writes_native_nested_value() {
+        use indexmap::IndexMap;
+
+        let schema = Arc::new(Schema::new(vec!["amount".into()]));
+        let config = XmlWriterConfig {
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: None,
+                footer_record_count_field: None,
+            }),
+            ..Default::default()
+        };
+        let mut metadata: IndexMap<Box<str>, Value> = IndexMap::new();
+        metadata.insert("@kind".into(), Value::String("batch".into()));
+        metadata.insert("name".into(), Value::String("A".into()));
+        let doc = doc_with_sections(&[("Head", &[("metadata", Value::Map(Box::new(metadata)))])]);
+        let mut buf = Vec::new();
+        {
+            let mut w = XmlWriter::new(&mut buf, Arc::clone(&schema), config);
+            w.begin_document(&doc).unwrap();
+            w.end_document(&doc).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains(r#"<header><metadata kind="batch"><name>A</name></metadata></header>"#),
             "got: {out}"
         );
     }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -14,15 +14,19 @@
 //! header section as a `<header>` element; the body `<Record>` elements stream
 //! between; `end_document` emits a `<footer>` element (section fields plus the
 //! streaming record count) and closes `</Document>`. No document is buffered.
+//!
+//! Each record is processed in two borrowed passes. The first validates the
+//! complete schema/value shape, XML names and scalar roles without touching the
+//! destination. The second emits directly from the original [`Record`]. The
+//! writer retains only a schema-derived tree plan across calls; it retains no
+//! rendered record values or record-sized scalar capacity.
 
 use std::borrow::Cow;
 use std::io::Write;
 use std::sync::Arc;
 
 use quick_xml::Writer as XmlEmitter;
-use quick_xml::events::attributes::Attribute;
-use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
-use quick_xml::name::QName;
+use quick_xml::events::{BytesEnd, BytesStart, Event};
 
 use clinker_record::field_path::{self, FieldPathError};
 use clinker_record::nested_key::{NestedKey, validate_nested_depth, validate_nested_keys};
@@ -79,12 +83,16 @@ impl Default for XmlWriterConfig {
     }
 }
 
+/// Streaming XML writer with complete-record validation before record bytes.
+///
+/// The writer borrows values twice per call and retains no per-record
+/// preparation state. Its only memoized heap state is the schema-derived XML
+/// tree plan, whose size is independent of record value widths.
 pub struct XmlWriter<W: Write> {
     writer: XmlEmitter<W>,
-    /// Schema pinned for the writer's lifetime. After the overflow rip
-    /// the emit path walks `Record::iter_all_fields` (schema-positional),
-    /// so the writer does not consult the schema per record — but the
-    /// Arc ownership here keeps factory callers honest.
+    /// Schema pinned for the writer's lifetime. The borrowed emit path walks
+    /// each record positionally, while this ownership keeps factory callers
+    /// honest about the stream's declared schema.
     _schema: Arc<Schema>,
     config: XmlWriterConfig,
     header_written: bool,
@@ -98,11 +106,6 @@ pub struct XmlWriter<W: Write> {
     /// lazily on the first `write_record` from `record.schema()` and rebuilt on
     /// a schema-identity change, so a multi-schema output stays correct.
     plan_cache: Option<PlanCache>,
-    /// Reusable per-record value buffer, one slot per field in iterator order.
-    /// Each slot's `String` capacity is retained across records so filling a
-    /// record's values reuses the allocation rather than building a fresh owned
-    /// tree. Bounded by the widest single record.
-    fill: FillBuf,
 }
 
 impl<W: Write> XmlWriter<W> {
@@ -118,7 +121,6 @@ impl<W: Write> XmlWriter<W> {
             header_written: false,
             framer,
             plan_cache: None,
-            fill: FillBuf::new(),
         }
     }
 
@@ -139,48 +141,6 @@ impl<W: Write> XmlWriter<W> {
         Ok(())
     }
 
-    /// Fill the reusable `fill` buffer with this record's rendered field values
-    /// and per-field presence, in the same iterator order the plan indexes.
-    /// Runs before any bytes are emitted, so malformed recursive values fail
-    /// the record without leaving partial output.
-    fn fill_values(&mut self, record: &Record) -> Result<(), FormatError> {
-        let Self {
-            plan_cache,
-            fill,
-            config,
-            ..
-        } = self;
-        let cache = plan_cache.as_ref().expect("plan built before fill_values");
-        let flags = &cache.field_is_attr;
-        let preserve = config.preserve_nulls;
-        let attribute_prefix = &config.attribute_prefix;
-        fill.reset(flags.len());
-        if config.include_engine_stamped {
-            for (i, (name, val)) in record.iter_all_fields().enumerate() {
-                fill_slot(
-                    &mut fill.slots[i],
-                    flags[i],
-                    preserve,
-                    attribute_prefix,
-                    name,
-                    val,
-                )?;
-            }
-        } else {
-            for (i, (name, val)) in record.iter_user_fields().enumerate() {
-                fill_slot(
-                    &mut fill.slots[i],
-                    flags[i],
-                    preserve,
-                    attribute_prefix,
-                    name,
-                    val,
-                )?;
-            }
-        }
-        Ok(())
-    }
-
     /// Emit a `<wrapper>…</wrapper>` element whose children are the section's
     /// fields rendered as nested elements (reusing the dotted-name expansion),
     /// optionally appending a `<count_field>N</count_field>` child. Called only
@@ -193,44 +153,13 @@ impl<W: Write> XmlWriter<W> {
         fields: &indexmap::IndexMap<Box<str>, Value>,
         count: Option<(&str, i64)>,
     ) -> Result<(), FormatError> {
-        let mut pairs: Vec<(&str, &Value)> = Vec::new();
-        for (name, value) in fields {
-            pairs.push((name.as_ref(), value));
-        }
-        // The computed count is held as an owned Value so it can be borrowed
-        // into the same pair list the section fields use.
-        let count_value = count.map(|(field, n)| (field, Value::Integer(n)));
-        if let Some((field, ref v)) = count_value {
-            pairs.push((field, v));
-        }
-        let names = pairs.iter().map(|(name, _)| *name).collect::<Vec<_>>();
-        let (plan, field_is_attr) = build_tree_plan(&names, config)?;
-        let mut fill = FillBuf::new();
-        fill.reset(pairs.len());
-        for (index, (name, value)) in pairs.iter().enumerate() {
-            fill_slot(
-                &mut fill.slots[index],
-                field_is_attr[index],
-                config.preserve_nulls,
-                &config.attribute_prefix,
-                name,
-                value,
-            )?;
-        }
-        let values = pairs.iter().map(|(_, value)| *value).collect::<Vec<_>>();
-        let mut start = BytesStart::new(wrapper);
-        for attr in &plan.root.attrs {
-            if fill.emits(attr.field) {
-                push_one_attribute(&mut start, &attr.name, fill.text(attr.field));
-            }
-        }
-        writer
-            .write_event(Event::Start(start))
-            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        let values = SectionFields::new(fields, count);
+        let plan = build_tree_plan(values.names(), config)?;
+        validate_body(&plan.root, &values, config)?;
+        write_planned_start(writer, wrapper, &plan.root.attrs, &values, false)?;
         emit_body(
             writer,
             &plan.root,
-            &fill,
             &values,
             config.preserve_nulls,
             &config.attribute_prefix,
@@ -259,53 +188,49 @@ impl<W: Write> XmlWriter<W> {
         }
         Ok(())
     }
+
+    #[cfg(test)]
+    fn retained_preparation_bytes(&self) -> usize {
+        0
+    }
 }
 
 impl<W: Write + Send> FormatWriter for XmlWriter<W> {
     fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
-        // Both the plan build and the value fill run before the record start
-        // tag is emitted: attribute-classified fields must be known when the
-        // tag opens, and a rejected field (malformed nested value or attribute
-        // name) must not leave a dangling half-written record behind.
+        // The schema plan and the complete borrowed-value validation pass both
+        // finish before the record start tag. Pass two can therefore emit
+        // directly from `record` without a prepared value tree or retained
+        // scalar strings, while a structural failure adds no record bytes.
         self.ensure_plan(record)?;
-        self.fill_values(record)?;
-
-        // The plan indexes emitted schema fields positionally. Borrow the
-        // corresponding values for the recursive collection emitter; this
-        // vector is bounded by schema width and does not clone record data.
-        let emitted_values: Vec<&Value> = if self.config.include_engine_stamped {
-            record.iter_all_fields().map(|(_, value)| value).collect()
-        } else {
-            record.iter_user_fields().map(|(_, value)| value).collect()
-        };
+        let values = RecordFields::new(record);
+        let plan = &self.plan_cache.as_ref().expect("plan built above").plan;
+        validate_body(&plan.root, &values, &self.config)?;
 
         self.write_header()?;
 
-        // Disjoint field borrows: the sink writes (`writer`) need the plan
-        // (`plan_cache`) and the filled values (`fill`) live at the same time.
+        // Disjoint field borrows let the sink, cached schema plan, and borrowed
+        // record values remain live together throughout direct emission.
         let Self {
             writer,
             plan_cache,
-            fill,
             config,
             framer,
             ..
         } = self;
         let plan = &plan_cache.as_ref().expect("plan built above").plan;
 
-        let mut start = BytesStart::new(&*config.record_element);
-        for attr in &plan.root.attrs {
-            if fill.emits(attr.field) {
-                push_one_attribute(&mut start, &attr.name, fill.text(attr.field));
-            }
-        }
-        writer.write_event(Event::Start(start)).map_err(xml_err)?;
+        write_planned_start(
+            writer,
+            &config.record_element,
+            &plan.root.attrs,
+            &values,
+            false,
+        )?;
 
         emit_body(
             writer,
             &plan.root,
-            fill,
-            &emitted_values,
+            &values,
             config.preserve_nulls,
             &config.attribute_prefix,
         )?;
@@ -387,40 +312,83 @@ fn field_path_error(source: FieldPathError) -> FormatError {
     FormatError::field_path("XML", source)
 }
 
-/// Push a single name/value attribute onto an element's start tag, escaping the
-/// value. Literal whitespace is emitted as character references so a
-/// conformant parser does not normalize it to spaces.
-fn push_one_attribute(start: &mut BytesStart, key: &str, value: &str) {
-    start.push_attribute(Attribute {
-        key: QName(key.as_bytes()),
-        value: Cow::Owned(escape_attribute_value(value).into_bytes()),
-    });
-}
-
 /// Map an emitter error into [`FormatError::Xml`]. The emitter surfaces
 /// `std::io::Error`; its `Display` carries the underlying cause.
 fn xml_err<E: std::fmt::Display>(e: E) -> FormatError {
     FormatError::Xml(e.to_string())
 }
 
-/// Escape an attribute value: the five predefined entities plus literal
-/// tab / CR / LF as character references (see [`push_attributes`]).
-fn escape_attribute_value(raw: &str) -> String {
-    let mut escaped = String::with_capacity(raw.len());
-    for c in raw.chars() {
-        match c {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&apos;"),
-            '\t' => escaped.push_str("&#9;"),
-            '\n' => escaped.push_str("&#10;"),
-            '\r' => escaped.push_str("&#13;"),
-            other => escaped.push(other),
-        }
+#[derive(Clone, Copy)]
+enum EscapeContext {
+    Text,
+    Attribute,
+}
+
+/// Write borrowed XML character data without first materializing an escaped
+/// copy. Attribute whitespace keeps the existing character-reference spelling
+/// so conforming readers cannot normalize tabs or line endings to spaces.
+fn write_escaped<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    raw: &str,
+    context: EscapeContext,
+) -> Result<(), FormatError> {
+    let mut copied_through = 0;
+    for (offset, ch) in raw.char_indices() {
+        let replacement = match ch {
+            '&' => Some("&amp;"),
+            '<' => Some("&lt;"),
+            '>' => Some("&gt;"),
+            '"' => Some("&quot;"),
+            '\'' => Some("&apos;"),
+            '\t' if matches!(context, EscapeContext::Attribute) => Some("&#9;"),
+            '\n' if matches!(context, EscapeContext::Attribute) => Some("&#10;"),
+            '\r' if matches!(context, EscapeContext::Attribute) => Some("&#13;"),
+            _ => None,
+        };
+        let Some(replacement) = replacement else {
+            continue;
+        };
+        writer
+            .get_mut()
+            .write_all(&raw.as_bytes()[copied_through..offset])
+            .map_err(xml_err)?;
+        writer
+            .get_mut()
+            .write_all(replacement.as_bytes())
+            .map_err(xml_err)?;
+        copied_through = offset + ch.len_utf8();
     }
-    escaped
+    writer
+        .get_mut()
+        .write_all(&raw.as_bytes()[copied_through..])
+        .map_err(xml_err)
+}
+
+fn begin_start_tag<W: Write>(writer: &mut XmlEmitter<W>, name: &str) -> Result<(), FormatError> {
+    writer.get_mut().write_all(b"<").map_err(xml_err)?;
+    writer.get_mut().write_all(name.as_bytes()).map_err(xml_err)
+}
+
+fn write_attribute<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    name: &str,
+    value: &str,
+) -> Result<(), FormatError> {
+    writer.get_mut().write_all(b" ").map_err(xml_err)?;
+    writer
+        .get_mut()
+        .write_all(name.as_bytes())
+        .map_err(xml_err)?;
+    writer.get_mut().write_all(b"=\"").map_err(xml_err)?;
+    write_escaped(writer, value, EscapeContext::Attribute)?;
+    writer.get_mut().write_all(b"\"").map_err(xml_err)
+}
+
+fn finish_start_tag<W: Write>(writer: &mut XmlEmitter<W>, empty: bool) -> Result<(), FormatError> {
+    writer
+        .get_mut()
+        .write_all(if empty { b"/>" } else { b">" })
+        .map_err(xml_err)
 }
 
 /// True when `c` may begin an XML 1.0 `Name` (the `NameStartChar`
@@ -493,43 +461,71 @@ fn check_xml_name(name: &str, context: &str) -> Result<(), FormatError> {
     }
 }
 
-/// Convert a clinker Value to XML text content.
-///
-/// This renders one scalar for an element body, attribute, or `#text` entry.
-/// Recursive callers dispatch arrays and maps before reaching this helper; the
-/// collection error arms are defensive invariant checks rather than a fallback
-/// serialization.
-fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
-    let mut buf = String::new();
-    write_value_text(&mut buf, col, val)?;
-    Ok(buf)
+const SCALAR_TEXT_CAPACITY: usize = 128;
+
+struct ScalarBuffer {
+    bytes: [u8; SCALAR_TEXT_CAPACITY],
+    len: usize,
 }
 
-/// Render a clinker Value as XML text content into `buf` (appending). Shares
-/// its logic with [`value_to_text`] so every scalar path stays byte-identical.
-fn write_value_text(buf: &mut String, col: &str, val: &Value) -> Result<(), FormatError> {
+impl ScalarBuffer {
+    fn new() -> Self {
+        Self {
+            bytes: [0; SCALAR_TEXT_CAPACITY],
+            len: 0,
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.bytes[..self.len])
+            .expect("fmt::Write only accepts valid UTF-8 strings")
+    }
+}
+
+impl std::fmt::Write for ScalarBuffer {
+    fn write_str(&mut self, text: &str) -> std::fmt::Result {
+        let end = self.len.checked_add(text.len()).ok_or(std::fmt::Error)?;
+        let destination = self.bytes.get_mut(self.len..end).ok_or(std::fmt::Error)?;
+        destination.copy_from_slice(text.as_bytes());
+        self.len = end;
+        Ok(())
+    }
+}
+
+enum ScalarText<'a> {
+    Borrowed(&'a str),
+    Formatted(ScalarBuffer),
+}
+
+impl ScalarText<'_> {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Borrowed(text) => text,
+            Self::Formatted(text) => text.as_str(),
+        }
+    }
+}
+
+/// Borrow authored strings and format every other scalar into fixed stack
+/// storage. The largest supported scalar representation is bounded by its Rust
+/// type, so record width and input string length cannot grow this scratch.
+fn scalar_text<'a>(col: &str, val: &'a Value) -> Result<ScalarText<'a>, FormatError> {
     use std::fmt::Write as _;
+    let mut buf = ScalarBuffer::new();
+    let overflow = || {
+        FormatError::Xml(format!(
+            "field '{col}': scalar rendering exceeds the XML writer's fixed bound"
+        ))
+    };
     match val {
-        Value::Null => {}
-        Value::Bool(b) => {
-            let _ = write!(buf, "{b}");
-        }
-        Value::Integer(i) => {
-            let _ = write!(buf, "{i}");
-        }
-        Value::Float(f) => {
-            let _ = write!(buf, "{f}");
-        }
-        Value::Decimal(d) => {
-            let _ = write!(buf, "{d}");
-        }
-        Value::String(s) => buf.push_str(s.as_str()),
-        Value::Date(d) => {
-            let _ = write!(buf, "{d}");
-        }
-        Value::DateTime(dt) => {
-            let _ = write!(buf, "{dt}");
-        }
+        Value::Null => return Ok(ScalarText::Borrowed("")),
+        Value::Bool(value) => write!(&mut buf, "{value}").map_err(|_| overflow())?,
+        Value::Integer(value) => write!(&mut buf, "{value}").map_err(|_| overflow())?,
+        Value::Float(value) => write!(&mut buf, "{value}").map_err(|_| overflow())?,
+        Value::Decimal(value) => write!(&mut buf, "{value}").map_err(|_| overflow())?,
+        Value::String(value) => return Ok(ScalarText::Borrowed(value.as_str())),
+        Value::Date(value) => write!(&mut buf, "{value}").map_err(|_| overflow())?,
+        Value::DateTime(value) => write!(&mut buf, "{value}").map_err(|_| overflow())?,
         Value::Array(_) => {
             return Err(FormatError::UnserializableArrayValue {
                 format: "XML",
@@ -543,7 +539,69 @@ fn write_value_text(buf: &mut String, col: &str, val: &Value) -> Result<(), Form
             });
         }
     }
-    Ok(())
+    Ok(ScalarText::Formatted(buf))
+}
+
+trait FieldSource {
+    fn field(&self, index: usize) -> (&str, &Value);
+}
+
+struct RecordFields<'a> {
+    record: &'a Record,
+}
+
+impl<'a> RecordFields<'a> {
+    fn new(record: &'a Record) -> Self {
+        Self { record }
+    }
+}
+
+impl FieldSource for RecordFields<'_> {
+    fn field(&self, index: usize) -> (&str, &Value) {
+        (
+            self.record.schema().columns()[index].as_ref(),
+            &self.record.values()[index],
+        )
+    }
+}
+
+struct SectionFields<'a> {
+    fields: &'a indexmap::IndexMap<Box<str>, Value>,
+    count: Option<(&'a str, Value)>,
+}
+
+impl<'a> SectionFields<'a> {
+    fn new(fields: &'a indexmap::IndexMap<Box<str>, Value>, count: Option<(&'a str, i64)>) -> Self {
+        Self {
+            fields,
+            count: count.map(|(name, value)| (name, Value::Integer(value))),
+        }
+    }
+
+    fn names(&self) -> impl Iterator<Item = (usize, &str)> + Clone {
+        self.fields
+            .keys()
+            .enumerate()
+            .map(|(index, name)| (index, name.as_ref()))
+            .chain(
+                self.count
+                    .iter()
+                    .map(|(name, _)| (self.fields.len(), *name)),
+            )
+    }
+}
+
+impl FieldSource for SectionFields<'_> {
+    fn field(&self, index: usize) -> (&str, &Value) {
+        if let Some((name, value)) = self.fields.get_index(index) {
+            return (name.as_ref(), value);
+        }
+        let (name, value) = self
+            .count
+            .as_ref()
+            .expect("the schema plan references the optional count field");
+        (*name, value)
+    }
 }
 
 // ── Precompiled record tree plan ─────────────────────────────────────
@@ -557,7 +615,7 @@ struct TreePlan {
 
 /// One element's precompiled body: the attributes on its start tag plus its
 /// child nodes. Values are not stored — each terminal carries the field index
-/// to read from the per-record fill buffer.
+/// to borrow from the current record.
 #[derive(Default)]
 struct PlanBody {
     attrs: Vec<PlanAttr>,
@@ -565,7 +623,7 @@ struct PlanBody {
 }
 
 /// A precompiled attribute: its (validated) XML name and the field index whose
-/// value fills it.
+/// value it borrows.
 struct PlanAttr {
     name: String,
     field: usize,
@@ -601,53 +659,51 @@ struct XmlRepeat {
     wrap_in: Option<String>,
 }
 
-/// The memoized plan plus the identity it was built for. `field_is_attr` marks,
-/// per field iterator position, whether that field is an attribute (drops null
-/// unconditionally) versus an element leaf (drops null only when
-/// `preserve_nulls` is false).
+/// The memoized schema-derived plan plus the identity it was built for. Field
+/// nodes retain only raw schema indices and validated XML names; record values
+/// remain borrowed from the caller throughout validation and emission.
 struct PlanCache {
     schema: Arc<Schema>,
     plan: TreePlan,
-    field_is_attr: Vec<bool>,
 }
 
 /// Build the tree plan for a record's schema. Walks the fields in iterator
 /// order (position = field index) and classifies each into the element tree,
 /// validating attribute names up front.
 fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCache, FormatError> {
-    let names: Vec<&str> = if config.include_engine_stamped {
-        record.iter_all_fields().map(|(name, _)| name).collect()
-    } else {
-        record.iter_user_fields().map(|(name, _)| name).collect()
-    };
-    let (plan, field_is_attr) = build_tree_plan(&names, config)?;
+    let schema = record.schema();
+    let fields = schema
+        .columns()
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| config.include_engine_stamped || !schema.is_engine_stamped(*index))
+        .map(|(index, name)| (index, name.as_ref()));
+    let plan = build_tree_plan(fields, config)?;
     Ok(PlanCache {
         schema: Arc::clone(record.schema()),
         plan,
-        field_is_attr,
     })
 }
 
-fn build_tree_plan(
-    names: &[&str],
+fn build_tree_plan<'a>(
+    fields: impl IntoIterator<Item = (usize, &'a str)> + Clone,
     config: &XmlWriterConfig,
-) -> Result<(TreePlan, Vec<bool>), FormatError> {
-    field_path::check_expandable(names.iter().copied()).map_err(field_path_error)?;
+) -> Result<TreePlan, FormatError> {
+    field_path::check_expandable(fields.clone().into_iter().map(|(_, name)| name))
+        .map_err(field_path_error)?;
     let mut root = PlanBody::default();
-    let mut field_is_attr = vec![false; names.len()];
-    for (i, name) in names.iter().enumerate() {
+    for (field_index, name) in fields {
         let path = field_path::decode(name).map_err(field_path_error)?;
         plan_insert_field(
             &mut root,
-            i,
+            field_index,
             name,
             &path,
             &config.attribute_prefix,
             &config.join_values,
-            &mut field_is_attr,
         )?;
     }
-    Ok((TreePlan { root }, field_is_attr))
+    Ok(TreePlan { root })
 }
 
 /// Insert a decoded field path into the plan, creating branches as needed —
@@ -661,7 +717,6 @@ fn plan_insert_field(
     path: &[Cow<'_, str>],
     attribute_prefix: &str,
     join_values: &[JoinValues],
-    field_is_attr: &mut [bool],
 ) -> Result<(), FormatError> {
     let (segment, rest) = path
         .split_first()
@@ -688,7 +743,6 @@ fn plan_insert_field(
                 rest,
                 attribute_prefix,
                 join_values,
-                field_is_attr,
             )
         } else {
             let mut branch_body = PlanBody::default();
@@ -699,7 +753,6 @@ fn plan_insert_field(
                 rest,
                 attribute_prefix,
                 join_values,
-                field_is_attr,
             )?;
             body.children.push(PlanNode::Branch {
                 name: segment.to_string(),
@@ -721,7 +774,6 @@ fn plan_insert_field(
                  well-formed XML name"
             )));
         }
-        field_is_attr[field_index] = true;
         body.attrs.push(PlanAttr {
             name: attr_name.to_string(),
             field: field_index,
@@ -775,111 +827,85 @@ fn build_repeat_spec(
     Ok(Some(XmlRepeat { item_name, wrap_in }))
 }
 
-/// Per-record scratch, one slot per field in iterator order. Slot `String`
-/// capacity is retained across records (only the length is reset) so filling a
-/// record reuses allocations. `emits` records whether the field appears in
-/// output for this record (null handling); `text` holds its rendered value.
-struct FillBuf {
-    slots: Vec<FillSlot>,
-}
-
-#[derive(Default)]
-struct FillSlot {
-    /// Scalar rendering. Empty when the field is null-dropped or holds a
-    /// recursively structured value.
-    text: String,
-    /// True for a native array or map. The emitter then borrows the original
-    /// record value after the validation pass instead of materializing a
-    /// second owned tree.
-    is_structured: bool,
-    emits: bool,
-}
-
-impl FillBuf {
-    fn new() -> Self {
-        Self { slots: Vec::new() }
+fn field_emits(value: &Value, is_attribute: bool, preserve_nulls: bool) -> bool {
+    if is_attribute {
+        return !value.is_null();
     }
+    match value {
+        Value::Null => preserve_nulls,
+        Value::Array(items) => !items.is_empty(),
+        Value::Map(_) => true,
+        _ => true,
+    }
+}
 
-    /// Ensure at least `n` slots exist (reusing existing `String` capacity),
-    /// ready to be overwritten for the current record. Every index in `0..n`
-    /// is written by `fill_values` before it is read, so stale contents beyond
-    /// a shrink never surface.
-    fn reset(&mut self, n: usize) {
-        if self.slots.len() < n {
-            self.slots.resize_with(n, FillSlot::default);
+fn validate_body<S: FieldSource>(
+    body: &PlanBody,
+    values: &S,
+    config: &XmlWriterConfig,
+) -> Result<(), FormatError> {
+    for attr in &body.attrs {
+        let (name, value) = values.field(attr.field);
+        validate_field_value(
+            value,
+            true,
+            config.preserve_nulls,
+            &config.attribute_prefix,
+            name,
+        )?;
+    }
+    for child in &body.children {
+        match child {
+            PlanNode::Leaf { field, .. } => {
+                let (name, value) = values.field(*field);
+                validate_field_value(
+                    value,
+                    false,
+                    config.preserve_nulls,
+                    &config.attribute_prefix,
+                    name,
+                )?;
+            }
+            PlanNode::Branch { body, .. } => validate_body(body, values, config)?,
         }
     }
-
-    fn emits(&self, field: usize) -> bool {
-        self.slots[field].emits
-    }
-
-    fn text(&self, field: usize) -> &str {
-        &self.slots[field].text
-    }
-
-    fn is_structured(&self, field: usize) -> bool {
-        self.slots[field].is_structured
-    }
+    Ok(())
 }
 
-/// Fill a single slot with a field's presence and rendered value(s).
-///
-/// A scalar field is dropped (`emits = false`) when it is a null attribute, or a
-/// null element under `preserve_nulls: false`; otherwise its text is rendered (a
-/// preserved null element renders to the empty string, emitted as a self-closing
-/// tag).
-///
-/// Arrays and maps at element fields are fully validated here before the record
-/// start tag is written, then emitted recursively from the borrowed value.
-/// Attributes remain scalar-only.
-fn fill_slot(
-    slot: &mut FillSlot,
+fn validate_field_value(
+    val: &Value,
     is_attr: bool,
-    preserve_nulls: bool,
+    _preserve_nulls: bool,
     attribute_prefix: &str,
     name: &str,
-    val: &Value,
 ) -> Result<(), FormatError> {
-    slot.is_structured = false;
     match val {
-        Value::Array(items) if !is_attr => {
-            validate_xml_nested_value(val, name, attribute_prefix)?;
-            slot.is_structured = true;
-            slot.text.clear();
-            slot.emits = !items.is_empty();
-        }
-        Value::Array(_) => {
-            return Err(FormatError::Xml(format!(
-                "field '{name}': an XML attribute cannot hold multiple values — a \
+        Value::Array(_) if !is_attr => validate_xml_nested_value(val, name, attribute_prefix),
+        Value::Array(_) => Err(FormatError::Xml(format!(
+            "field '{name}': an XML attribute cannot hold multiple values — a \
                  `multiple:` field maps to repeated elements, not an attribute"
-            )));
-        }
-        Value::Map(_) if is_attr => {
-            return Err(FormatError::UnserializableMapValue {
-                format: "XML",
-                column: name.to_string(),
-            });
-        }
-        Value::Map(_) => {
-            validate_xml_nested_value(val, name, attribute_prefix)?;
-            slot.is_structured = true;
-            slot.text.clear();
-            // A map has a named container even when it has no children.
-            slot.emits = true;
-        }
-        _ => {
-            let skip = if is_attr {
-                val.is_null()
-            } else {
-                val.is_null() && !preserve_nulls
-            };
-            slot.emits = !skip;
-            slot.text.clear();
-            if !skip {
-                write_value_text(&mut slot.text, name, val)?;
-            }
-        }
+        ))),
+        Value::Map(_) if is_attr => Err(FormatError::UnserializableMapValue {
+            format: "XML",
+            column: name.to_string(),
+        }),
+        Value::Map(_) => validate_xml_nested_value(val, name, attribute_prefix),
+        _ => validate_scalar_value(name, val),
+    }
+}
+
+fn validate_scalar_value(field: &str, value: &Value) -> Result<(), FormatError> {
+    let text = scalar_text(field, value)?;
+    if let Some(character) = text.as_str().chars().find(|character| {
+        !matches!(
+            *character,
+            '\u{9}' | '\u{A}' | '\u{D}' | '\u{20}'..='\u{D7FF}' | '\u{E000}'..='\u{10FFFF}'
+        )
+    }) {
+        return Err(FormatError::Xml(format!(
+            "field '{field}': character U+{:04X} is not permitted in XML 1.0 text",
+            character as u32
+        )));
     }
     Ok(())
 }
@@ -933,19 +959,21 @@ fn validate_xml_nested_value(
                                 key.text
                             )));
                         }
+                        validate_scalar_value(field, child)?;
                     } else if is_text {
                         if matches!(child, Value::Array(_) | Value::Map(_)) {
                             return Err(FormatError::Xml(format!(
                                 "field '{field}': nested XML #text must hold a scalar value"
                             )));
                         }
+                        validate_scalar_value(field, child)?;
                     } else {
                         check_xml_name(&key.text, &format!("field '{field}': nested element"))?;
                         visit(child, field, attribute_prefix)?;
                     }
                 }
             }
-            _ => {}
+            _ => validate_scalar_value(field, value)?,
         }
         Ok(())
     }
@@ -953,15 +981,33 @@ fn validate_xml_nested_value(
     visit(value, field, attribute_prefix)
 }
 
-/// Emit a body's child nodes (its start-tag attributes are handled by the
-/// caller). A branch is emitted only when it has at least one emitting
-/// attribute or child, and self-closes when it has no emitting children —
-/// matching the null-pruning rules used while filling each leaf.
-fn emit_body<W: Write>(
+fn write_planned_start<W: Write, S: FieldSource>(
+    writer: &mut XmlEmitter<W>,
+    name: &str,
+    attrs: &[PlanAttr],
+    values: &S,
+    empty: bool,
+) -> Result<(), FormatError> {
+    begin_start_tag(writer, name)?;
+    for attr in attrs {
+        let (field, value) = values.field(attr.field);
+        if value.is_null() {
+            continue;
+        }
+        let text = scalar_text(field, value)?;
+        write_attribute(writer, &attr.name, text.as_str())?;
+    }
+    finish_start_tag(writer, empty)
+}
+
+/// Emit a body's child nodes directly from borrowed field values. A branch is
+/// emitted only when it has at least one emitting attribute or child, and
+/// self-closes when it has no emitting children, preserving the existing null
+/// and empty-container decisions byte for byte.
+fn emit_body<W: Write, S: FieldSource>(
     writer: &mut XmlEmitter<W>,
     body: &PlanBody,
-    fill: &FillBuf,
-    values: &[&Value],
+    values: &S,
     preserve_nulls: bool,
     attribute_prefix: &str,
 ) -> Result<(), FormatError> {
@@ -972,21 +1018,21 @@ fn emit_body<W: Write>(
                 field,
                 repeat,
             } => {
-                if !fill.emits(*field) {
+                let (field_name, value) = values.field(*field);
+                if !field_emits(value, false, preserve_nulls) {
                     continue;
                 }
-                if fill.is_structured(*field) {
+                if matches!(value, Value::Array(_) | Value::Map(_)) {
                     emit_structured_leaf(
                         writer,
                         name,
                         repeat,
-                        values[*field],
+                        value,
                         preserve_nulls,
                         attribute_prefix,
                     )?;
                     continue;
                 }
-                let text = fill.text(*field);
                 // A scalar on a field carrying a `repeat_as` / `wrap_in` override
                 // is a one-element sequence: apply the same naming an array of
                 // length one would get, so the emitted shape does not depend on
@@ -995,46 +1041,31 @@ fn emit_body<W: Write>(
                 // one-element array. A field with no override (`repeat` is
                 // `None`) keeps the plain `<name>text</name>` rendering.
                 if repeat.is_some() {
-                    let one = [text.to_owned()];
-                    emit_repeated_leaf(writer, name, repeat, &one)?;
+                    emit_scalar_leaf(writer, name, repeat, field_name, value)?;
                     continue;
                 }
-                if text.is_empty() {
-                    writer
-                        .write_event(Event::Empty(BytesStart::new(name.as_str())))
-                        .map_err(xml_err)?;
-                } else {
-                    writer
-                        .write_event(Event::Start(BytesStart::new(name.as_str())))
-                        .map_err(xml_err)?;
-                    writer
-                        .write_event(Event::Text(BytesText::new(text)))
-                        .map_err(xml_err)?;
-                    writer
-                        .write_event(Event::End(BytesEnd::new(name.as_str())))
-                        .map_err(xml_err)?;
-                }
+                emit_scalar_element(writer, name, field_name, value)?;
             }
             PlanNode::Branch { name, body } => {
-                let has_attrs = body.attrs.iter().any(|a| fill.emits(a.field));
-                let has_children = body.children.iter().any(|c| node_emits(c, fill));
+                let has_attrs = body
+                    .attrs
+                    .iter()
+                    .any(|attr| field_emits(values.field(attr.field).1, true, preserve_nulls));
+                let has_children = body
+                    .children
+                    .iter()
+                    .any(|child| node_emits(child, values, preserve_nulls));
                 if !has_attrs && !has_children {
                     continue;
                 }
-                let mut start = BytesStart::new(name.as_str());
-                for attr in &body.attrs {
-                    if fill.emits(attr.field) {
-                        push_one_attribute(&mut start, &attr.name, fill.text(attr.field));
-                    }
-                }
                 if has_children {
-                    writer.write_event(Event::Start(start)).map_err(xml_err)?;
-                    emit_body(writer, body, fill, values, preserve_nulls, attribute_prefix)?;
+                    write_planned_start(writer, name, &body.attrs, values, false)?;
+                    emit_body(writer, body, values, preserve_nulls, attribute_prefix)?;
                     writer
                         .write_event(Event::End(BytesEnd::new(name.as_str())))
                         .map_err(xml_err)?;
                 } else {
-                    writer.write_event(Event::Empty(start)).map_err(xml_err)?;
+                    write_planned_start(writer, name, &body.attrs, values, true)?;
                 }
             }
         }
@@ -1101,7 +1132,7 @@ fn emit_named_value<W: Write>(
             Ok(())
         }
         Value::Map(entries) => {
-            let mut start = BytesStart::new(name);
+            begin_start_tag(writer, name)?;
             for (raw_key, child) in entries.iter() {
                 let key = NestedKey::decode(raw_key).expect("keys validated before emission");
                 let is_attribute = !key.escaped
@@ -1109,15 +1140,15 @@ fn emit_named_value<W: Write>(
                     && key.text.starts_with(attribute_prefix);
                 if is_attribute && !child.is_null() {
                     let attr_name = &key.text[attribute_prefix.len()..];
-                    let text = value_to_text(raw_key, child)?;
-                    push_one_attribute(&mut start, attr_name, &text);
+                    let text = scalar_text(raw_key, child)?;
+                    write_attribute(writer, attr_name, text.as_str())?;
                 }
             }
 
             if !map_has_content(entries, preserve_nulls, attribute_prefix) {
-                return writer.write_event(Event::Empty(start)).map_err(xml_err);
+                return finish_start_tag(writer, true);
             }
-            writer.write_event(Event::Start(start)).map_err(xml_err)?;
+            finish_start_tag(writer, false)?;
             for (raw_key, child) in entries.iter() {
                 let key = NestedKey::decode(raw_key).expect("keys validated before emission");
                 let is_attribute = !key.escaped
@@ -1128,11 +1159,9 @@ fn emit_named_value<W: Write>(
                 }
                 if !key.escaped && key.text == "#text" {
                     if !child.is_null() {
-                        let text = value_to_text(raw_key, child)?;
-                        if !text.is_empty() {
-                            writer
-                                .write_event(Event::Text(BytesText::new(&text)))
-                                .map_err(xml_err)?;
+                        let text = scalar_text(raw_key, child)?;
+                        if !text.as_str().is_empty() {
+                            write_escaped(writer, text.as_str(), EscapeContext::Text)?;
                         }
                     }
                     continue;
@@ -1143,24 +1172,7 @@ fn emit_named_value<W: Write>(
                 .write_event(Event::End(BytesEnd::new(name)))
                 .map_err(xml_err)
         }
-        _ => {
-            let text = value_to_text(name, value)?;
-            if text.is_empty() {
-                writer
-                    .write_event(Event::Empty(BytesStart::new(name)))
-                    .map_err(xml_err)
-            } else {
-                writer
-                    .write_event(Event::Start(BytesStart::new(name)))
-                    .map_err(xml_err)?;
-                writer
-                    .write_event(Event::Text(BytesText::new(&text)))
-                    .map_err(xml_err)?;
-                writer
-                    .write_event(Event::End(BytesEnd::new(name)))
-                    .map_err(xml_err)
-            }
-        }
+        _ => emit_scalar_element(writer, name, name, value),
     }
 }
 
@@ -1196,19 +1208,36 @@ fn value_emits(value: &Value, preserve_nulls: bool) -> bool {
     }
 }
 
-/// Emit a `multiple:` field's values as repeated child elements. `parts` holds
-/// the per-element rendered text and is non-empty (an empty array sets
-/// `emits = false`, so the caller skips it). Each item is
-/// `<item_name>text</item_name>`, or a self-closing `<item_name/>` when its text
-/// is empty; a `wrap_in` container, when set, brackets the whole run.
-///
-/// `item_name` and any `wrap_in` were validated as legal XML names at plan build
-/// ([`build_repeat_spec`]), so no per-record name check is needed here.
-fn emit_repeated_leaf<W: Write>(
+fn emit_scalar_element<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    element_name: &str,
+    field_name: &str,
+    value: &Value,
+) -> Result<(), FormatError> {
+    let text = scalar_text(field_name, value)?;
+    if text.as_str().is_empty() {
+        writer
+            .write_event(Event::Empty(BytesStart::new(element_name)))
+            .map_err(xml_err)
+    } else {
+        writer
+            .write_event(Event::Start(BytesStart::new(element_name)))
+            .map_err(xml_err)?;
+        write_escaped(writer, text.as_str(), EscapeContext::Text)?;
+        writer
+            .write_event(Event::End(BytesEnd::new(element_name)))
+            .map_err(xml_err)
+    }
+}
+
+/// Emit one scalar through the same item/wrapper naming used for a one-element
+/// array, without cloning its rendered text into a temporary collection.
+fn emit_scalar_leaf<W: Write>(
     writer: &mut XmlEmitter<W>,
     leaf_name: &str,
     repeat: &Option<XmlRepeat>,
-    parts: &[String],
+    field_name: &str,
+    value: &Value,
 ) -> Result<(), FormatError> {
     let item_name = repeat.as_ref().map_or(leaf_name, |r| r.item_name.as_str());
     let wrap_in = repeat.as_ref().and_then(|r| r.wrap_in.as_deref());
@@ -1217,23 +1246,7 @@ fn emit_repeated_leaf<W: Write>(
             .write_event(Event::Start(BytesStart::new(container)))
             .map_err(xml_err)?;
     }
-    for part in parts {
-        if part.is_empty() {
-            writer
-                .write_event(Event::Empty(BytesStart::new(item_name)))
-                .map_err(xml_err)?;
-        } else {
-            writer
-                .write_event(Event::Start(BytesStart::new(item_name)))
-                .map_err(xml_err)?;
-            writer
-                .write_event(Event::Text(BytesText::new(part)))
-                .map_err(xml_err)?;
-            writer
-                .write_event(Event::End(BytesEnd::new(item_name)))
-                .map_err(xml_err)?;
-        }
-    }
+    emit_scalar_element(writer, item_name, field_name, value)?;
     if let Some(container) = wrap_in {
         writer
             .write_event(Event::End(BytesEnd::new(container)))
@@ -1243,13 +1256,19 @@ fn emit_repeated_leaf<W: Write>(
 }
 
 /// Whether a node contributes any output for the current record: a leaf emits
-/// per its fill slot; a branch emits when any attribute or descendant does.
-fn node_emits(node: &PlanNode, fill: &FillBuf) -> bool {
+/// from its borrowed value; a branch emits when any attribute or descendant
+/// does.
+fn node_emits<S: FieldSource>(node: &PlanNode, values: &S, preserve_nulls: bool) -> bool {
     match node {
-        PlanNode::Leaf { field, .. } => fill.emits(*field),
+        PlanNode::Leaf { field, .. } => field_emits(values.field(*field).1, false, preserve_nulls),
         PlanNode::Branch { body, .. } => {
-            body.attrs.iter().any(|a| fill.emits(a.field))
-                || body.children.iter().any(|c| node_emits(c, fill))
+            body.attrs
+                .iter()
+                .any(|attr| field_emits(values.field(attr.field).1, true, preserve_nulls))
+                || body
+                    .children
+                    .iter()
+                    .any(|child| node_emits(child, values, preserve_nulls))
         }
     }
 }
@@ -1259,6 +1278,27 @@ mod tests {
     use super::*;
     use crate::traits::FormatReader;
     use crate::xml::reader::{XmlReader, XmlReaderConfig};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone, Default)]
+    struct ByteCounter(Arc<AtomicUsize>);
+
+    impl ByteCounter {
+        fn bytes(&self) -> usize {
+            self.0.load(Ordering::Relaxed)
+        }
+    }
+
+    impl Write for ByteCounter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.fetch_add(buf.len(), Ordering::Relaxed);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
 
     fn test_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec!["name".into(), "age".into()]))
@@ -1539,6 +1579,91 @@ mod tests {
             output,
             "<Root><Record><id>7</id><payload kind=\"event\">before<item id=\"1\">alpha</item><item id=\"2\">beta</item><tail>after</tail></payload></Record></Root>"
         );
+    }
+
+    #[test]
+    fn large_authored_text_does_not_grow_retained_preparation_state() {
+        let schema = Arc::new(Schema::new(vec!["@kind".into(), "payload".into()]));
+        let large = "large <&> \"quoted\"\n".repeat(64 * 1024);
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String(large.clone().into()),
+                Value::String(large.into()),
+            ],
+        );
+        let sink = ByteCounter::default();
+        let mut writer = XmlWriter::new(sink, Arc::clone(&schema), XmlWriterConfig::default());
+
+        writer.write_record(&record).expect("large record writes");
+
+        assert_eq!(
+            writer.retained_preparation_bytes(),
+            0,
+            "record-sized scalar preparation must not survive write_record",
+        );
+    }
+
+    #[test]
+    fn complete_validation_failures_add_no_record_bytes() {
+        use indexmap::IndexMap;
+
+        let schema = Arc::new(Schema::new(vec!["payload".into()]));
+        let mut invalid_name = IndexMap::new();
+        invalid_name.insert("1bad".into(), Value::Integer(1));
+
+        let mut collision = IndexMap::new();
+        collision.insert("@id".into(), Value::Integer(1));
+        collision.insert("\\@id".into(), Value::Integer(2));
+
+        let mut too_deep = Value::Null;
+        for _ in 0..=clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+            too_deep = Value::Map(Box::new(IndexMap::from([("next".into(), too_deep)])));
+        }
+
+        for (case, invalid) in [
+            ("malformed name", Value::Map(Box::new(invalid_name))),
+            ("invalid text", Value::String("bad\u{1}".into())),
+            ("excess depth", too_deep),
+            ("decoded-key collision", Value::Map(Box::new(collision))),
+        ] {
+            let sink = ByteCounter::default();
+            let observation = sink.clone();
+            let mut writer = XmlWriter::new(sink, Arc::clone(&schema), XmlWriterConfig::default());
+            writer
+                .write_record(&Record::new(
+                    Arc::clone(&schema),
+                    vec![Value::String("valid".into())],
+                ))
+                .expect("control record writes");
+            let before = observation.bytes();
+
+            writer
+                .write_record(&Record::new(Arc::clone(&schema), vec![invalid]))
+                .expect_err(case);
+
+            assert_eq!(
+                observation.bytes(),
+                before,
+                "{case} must add zero bytes after an earlier valid record",
+            );
+        }
+    }
+
+    #[test]
+    fn repeated_records_never_accumulate_preparation_state() {
+        let schema = Arc::new(Schema::new(vec!["payload".into()]));
+        let sink = ByteCounter::default();
+        let mut writer = XmlWriter::new(sink, Arc::clone(&schema), XmlWriterConfig::default());
+
+        for width in [1, 4096, 17, 128 * 1024, 2] {
+            let record = Record::new(
+                Arc::clone(&schema),
+                vec![Value::String("<&".repeat(width).into())],
+            );
+            writer.write_record(&record).expect("record writes");
+            assert_eq!(writer.retained_preparation_bytes(), 0);
+        }
     }
 
     #[test]

--- a/crates/clinker-format/tests/nested_write_symmetry.rs
+++ b/crates/clinker-format/tests/nested_write_symmetry.rs
@@ -12,6 +12,7 @@ use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
 use clinker_format::{FormatError, FormatWriter};
 use clinker_record::schema::FieldMetadata;
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
+use indexmap::IndexMap;
 
 fn schema_of(columns: &[&str]) -> Arc<Schema> {
     columns.iter().copied().collect::<SchemaBuilder>().build()
@@ -211,4 +212,101 @@ fn both_writers_refuse_a_malformed_escape() {
         let err = err.expect("a malformed escape is refused by both writers");
         assert!(matches!(err, FormatError::FieldPath { .. }), "{err:?}");
     }
+}
+
+#[test]
+fn native_nested_values_keep_order_and_format_specific_xml_roles() {
+    let schema = schema_of(&["payload"]);
+    let mut first = IndexMap::new();
+    first.insert("@id".into(), Value::Integer(1));
+    first.insert("#text".into(), Value::String("alpha".into()));
+    let mut second = IndexMap::new();
+    second.insert("@id".into(), Value::Integer(2));
+    second.insert("#text".into(), Value::String("beta".into()));
+    let mut payload = IndexMap::new();
+    payload.insert("@kind".into(), Value::String("event".into()));
+    payload.insert("#text".into(), Value::String("before".into()));
+    payload.insert(
+        "item".into(),
+        Value::Array(vec![
+            Value::Map(Box::new(first)),
+            Value::Map(Box::new(second)),
+        ]),
+    );
+    payload.insert("tail".into(), Value::String("after".into()));
+    let value = Value::Map(Box::new(payload));
+
+    assert_eq!(
+        write_json(&schema, vec![value.clone()], false),
+        r##"{"payload":{"@kind":"event","#text":"before","item":[{"@id":1,"#text":"alpha"},{"@id":2,"#text":"beta"}],"tail":"after"}}"##
+    );
+    assert_eq!(
+        write_xml(&schema, vec![value], false),
+        "<Root><Record><payload kind=\"event\">before<item id=\"1\">alpha</item><item id=\"2\">beta</item><tail>after</tail></payload></Record></Root>"
+    );
+}
+
+#[test]
+fn escaped_nested_keys_decode_for_json_and_are_validated_before_output() {
+    let schema = schema_of(&["payload"]);
+    let mut payload = IndexMap::new();
+    payload.insert("\\@literal".into(), Value::Integer(1));
+    assert_eq!(
+        write_json(&schema, vec![Value::Map(Box::new(payload))], false),
+        r#"{"payload":{"@literal":1}}"#
+    );
+
+    let mut duplicate = IndexMap::new();
+    duplicate.insert("@id".into(), Value::Integer(1));
+    duplicate.insert("\\@id".into(), Value::Integer(2));
+    let record = Record::new(Arc::clone(&schema), vec![Value::Map(Box::new(duplicate))]);
+    let mut json_buf = Vec::new();
+    let mut json = JsonWriter::new(
+        &mut json_buf,
+        Arc::clone(&schema),
+        JsonWriterConfig::default(),
+    );
+    assert!(json.write_record(&record).is_err());
+    drop(json);
+    assert!(json_buf.is_empty());
+
+    let mut xml_buf = Vec::new();
+    let mut xml = XmlWriter::new(
+        &mut xml_buf,
+        Arc::clone(&schema),
+        XmlWriterConfig::default(),
+    );
+    assert!(xml.write_record(&record).is_err());
+    drop(xml);
+    assert!(xml_buf.is_empty());
+}
+
+#[test]
+fn both_recursive_writers_reject_depth_cap_plus_one_before_output() {
+    let schema = schema_of(&["payload"]);
+    let mut value = Value::Null;
+    for _ in 0..=clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+        value = Value::Array(vec![value]);
+    }
+    let record = Record::new(Arc::clone(&schema), vec![value]);
+
+    let mut json_buf = Vec::new();
+    let mut json = JsonWriter::new(
+        &mut json_buf,
+        Arc::clone(&schema),
+        JsonWriterConfig::default(),
+    );
+    assert!(json.write_record(&record).is_err());
+    drop(json);
+    assert!(json_buf.is_empty());
+
+    let mut xml_buf = Vec::new();
+    let mut xml = XmlWriter::new(
+        &mut xml_buf,
+        Arc::clone(&schema),
+        XmlWriterConfig::default(),
+    );
+    assert!(xml.write_record(&record).is_err());
+    drop(xml);
+    assert!(xml_buf.is_empty());
 }

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -1579,6 +1579,31 @@ fn collect_agg_leaves<'a>(expr: &'a Expr, out: &mut Vec<AggLeaf<'a>>) {
             collect_agg_leaves(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_agg_leaves(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_agg_leaves(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_agg_leaves(key, out);
+                }
+                collect_agg_leaves(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_agg_leaves(source, out);
+            collect_agg_leaves(item, out);
+            if let Some(predicate) = predicate {
+                collect_agg_leaves(predicate, out);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -1714,6 +1739,31 @@ fn collect_field_refs(expr: &Expr, out: &mut Vec<QualifiedField>) {
             collect_field_refs(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_field_refs(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_field_refs(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_field_refs(key, out);
+                }
+                collect_field_refs(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_field_refs(source, out);
+            collect_field_refs(item, out);
+            if let Some(predicate) = predicate {
+                collect_field_refs(predicate, out);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -1793,6 +1843,31 @@ fn collect_doc_paths_in_expr(expr: &Expr, out: &mut Vec<DocPath>) {
             collect_doc_paths_in_expr(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_doc_paths_in_expr(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_doc_paths_in_expr(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_doc_paths_in_expr(key, out);
+                }
+                collect_doc_paths_in_expr(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_doc_paths_in_expr(source, out);
+            collect_doc_paths_in_expr(item, out);
+            if let Some(predicate) = predicate {
+                collect_doc_paths_in_expr(predicate, out);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -2530,6 +2605,52 @@ nodes:
                 namespace: "file".to_string(),
                 name: src.to_string(),
             }]
+        );
+    }
+
+    #[test]
+    fn transform_nested_constructor_dependencies_are_direct_lineage() {
+        let yaml = r#"
+pipeline: { name: nested_lineage }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: data/rows.csv
+      schema:
+        - { name: dept, type: string }
+        - { name: amount, type: int }
+        - { name: score, type: int }
+        - { name: region, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        emit payload = {
+          dept: dept,
+          values: [item + amount for item in [score] if region == "west"],
+        }
+  - type: output
+    name: out
+    input: construct
+    config: { name: out, type: json, path: out/nested.json, include_unmapped: false }
+"#;
+        let lineage = lineage_of(yaml);
+        let source = "/w/data/rows.csv";
+        let fields = &only_output(&lineage).facet.fields;
+        use TransformationSubtype::Transformation;
+        assert_field(
+            fields,
+            "payload",
+            &[
+                direct(source, "amount", Transformation),
+                direct(source, "dept", Transformation),
+                direct(source, "region", Transformation),
+                direct(source, "score", Transformation),
+            ],
         );
     }
 

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -385,6 +385,10 @@ fn walk_scope(
         // Set by the Composition arm to the body's output-port INDIRECT influence,
         // merged into this node's influence below.
         let mut comp_body_influence: Option<InfluenceMap> = None;
+        // Structural reads inside nested constructors/comprehensions are
+        // collected while their value terms are resolved, then merged with the
+        // node's ordinary predicate influence below.
+        let mut nested_influence = InfluenceMap::new();
         let cols: ColumnTerminals = match node {
             PlanNode::Source { .. } => {
                 let mut cols = ColumnTerminals::new();
@@ -483,6 +487,7 @@ fn walk_scope(
                         &payload.typed.program.statements,
                         &mut env,
                         &mut emitted,
+                        &mut nested_influence,
                         &resolve_unbound,
                         &node_doc_srcs,
                         ctx.declared_sections,
@@ -513,6 +518,15 @@ fn walk_scope(
                     {
                         merge_terminals(&mut terms, upstream_col(&lineage, up, &col), st);
                     }
+                    for (col, role) in
+                        aggregate_emit_influence(&emit.residual, compiled, input_schema)
+                    {
+                        add_upstream_influence(
+                            &mut nested_influence,
+                            upstream_col(&lineage, up, &col),
+                            role,
+                        );
+                    }
                     // Envelope reads in this emit, attributed against the feeding
                     // sources. A `$doc` left in the residual (outside any aggregate
                     // call) survives as a passthrough leaf and keeps the emit's own
@@ -524,23 +538,49 @@ fn walk_scope(
                     // feeds this node.
                     if !node_doc_srcs.is_empty() {
                         let mut residual_docs = Vec::new();
-                        collect_doc_paths_in_expr(&emit.residual, &mut residual_docs);
-                        merge_doc_read_terms(
-                            &mut terms,
-                            &residual_docs,
-                            field_ref_subtype(&emit.residual),
-                            &node_doc_srcs,
-                            ctx.declared_sections,
+                        collect_doc_paths_with_role(
+                            &emit.residual,
+                            ExprRole::Direct,
+                            &mut residual_docs,
                         );
+                        for (path, role) in residual_docs {
+                            match role {
+                                ExprRole::Direct => merge_doc_read_terms(
+                                    &mut terms,
+                                    std::slice::from_ref(&path),
+                                    field_ref_subtype(&emit.residual),
+                                    &node_doc_srcs,
+                                    ctx.declared_sections,
+                                ),
+                                ExprRole::Indirect(subtype) => add_doc_influence(
+                                    &mut nested_influence,
+                                    std::slice::from_ref(&path),
+                                    &node_doc_srcs,
+                                    ctx.declared_sections,
+                                    subtype,
+                                ),
+                            }
+                        }
                         let mut agg_docs = Vec::new();
                         aggregate_binding_doc_paths(&emit.residual, compiled, &mut agg_docs);
-                        merge_doc_read_terms(
-                            &mut terms,
-                            &agg_docs,
-                            Subtype::Aggregation,
-                            &node_doc_srcs,
-                            ctx.declared_sections,
-                        );
+                        for (path, role) in agg_docs {
+                            match role {
+                                ExprRole::Direct => merge_doc_read_terms(
+                                    &mut terms,
+                                    std::slice::from_ref(&path),
+                                    Subtype::Aggregation,
+                                    &node_doc_srcs,
+                                    ctx.declared_sections,
+                                ),
+                                ExprRole::Indirect(subtype) => add_doc_influence(
+                                    &mut nested_influence,
+                                    std::slice::from_ref(&path),
+                                    &node_doc_srcs,
+                                    ctx.declared_sections,
+                                    subtype,
+                                ),
+                            }
+                        }
                     }
                     cols.insert_nonempty(&emit.output_name, terms);
                 }
@@ -618,6 +658,7 @@ fn walk_scope(
                             &tp.program.statements,
                             &mut env,
                             &mut emitted,
+                            &mut nested_influence,
                             &resolve_unbound,
                             &node_doc_srcs,
                             ctx.declared_sections,
@@ -802,6 +843,7 @@ fn walk_scope(
             &node_doc_srcs,
             ctx.declared_sections,
         );
+        merge_influence(&mut node_influence, nested_influence);
         // A composition's in-body INDIRECT influence (filters / joins / group-bys
         // inside the body), harvested at its output port, joins the inherited
         // upstream influence. Set-union, so the parent influence carried through
@@ -963,6 +1005,15 @@ enum IndirectSub {
     Conditional,
 }
 
+/// How one expression child contributes to lineage. Value-producing reads stay
+/// per-column DIRECT edges; children that choose membership or output structure
+/// become whole-dataset INDIRECT influence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExprRole {
+    Direct,
+    Indirect(IndirectSub),
+}
+
 impl IndirectSub {
     fn to_openlineage(self) -> TransformationSubtype {
         match self {
@@ -979,6 +1030,15 @@ impl IndirectSub {
 /// to the set of influence subtypes through which it reaches the dataset. The
 /// `BTreeMap`/`BTreeSet` keep the emitted `dataset[]` order deterministic.
 type InfluenceMap = BTreeMap<Terminal, BTreeSet<IndirectSub>>;
+
+/// DIRECT terminals and INDIRECT influence retained for an expression or one
+/// lexical binding. Keeping both in the lexical environment prevents a `let`
+/// from losing structural influence when the binding is emitted later.
+#[derive(Clone, Default)]
+struct ResolvedExprLineage {
+    terms: TermMap,
+    influence: InfluenceMap,
+}
 
 /// One Source dataset column: the terminal of a DIRECT lineage path.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -1061,7 +1121,7 @@ fn upstream_ids(dag: &ExecutionPlanDag, idx: NodeIndex) -> Vec<PlanNodeId> {
 /// This returns the sources whose document *could* carry the read; the final
 /// per-section narrowing — attribute a `$doc.<section>` read only to sources
 /// whose envelope declares `<section>` — happens at attribution time
-/// (`resolve_expr_terms`), so a multi-source fan-in never emits a false edge to
+/// (`resolve_expr_lineage`), so a multi-source fan-in never emits a false edge to
 /// a source whose document lacks the section.
 fn node_doc_sources(
     node: &PlanNode,
@@ -1336,8 +1396,9 @@ fn program_field_ref_subtype(program: &Program) -> Subtype {
 /// land in `env` and expand at the binding's use site.
 fn collect_field_emits(
     statements: &[Statement],
-    env: &mut HashMap<String, TermMap>,
+    env: &mut HashMap<String, ResolvedExprLineage>,
     emitted: &mut HashMap<String, TermMap>,
+    nested_influence: &mut InfluenceMap,
     resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
     doc_sources: &BTreeSet<DatasetId>,
     declared_sections: &HashMap<DatasetId, BTreeSet<String>>,
@@ -1345,9 +1406,14 @@ fn collect_field_emits(
     for stmt in statements {
         match stmt {
             Statement::Let { name, expr, .. } => {
-                let terms =
-                    resolve_expr_terms(expr, env, resolve_unbound, doc_sources, declared_sections);
-                env.insert(name.to_string(), terms);
+                let resolved = resolve_expr_lineage(
+                    expr,
+                    env,
+                    resolve_unbound,
+                    doc_sources,
+                    declared_sections,
+                );
+                env.insert(name.to_string(), resolved);
             }
             Statement::Emit {
                 name,
@@ -1358,9 +1424,15 @@ fn collect_field_emits(
                 if name.starts_with('$') {
                     continue;
                 }
-                let terms =
-                    resolve_expr_terms(expr, env, resolve_unbound, doc_sources, declared_sections);
-                emitted.insert(name.to_string(), terms);
+                let resolved = resolve_expr_lineage(
+                    expr,
+                    env,
+                    resolve_unbound,
+                    doc_sources,
+                    declared_sections,
+                );
+                merge_influence(nested_influence, resolved.influence);
+                emitted.insert(name.to_string(), resolved.terms);
             }
             Statement::EmitEach {
                 binding,
@@ -1374,7 +1446,7 @@ fn collect_field_emits(
                 body,
                 ..
             } => {
-                let src = resolve_expr_terms(
+                let src = resolve_expr_lineage(
                     source,
                     env,
                     resolve_unbound,
@@ -1382,16 +1454,23 @@ fn collect_field_emits(
                     declared_sections,
                 );
                 let mut tagged = TermMap::new();
-                merge_terminals(&mut tagged, Some(&src), Subtype::Transformation);
+                merge_terminals(&mut tagged, Some(&src.terms), Subtype::Transformation);
                 // The body is a lexical block: save the scope, bind the loop
                 // variable, recurse, then restore — body-local `let`s and the
                 // loop binding both fall out of scope here.
                 let saved = env.clone();
-                env.insert(binding.to_string(), tagged);
+                env.insert(
+                    binding.to_string(),
+                    ResolvedExprLineage {
+                        terms: tagged,
+                        influence: src.influence,
+                    },
+                );
                 collect_field_emits(
                     body,
                     env,
                     emitted,
+                    nested_influence,
                     resolve_unbound,
                     doc_sources,
                     declared_sections,
@@ -1403,36 +1482,289 @@ fn collect_field_emits(
     }
 }
 
-/// Resolve the source terminals an emit/let RHS expression derives from. The
-/// whole expression's [`field_ref_subtype`] (IDENTITY for a bare copy/rename,
-/// else TRANSFORMATION) is composed onto every leaf it reads — a record column
-/// (via `resolve_unbound`) or an envelope `$doc` read (attributed to each
-/// feeding `doc_sources` dataset whose envelope declares the read section, with
-/// the rendered doc path as its `field`).
-fn resolve_expr_terms(
+/// Resolve one emit/let RHS into its value terminals and structural influence.
+/// Array items and map values inherit DIRECT; a comprehension source/predicate
+/// becomes FILTER influence and a computed map key becomes CONDITIONAL
+/// influence. Once a subtree is already indirect, all of its children keep that
+/// role. Static map keys are text, not expressions, and add no dependency.
+fn resolve_expr_lineage(
     expr: &Expr,
-    env: &HashMap<String, TermMap>,
+    env: &HashMap<String, ResolvedExprLineage>,
     resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
     doc_sources: &BTreeSet<DatasetId>,
     declared_sections: &HashMap<DatasetId, BTreeSet<String>>,
-) -> TermMap {
+) -> ResolvedExprLineage {
     let local = field_ref_subtype(expr);
-    let mut out = TermMap::new();
+    let mut out = ResolvedExprLineage::default();
+    resolve_expr_role(
+        expr,
+        ExprRole::Direct,
+        local,
+        env,
+        resolve_unbound,
+        doc_sources,
+        declared_sections,
+        &mut out,
+    );
+    out
+}
 
-    let mut refs = Vec::new();
-    collect_field_refs(expr, &mut refs);
-    for qf in &refs {
-        let base = resolve_leaf_terms(qf, env, resolve_unbound);
-        merge_terminals(&mut out, base.as_ref(), local);
+#[allow(clippy::too_many_arguments)]
+fn resolve_expr_role(
+    expr: &Expr,
+    role: ExprRole,
+    local: Subtype,
+    env: &HashMap<String, ResolvedExprLineage>,
+    resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
+    doc_sources: &BTreeSet<DatasetId>,
+    declared_sections: &HashMap<DatasetId, BTreeSet<String>>,
+    out: &mut ResolvedExprLineage,
+) {
+    let recurse = |child: &Expr, child_role: ExprRole, out: &mut ResolvedExprLineage| {
+        resolve_expr_role(
+            child,
+            child_role,
+            local,
+            env,
+            resolve_unbound,
+            doc_sources,
+            declared_sections,
+            out,
+        );
+    };
+
+    if let Expr::IndexAccess { .. } = expr
+        && let Some(Ok(path)) = classify_doc_index_chain(expr)
+    {
+        merge_doc_role(out, &path, role, local, doc_sources, declared_sections);
+        return;
+    }
+    if let Expr::DocAccess { section, field, .. } = expr {
+        merge_doc_role(
+            out,
+            &DocPath {
+                section: section.clone(),
+                field: field.clone(),
+                indices: Vec::new(),
+            },
+            role,
+            local,
+            doc_sources,
+            declared_sections,
+        );
+        return;
     }
 
-    // Envelope reads resolve to the feeding source datasets, not through the
-    // upstream column map (a `$doc` access names a section/field, not a column).
-    let mut doc_paths = Vec::new();
-    collect_doc_paths_in_expr(expr, &mut doc_paths);
-    merge_doc_read_terms(&mut out, &doc_paths, local, doc_sources, declared_sections);
+    match expr {
+        Expr::FieldRef { name, .. } if !name.starts_with('$') => {
+            merge_leaf_role(
+                out,
+                &QualifiedField::bare(name.as_ref()),
+                role,
+                local,
+                env,
+                resolve_unbound,
+            );
+        }
+        Expr::QualifiedFieldRef { parts, .. }
+            if parts.first().is_some_and(|part| !part.starts_with('$')) =>
+        {
+            let qf = if parts.len() >= 2 {
+                QualifiedField::qualified(parts[0].as_ref(), parts[1].as_ref())
+            } else {
+                QualifiedField::bare(parts[0].as_ref())
+            };
+            merge_leaf_role(out, &qf, role, local, env, resolve_unbound);
+        }
+        Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
+            recurse(lhs, role, out);
+            recurse(rhs, role, out);
+        }
+        Expr::Unary { operand, .. } => recurse(operand, role, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                recurse(element, role, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    let key_role = match role {
+                        ExprRole::Direct => ExprRole::Indirect(IndirectSub::Conditional),
+                        indirect => indirect,
+                    };
+                    recurse(key, key_role, out);
+                }
+                recurse(&entry.value, role, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            let structural_role = match role {
+                ExprRole::Direct => ExprRole::Indirect(IndirectSub::Filter),
+                indirect => indirect,
+            };
+            recurse(source, structural_role, out);
 
-    out
+            // The lexical item binding represents values drawn from `source`.
+            // Resolve the source once as a value solely to seed that binding;
+            // its role-carrying walk above is the only contribution made by the
+            // source expression itself.
+            let source_value =
+                resolve_expr_lineage(source, env, resolve_unbound, doc_sources, declared_sections);
+            let mut binding_terms = TermMap::new();
+            merge_terminals(
+                &mut binding_terms,
+                Some(&source_value.terms),
+                Subtype::Transformation,
+            );
+            let mut nested_env = env.clone();
+            nested_env.insert(
+                binding.to_string(),
+                ResolvedExprLineage {
+                    terms: binding_terms,
+                    influence: InfluenceMap::new(),
+                },
+            );
+            resolve_expr_role(
+                item,
+                role,
+                local,
+                &nested_env,
+                resolve_unbound,
+                doc_sources,
+                declared_sections,
+                out,
+            );
+            if let Some(predicate) = predicate {
+                resolve_expr_role(
+                    predicate,
+                    structural_role,
+                    local,
+                    &nested_env,
+                    resolve_unbound,
+                    doc_sources,
+                    declared_sections,
+                    out,
+                );
+            }
+        }
+        Expr::IfThenElse {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            recurse(condition, role, out);
+            recurse(then_branch, role, out);
+            if let Some(branch) = else_branch {
+                recurse(branch, role, out);
+            }
+        }
+        Expr::Match { subject, arms, .. } => {
+            if let Some(subject) = subject {
+                recurse(subject, role, out);
+            }
+            for arm in arms {
+                recurse(&arm.pattern, role, out);
+                recurse(&arm.body, role, out);
+            }
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            recurse(receiver, role, out);
+            for argument in args {
+                recurse(argument, role, out);
+            }
+        }
+        Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
+            for argument in args {
+                recurse(argument, role, out);
+            }
+        }
+        Expr::IndexAccess {
+            receiver, index, ..
+        } => {
+            recurse(receiver, role, out);
+            recurse(index, role, out);
+        }
+        Expr::Closure { body, .. } => recurse(body, role, out),
+        Expr::Literal { .. }
+        | Expr::FieldRef { .. }
+        | Expr::QualifiedFieldRef { .. }
+        | Expr::PipelineAccess { .. }
+        | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
+        | Expr::SourceAccess { .. }
+        | Expr::QualifiedSourceAccess { .. }
+        | Expr::RecordAccess { .. }
+        | Expr::DocAccess { .. }
+        | Expr::Now { .. }
+        | Expr::Wildcard { .. }
+        | Expr::AggSlot { .. }
+        | Expr::GroupKey { .. } => {}
+    }
+}
+
+fn merge_leaf_role(
+    out: &mut ResolvedExprLineage,
+    qf: &QualifiedField,
+    role: ExprRole,
+    local: Subtype,
+    env: &HashMap<String, ResolvedExprLineage>,
+    resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
+) {
+    let first = qf.qualifier.as_deref().unwrap_or(qf.name.as_ref());
+    if let Some(binding) = env.get(first) {
+        match role {
+            ExprRole::Direct => {
+                merge_terminals(&mut out.terms, Some(&binding.terms), local);
+                merge_influence(&mut out.influence, binding.influence.clone());
+            }
+            ExprRole::Indirect(subtype) => {
+                add_upstream_influence(&mut out.influence, Some(&binding.terms), subtype);
+                merge_influence(&mut out.influence, binding.influence.clone());
+            }
+        }
+        return;
+    }
+    let base = resolve_unbound(qf);
+    match role {
+        ExprRole::Direct => merge_terminals(&mut out.terms, base.as_ref(), local),
+        ExprRole::Indirect(subtype) => {
+            add_upstream_influence(&mut out.influence, base.as_ref(), subtype);
+        }
+    }
+}
+
+fn merge_doc_role(
+    out: &mut ResolvedExprLineage,
+    path: &DocPath,
+    role: ExprRole,
+    local: Subtype,
+    doc_sources: &BTreeSet<DatasetId>,
+    declared_sections: &HashMap<DatasetId, BTreeSet<String>>,
+) {
+    match role {
+        ExprRole::Direct => merge_doc_read_terms(
+            &mut out.terms,
+            std::slice::from_ref(path),
+            local,
+            doc_sources,
+            declared_sections,
+        ),
+        ExprRole::Indirect(subtype) => add_doc_influence(
+            &mut out.influence,
+            std::slice::from_ref(path),
+            doc_sources,
+            declared_sections,
+            subtype,
+        ),
+    }
 }
 
 /// Merge the DIRECT terminals a set of `$doc` envelope reads derives from into
@@ -1444,7 +1776,7 @@ fn resolve_expr_terms(
 /// read is itself a verbatim copy of the envelope value); `local` then dominates
 /// it, so a bare `$doc` emit stays IDENTITY while a `$doc` inside an expression
 /// composes to TRANSFORMATION. Shared by the Transform/Combine body walk
-/// (`resolve_expr_terms`) and the Aggregate emit arm.
+/// (`resolve_expr_lineage`) and the Aggregate emit arm.
 fn merge_doc_read_terms(
     out: &mut TermMap,
     doc_paths: &[DocPath],
@@ -1484,21 +1816,6 @@ fn doc_read_terminals<'a>(
         .map(move |ds| Terminal::new(&ds.namespace, &ds.name, &rendered))
 }
 
-/// Resolve one leaf field reference to its source terminals: an in-scope binding
-/// (`let` or `emit each` loop variable, matched by the reference's first segment)
-/// wins, then `resolve_unbound` (the operator input).
-fn resolve_leaf_terms(
-    qf: &QualifiedField,
-    env: &HashMap<String, TermMap>,
-    resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
-) -> Option<TermMap> {
-    let first = qf.qualifier.as_deref().unwrap_or(qf.name.as_ref());
-    if let Some(terms) = env.get(first) {
-        return Some(terms.clone());
-    }
-    resolve_unbound(qf)
-}
-
 /// The input column(s) and DIRECT subtype each contributing to one aggregate
 /// output column, read off the post-extraction `residual`.
 fn aggregate_emit_sources(
@@ -1510,11 +1827,14 @@ fn aggregate_emit_sources(
     // any expression the group-key contribution becomes a transformation.
     let bare_leaf = matches!(residual, Expr::GroupKey { .. } | Expr::AggSlot { .. });
     let mut leaves = Vec::new();
-    collect_agg_leaves(residual, &mut leaves);
+    collect_agg_leaves(residual, ExprRole::Direct, &mut leaves);
 
     let mut out = Vec::new();
-    for leaf in leaves {
-        match leaf {
+    for read in leaves {
+        if read.role != ExprRole::Direct {
+            continue;
+        }
+        match read.leaf {
             AggLeaf::Group(slot) => {
                 if let Some(name) = compiled.group_by_fields.get(slot as usize) {
                     let st = if bare_leaf {
@@ -1545,6 +1865,43 @@ fn aggregate_emit_sources(
     out
 }
 
+/// Aggregate residual inputs that choose comprehension membership or computed
+/// map structure. They affect the output dataset without becoming inputs to the
+/// emitted column value.
+fn aggregate_emit_influence(
+    residual: &Expr,
+    compiled: &cxl::plan::CompiledAggregate,
+    input_schema: Option<&Schema>,
+) -> Vec<(String, IndirectSub)> {
+    let mut leaves = Vec::new();
+    collect_agg_leaves(residual, ExprRole::Direct, &mut leaves);
+
+    let mut out = Vec::new();
+    for read in leaves {
+        let ExprRole::Indirect(subtype) = read.role else {
+            continue;
+        };
+        match read.leaf {
+            AggLeaf::Group(slot) => {
+                if let Some(name) = compiled.group_by_fields.get(slot as usize) {
+                    out.push((name.clone(), subtype));
+                }
+            }
+            AggLeaf::Agg(slot) => {
+                if let Some(binding) = compiled.bindings.get(slot as usize) {
+                    out.extend(
+                        binding_arg_input_names(&binding.arg, input_schema)
+                            .into_iter()
+                            .map(|name| (name, subtype)),
+                    );
+                }
+            }
+            AggLeaf::Field(name) => out.push((name.to_string(), subtype)),
+        }
+    }
+    out
+}
+
 /// Leaf of an aggregate emit residual that carries column provenance.
 enum AggLeaf<'a> {
     /// `GroupKey { slot }` — passthrough of a group-by column.
@@ -1556,13 +1913,27 @@ enum AggLeaf<'a> {
     Field(&'a str),
 }
 
-fn collect_agg_leaves<'a>(expr: &'a Expr, out: &mut Vec<AggLeaf<'a>>) {
+struct AggRead<'a> {
+    leaf: AggLeaf<'a>,
+    role: ExprRole,
+}
+
+fn collect_agg_leaves<'a>(expr: &'a Expr, role: ExprRole, out: &mut Vec<AggRead<'a>>) {
     match expr {
-        Expr::GroupKey { slot, .. } => out.push(AggLeaf::Group(*slot)),
-        Expr::AggSlot { slot, .. } => out.push(AggLeaf::Agg(*slot)),
+        Expr::GroupKey { slot, .. } => out.push(AggRead {
+            leaf: AggLeaf::Group(*slot),
+            role,
+        }),
+        Expr::AggSlot { slot, .. } => out.push(AggRead {
+            leaf: AggLeaf::Agg(*slot),
+            role,
+        }),
         Expr::FieldRef { name, .. } => {
             if !name.starts_with('$') {
-                out.push(AggLeaf::Field(name));
+                out.push(AggRead {
+                    leaf: AggLeaf::Field(name),
+                    role,
+                });
             }
         }
         Expr::QualifiedFieldRef { parts, .. } => {
@@ -1571,25 +1942,32 @@ fn collect_agg_leaves<'a>(expr: &'a Expr, out: &mut Vec<AggLeaf<'a>>) {
             if let Some(first) = parts.first()
                 && !first.starts_with('$')
             {
-                out.push(AggLeaf::Field(first.as_ref()));
+                out.push(AggRead {
+                    leaf: AggLeaf::Field(first.as_ref()),
+                    role,
+                });
             }
         }
         Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
-            collect_agg_leaves(lhs, out);
-            collect_agg_leaves(rhs, out);
+            collect_agg_leaves(lhs, role, out);
+            collect_agg_leaves(rhs, role, out);
         }
-        Expr::Unary { operand, .. } => collect_agg_leaves(operand, out),
+        Expr::Unary { operand, .. } => collect_agg_leaves(operand, role, out),
         Expr::ArrayLiteral { elements, .. } => {
             for element in elements {
-                collect_agg_leaves(element, out);
+                collect_agg_leaves(element, role, out);
             }
         }
         Expr::MapLiteral { entries, .. } => {
             for entry in entries {
                 if let cxl::ast::MapKey::Computed(key) = &entry.key {
-                    collect_agg_leaves(key, out);
+                    let key_role = match role {
+                        ExprRole::Direct => ExprRole::Indirect(IndirectSub::Conditional),
+                        indirect => indirect,
+                    };
+                    collect_agg_leaves(key, key_role, out);
                 }
-                collect_agg_leaves(&entry.value, out);
+                collect_agg_leaves(&entry.value, role, out);
             }
         }
         Expr::ArrayComprehension {
@@ -1598,10 +1976,14 @@ fn collect_agg_leaves<'a>(expr: &'a Expr, out: &mut Vec<AggLeaf<'a>>) {
             predicate,
             ..
         } => {
-            collect_agg_leaves(source, out);
-            collect_agg_leaves(item, out);
+            let structural_role = match role {
+                ExprRole::Direct => ExprRole::Indirect(IndirectSub::Filter),
+                indirect => indirect,
+            };
+            collect_agg_leaves(source, structural_role, out);
+            collect_agg_leaves(item, role, out);
             if let Some(predicate) = predicate {
-                collect_agg_leaves(predicate, out);
+                collect_agg_leaves(predicate, structural_role, out);
             }
         }
         Expr::IfThenElse {
@@ -1610,39 +1992,39 @@ fn collect_agg_leaves<'a>(expr: &'a Expr, out: &mut Vec<AggLeaf<'a>>) {
             else_branch,
             ..
         } => {
-            collect_agg_leaves(condition, out);
-            collect_agg_leaves(then_branch, out);
+            collect_agg_leaves(condition, role, out);
+            collect_agg_leaves(then_branch, role, out);
             if let Some(eb) = else_branch {
-                collect_agg_leaves(eb, out);
+                collect_agg_leaves(eb, role, out);
             }
         }
         Expr::Match { subject, arms, .. } => {
             if let Some(s) = subject {
-                collect_agg_leaves(s, out);
+                collect_agg_leaves(s, role, out);
             }
             for arm in arms {
-                collect_agg_leaves(&arm.pattern, out);
-                collect_agg_leaves(&arm.body, out);
+                collect_agg_leaves(&arm.pattern, role, out);
+                collect_agg_leaves(&arm.body, role, out);
             }
         }
         Expr::MethodCall { receiver, args, .. } => {
-            collect_agg_leaves(receiver, out);
+            collect_agg_leaves(receiver, role, out);
             for a in args {
-                collect_agg_leaves(a, out);
+                collect_agg_leaves(a, role, out);
             }
         }
         Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
             for a in args {
-                collect_agg_leaves(a, out);
+                collect_agg_leaves(a, role, out);
             }
         }
         Expr::IndexAccess {
             receiver, index, ..
         } => {
-            collect_agg_leaves(receiver, out);
-            collect_agg_leaves(index, out);
+            collect_agg_leaves(receiver, role, out);
+            collect_agg_leaves(index, role, out);
         }
-        Expr::Closure { body, .. } => collect_agg_leaves(body, out),
+        Expr::Closure { body, .. } => collect_agg_leaves(body, role, out),
         _ => {}
     }
 }
@@ -1676,15 +2058,15 @@ fn binding_arg_input_names(arg: &BindingArg, schema: Option<&Schema>) -> Vec<Str
 fn aggregate_binding_doc_paths(
     residual: &Expr,
     compiled: &cxl::plan::CompiledAggregate,
-    out: &mut Vec<DocPath>,
+    out: &mut Vec<(DocPath, ExprRole)>,
 ) {
     let mut leaves = Vec::new();
-    collect_agg_leaves(residual, &mut leaves);
-    for leaf in leaves {
-        if let AggLeaf::Agg(slot) = leaf
+    collect_agg_leaves(residual, ExprRole::Direct, &mut leaves);
+    for read in leaves {
+        if let AggLeaf::Agg(slot) = read.leaf
             && let Some(binding) = compiled.bindings.get(slot as usize)
         {
-            binding_arg_doc_paths(&binding.arg, out);
+            binding_arg_doc_paths(&binding.arg, read.role, out);
         }
     }
 }
@@ -1692,12 +2074,12 @@ fn aggregate_binding_doc_paths(
 /// `$doc` paths read by a single aggregate argument — the envelope analogue of
 /// [`binding_arg_input_names`], which sees only record columns (`support_into`
 /// excludes the `$doc` namespace).
-fn binding_arg_doc_paths(arg: &BindingArg, out: &mut Vec<DocPath>) {
+fn binding_arg_doc_paths(arg: &BindingArg, role: ExprRole, out: &mut Vec<(DocPath, ExprRole)>) {
     match arg {
-        BindingArg::Expr(e) => collect_doc_paths_in_expr(e, out),
+        BindingArg::Expr(e) => collect_doc_paths_with_role(e, role, out),
         BindingArg::Pair(a, b) => {
-            binding_arg_doc_paths(a, out);
-            binding_arg_doc_paths(b, out);
+            binding_arg_doc_paths(a, role, out);
+            binding_arg_doc_paths(b, role, out);
         }
         BindingArg::Field(_) | BindingArg::Wildcard => {}
     }
@@ -1818,6 +2200,12 @@ fn collect_field_refs(expr: &Expr, out: &mut Vec<QualifiedField>) {
 /// carries an unresolvable chain; the `Err` arm is descended defensively only so
 /// a nested `$doc` is never silently lost.
 fn collect_doc_paths_in_expr(expr: &Expr, out: &mut Vec<DocPath>) {
+    let mut reads = Vec::new();
+    collect_doc_paths_with_role(expr, ExprRole::Direct, &mut reads);
+    out.extend(reads.into_iter().map(|(path, _)| path));
+}
+
+fn collect_doc_paths_with_role(expr: &Expr, role: ExprRole, out: &mut Vec<(DocPath, ExprRole)>) {
     // A `$doc` index chain is one path — classify before the generic descent so
     // its index expressions are not walked as separate references. Anything else
     // (a non-`$doc` index access, or an unreachable dynamic-index `Err`) falls
@@ -1826,34 +2214,41 @@ fn collect_doc_paths_in_expr(expr: &Expr, out: &mut Vec<DocPath>) {
     if let Expr::IndexAccess { .. } = expr
         && let Some(Ok(path)) = classify_doc_index_chain(expr)
     {
-        out.push(path);
+        out.push((path, role));
         return;
     }
     if let Expr::DocAccess { section, field, .. } = expr {
-        out.push(DocPath {
-            section: section.clone(),
-            field: field.clone(),
-            indices: Vec::new(),
-        });
+        out.push((
+            DocPath {
+                section: section.clone(),
+                field: field.clone(),
+                indices: Vec::new(),
+            },
+            role,
+        ));
         return;
     }
     match expr {
         Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
-            collect_doc_paths_in_expr(lhs, out);
-            collect_doc_paths_in_expr(rhs, out);
+            collect_doc_paths_with_role(lhs, role, out);
+            collect_doc_paths_with_role(rhs, role, out);
         }
-        Expr::Unary { operand, .. } => collect_doc_paths_in_expr(operand, out),
+        Expr::Unary { operand, .. } => collect_doc_paths_with_role(operand, role, out),
         Expr::ArrayLiteral { elements, .. } => {
             for element in elements {
-                collect_doc_paths_in_expr(element, out);
+                collect_doc_paths_with_role(element, role, out);
             }
         }
         Expr::MapLiteral { entries, .. } => {
             for entry in entries {
                 if let cxl::ast::MapKey::Computed(key) = &entry.key {
-                    collect_doc_paths_in_expr(key, out);
+                    let key_role = match role {
+                        ExprRole::Direct => ExprRole::Indirect(IndirectSub::Conditional),
+                        indirect => indirect,
+                    };
+                    collect_doc_paths_with_role(key, key_role, out);
                 }
-                collect_doc_paths_in_expr(&entry.value, out);
+                collect_doc_paths_with_role(&entry.value, role, out);
             }
         }
         Expr::ArrayComprehension {
@@ -1862,10 +2257,14 @@ fn collect_doc_paths_in_expr(expr: &Expr, out: &mut Vec<DocPath>) {
             predicate,
             ..
         } => {
-            collect_doc_paths_in_expr(source, out);
-            collect_doc_paths_in_expr(item, out);
+            let structural_role = match role {
+                ExprRole::Direct => ExprRole::Indirect(IndirectSub::Filter),
+                indirect => indirect,
+            };
+            collect_doc_paths_with_role(source, structural_role, out);
+            collect_doc_paths_with_role(item, role, out);
             if let Some(predicate) = predicate {
-                collect_doc_paths_in_expr(predicate, out);
+                collect_doc_paths_with_role(predicate, structural_role, out);
             }
         }
         Expr::IfThenElse {
@@ -1874,39 +2273,39 @@ fn collect_doc_paths_in_expr(expr: &Expr, out: &mut Vec<DocPath>) {
             else_branch,
             ..
         } => {
-            collect_doc_paths_in_expr(condition, out);
-            collect_doc_paths_in_expr(then_branch, out);
+            collect_doc_paths_with_role(condition, role, out);
+            collect_doc_paths_with_role(then_branch, role, out);
             if let Some(eb) = else_branch {
-                collect_doc_paths_in_expr(eb, out);
+                collect_doc_paths_with_role(eb, role, out);
             }
         }
         Expr::Match { subject, arms, .. } => {
             if let Some(s) = subject {
-                collect_doc_paths_in_expr(s, out);
+                collect_doc_paths_with_role(s, role, out);
             }
             for arm in arms {
-                collect_doc_paths_in_expr(&arm.pattern, out);
-                collect_doc_paths_in_expr(&arm.body, out);
+                collect_doc_paths_with_role(&arm.pattern, role, out);
+                collect_doc_paths_with_role(&arm.body, role, out);
             }
         }
         Expr::MethodCall { receiver, args, .. } => {
-            collect_doc_paths_in_expr(receiver, out);
+            collect_doc_paths_with_role(receiver, role, out);
             for a in args {
-                collect_doc_paths_in_expr(a, out);
+                collect_doc_paths_with_role(a, role, out);
             }
         }
         Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
             for a in args {
-                collect_doc_paths_in_expr(a, out);
+                collect_doc_paths_with_role(a, role, out);
             }
         }
         Expr::IndexAccess {
             receiver, index, ..
         } => {
-            collect_doc_paths_in_expr(receiver, out);
-            collect_doc_paths_in_expr(index, out);
+            collect_doc_paths_with_role(receiver, role, out);
+            collect_doc_paths_with_role(index, role, out);
         }
-        Expr::Closure { body, .. } => collect_doc_paths_in_expr(body, out),
+        Expr::Closure { body, .. } => collect_doc_paths_with_role(body, role, out),
         _ => {}
     }
 }
@@ -2267,6 +2666,12 @@ fn add_upstream_influence(inf: &mut InfluenceMap, up_terms: Option<&TermMap>, su
     }
 }
 
+fn merge_influence(target: &mut InfluenceMap, source: InfluenceMap) {
+    for (terminal, subtypes) in source {
+        target.entry(terminal).or_default().extend(subtypes);
+    }
+}
+
 /// Add each `$doc` envelope read in `doc_paths` to `inf` as an INDIRECT influence
 /// of subtype `sub`. A `$doc` read names a section/field, not a record column, so
 /// it resolves directly to each feeding `doc_srcs` dataset whose envelope
@@ -2609,7 +3014,7 @@ nodes:
     }
 
     #[test]
-    fn transform_nested_constructor_dependencies_are_direct_lineage() {
+    fn transform_nested_constructor_dependencies_keep_value_and_selection_roles() {
         let yaml = r#"
 pipeline: { name: nested_lineage }
 nodes:
@@ -2640,7 +3045,8 @@ nodes:
 "#;
         let lineage = lineage_of(yaml);
         let source = "/w/data/rows.csv";
-        let fields = &only_output(&lineage).facet.fields;
+        let output = only_output(&lineage);
+        let fields = &output.facet.fields;
         use TransformationSubtype::Transformation;
         assert_field(
             fields,
@@ -2648,8 +3054,15 @@ nodes:
             &[
                 direct(source, "amount", Transformation),
                 direct(source, "dept", Transformation),
-                direct(source, "region", Transformation),
                 direct(source, "score", Transformation),
+            ],
+        );
+        use TransformationSubtype::Filter;
+        assert_eq!(
+            output.facet.dataset,
+            vec![
+                indirect(source, "region", &[Filter]),
+                indirect(source, "score", &[Filter]),
             ],
         );
     }
@@ -3444,9 +3857,15 @@ nodes:
             span: Span::default(),
         };
         let mut leaves = Vec::new();
-        collect_agg_leaves(&expr, &mut leaves);
+        collect_agg_leaves(&expr, ExprRole::Direct, &mut leaves);
         assert!(
-            matches!(leaves.as_slice(), [AggLeaf::Field("amount")]),
+            matches!(
+                leaves.as_slice(),
+                [AggRead {
+                    leaf: AggLeaf::Field("amount"),
+                    role: ExprRole::Direct,
+                }]
+            ),
             "qualified ref base column must contribute a leaf"
         );
     }

--- a/crates/clinker-lineage/tests/composition_lineage.rs
+++ b/crates/clinker-lineage/tests/composition_lineage.rs
@@ -102,6 +102,103 @@ fn assert_field(fields: &BTreeMap<String, FieldLineage>, col: &str, expected: &[
     assert_eq!(actual.input_fields, expected, "lineage for column {col:?}");
 }
 
+#[test]
+fn nested_value_and_structural_reads_keep_distinct_lineage_roles() {
+    let yaml = r#"
+pipeline: { name: nested_roles }
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: data/src.csv
+      schema:
+        - { name: value_field, type: string }
+        - { name: key_field, type: string }
+        - { name: shared, type: string }
+        - { name: predicate_field, type: bool }
+  - type: transform
+    name: construct
+    input: src
+    config:
+      cxl: |
+        emit payload = {
+          static: value_field,
+          [key_field]: [entry for entry in [shared] if predicate_field],
+        }
+  - type: output
+    name: out
+    input: construct
+    config: { name: out, type: json, path: out/nested-roles.json, include_unmapped: false }
+"#;
+    let lineage = lineage_of(yaml);
+    let src = src_name();
+    let out = only_output(&lineage);
+
+    use TransformationSubtype::{Conditional, Filter, Transformation};
+    assert_field(
+        &out.facet.fields,
+        "payload",
+        &[
+            direct(&src, "shared", Transformation),
+            direct(&src, "value_field", Transformation),
+        ],
+    );
+    assert_eq!(
+        out.facet.dataset,
+        vec![
+            indirect(&src, "key_field", &[Conditional]),
+            indirect(&src, "predicate_field", &[Filter]),
+            indirect(&src, "shared", &[Filter]),
+        ],
+        "computed keys and comprehension selection affect structure/membership without becoming value edges",
+    );
+}
+
+#[test]
+fn nested_static_keys_add_no_dependency_and_literal_items_stay_direct() {
+    let yaml = r#"
+pipeline: { name: nested_static_keys }
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: data/src.csv
+      schema:
+        - { name: first_value, type: string }
+        - { name: second_value, type: string }
+  - type: transform
+    name: construct
+    input: src
+    config:
+      cxl: 'emit payload = [first_value, {static: second_value}]'
+  - type: output
+    name: out
+    input: construct
+    config: { name: out, type: json, path: out/nested-static.json, include_unmapped: false }
+"#;
+    let lineage = lineage_of(yaml);
+    let src = src_name();
+    let out = only_output(&lineage);
+
+    use TransformationSubtype::Transformation;
+    assert_field(
+        &out.facet.fields,
+        "payload",
+        &[
+            direct(&src, "first_value", Transformation),
+            direct(&src, "second_value", Transformation),
+        ],
+    );
+    assert!(
+        out.facet.dataset.is_empty(),
+        "authored static key text carries no source-field dependency",
+    );
+}
+
 /// A single-boundary composition whose body renames a port column. The renamed
 /// output column must resolve to the TRUE source column (not the coarse
 /// all-to-all fan-out the opaque approximation produced), and the placeholder

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -6273,6 +6273,31 @@ fn walk_expr_for_qualified_refs(
         Expr::Unary { operand, .. } => {
             walk_expr_for_qualified_refs(Some(operand), inputs, driver_qualifier, out);
         }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                walk_expr_for_qualified_refs(Some(element), inputs, driver_qualifier, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    walk_expr_for_qualified_refs(Some(key), inputs, driver_qualifier, out);
+                }
+                walk_expr_for_qualified_refs(Some(&entry.value), inputs, driver_qualifier, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            walk_expr_for_qualified_refs(Some(source), inputs, driver_qualifier, out);
+            walk_expr_for_qualified_refs(Some(item), inputs, driver_qualifier, out);
+            if let Some(predicate) = predicate {
+                walk_expr_for_qualified_refs(Some(predicate), inputs, driver_qualifier, out);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             walk_expr_for_qualified_refs(Some(receiver), inputs, driver_qualifier, out);
             for a in args {

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1082,6 +1082,31 @@ fn collect_scope_reads_in_expr(expr: &Expr, out: &mut Vec<(crate::config::VarSco
             collect_scope_reads_in_expr(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_scope_reads_in_expr(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_scope_reads_in_expr(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_scope_reads_in_expr(key, out);
+                }
+                collect_scope_reads_in_expr(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_scope_reads_in_expr(source, out);
+            collect_scope_reads_in_expr(item, out);
+            if let Some(predicate) = predicate {
+                collect_scope_reads_in_expr(predicate, out);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -5441,6 +5466,22 @@ fn first_body_field_ref(expr: &Expr) -> Option<String> {
             first_body_field_ref(lhs).or_else(|| first_body_field_ref(rhs))
         }
         Expr::Unary { operand, .. } => first_body_field_ref(operand),
+        Expr::ArrayLiteral { elements, .. } => elements.iter().find_map(first_body_field_ref),
+        Expr::MapLiteral { entries, .. } => entries.iter().find_map(|entry| {
+            match &entry.key {
+                cxl::ast::MapKey::Computed(key) => first_body_field_ref(key),
+                cxl::ast::MapKey::Static(_) => None,
+            }
+            .or_else(|| first_body_field_ref(&entry.value))
+        }),
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => first_body_field_ref(source)
+            .or_else(|| first_body_field_ref(item))
+            .or_else(|| predicate.as_deref().and_then(first_body_field_ref)),
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -6445,6 +6486,31 @@ fn walk_for_unknown_refs(expr: &Expr, cx: CombineWalkContext<'_>, diags: &mut Ve
             walk_for_unknown_refs(rhs, cx, diags);
         }
         Expr::Unary { operand, .. } => walk_for_unknown_refs(operand, cx, diags),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                walk_for_unknown_refs(element, cx, diags);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    walk_for_unknown_refs(key, cx, diags);
+                }
+                walk_for_unknown_refs(&entry.value, cx, diags);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            walk_for_unknown_refs(source, cx, diags);
+            walk_for_unknown_refs(item, cx, diags);
+            if let Some(predicate) = predicate {
+                walk_for_unknown_refs(predicate, cx, diags);
+            }
+        }
         Expr::Coalesce { lhs, rhs, .. } => {
             walk_for_unknown_refs(lhs, cx, diags);
             walk_for_unknown_refs(rhs, cx, diags);

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -458,6 +458,31 @@ fn collect_qualifiers_inner(expr: &Expr, out: &mut HashSet<Arc<str>>) {
             collect_qualifiers_inner(rhs, out);
         }
         Expr::Unary { operand, .. } => collect_qualifiers_inner(operand, out),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_qualifiers_inner(element, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_qualifiers_inner(key, out);
+                }
+                collect_qualifiers_inner(&entry.value, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_qualifiers_inner(source, out);
+            collect_qualifiers_inner(item, out);
+            if let Some(predicate) = predicate {
+                collect_qualifiers_inner(predicate, out);
+            }
+        }
         Expr::Coalesce { lhs, rhs, .. } => {
             collect_qualifiers_inner(lhs, out);
             collect_qualifiers_inner(rhs, out);

--- a/crates/clinker-plan/src/resources/mod.rs
+++ b/crates/clinker-plan/src/resources/mod.rs
@@ -936,6 +936,46 @@ impl SemanticModuleHasher {
                 self.tag(2);
                 self.literal(value);
             }
+            Expr::ArrayLiteral { elements, .. } => {
+                self.tag(24);
+                self.expression_list(elements);
+            }
+            Expr::MapLiteral { entries, .. } => {
+                self.tag(25);
+                self.usize(entries.len());
+                for entry in entries {
+                    match &entry.key {
+                        cxl::ast::MapKey::Static(key) => {
+                            self.tag(0);
+                            self.string(key);
+                        }
+                        cxl::ast::MapKey::Computed(key) => {
+                            self.tag(1);
+                            self.expression(key);
+                        }
+                    }
+                    self.expression(&entry.value);
+                }
+            }
+            Expr::ArrayComprehension {
+                item,
+                binding,
+                source,
+                predicate,
+                ..
+            } => {
+                self.tag(26);
+                self.expression(item);
+                self.string(binding);
+                self.expression(source);
+                match predicate {
+                    Some(predicate) => {
+                        self.tag(1);
+                        self.expression(predicate);
+                    }
+                    None => self.tag(0),
+                }
+            }
             Expr::FieldRef { name, .. } => {
                 self.tag(3);
                 self.string(name);
@@ -1143,4 +1183,30 @@ fn semantic_module_digest(module: &Module) -> [u8; 32] {
     }
 
     hasher.finish()
+}
+
+#[cfg(test)]
+mod semantic_nested_value_tests {
+    use super::*;
+    use cxl::parser::Parser;
+
+    fn digest(source: &str) -> [u8; 32] {
+        let parsed = Parser::parse_module(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        semantic_module_digest(&parsed.module)
+    }
+
+    #[test]
+    fn nested_constructor_identity_ignores_layout_but_preserves_author_order() {
+        let compact = digest("let PAYLOAD = {first: [1, 2], last: [x for x in [3, 4]]}");
+        let multiline =
+            digest("let PAYLOAD = {\n  first: [1, 2],\n  last: [x for x in [3, 4]],\n}");
+        let reordered = digest("let PAYLOAD = {last: [x for x in [3, 4]], first: [1, 2]}");
+        assert_eq!(compact, multiline);
+        assert_ne!(compact, reordered, "map insertion order is semantic");
+    }
 }

--- a/crates/clinker-plan/tests/nested_cxl_integration.rs
+++ b/crates/clinker-plan/tests/nested_cxl_integration.rs
@@ -1,0 +1,420 @@
+//! Downstream planner coverage for nested CXL constructors and comprehensions.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use clinker_core_types::Diagnostic;
+use clinker_plan::config::{CompileContext, load_config, parse_config};
+use clinker_plan::plan::CompiledPlan;
+use clinker_plan::plan::execution::PlanNode;
+use clinker_plan::resources::{
+    CatalogConfig, CompiledModuleRegistry, LogicalResourceId, ModuleLimits, WorkspaceCatalog,
+    collect_cxl_fields_with_composition_identities, collect_direct_imports, compile_module_closure,
+};
+use cxl::ast::{Expr, MapKey};
+use cxl::lexer::Span;
+use cxl::module_eval::{ResolvedDeclarationId, ResolvedDeclarationKind};
+
+const PIPELINE: &str = r#"
+pipeline: { name: nested_cxl }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: rows.csv
+      schema:
+        - { name: value, type: string }
+  - type: transform
+    name: construct
+    input: rows
+    config:
+      cxl: |
+        use root
+        emit payload = root.payload(value)
+  - type: output
+    name: out
+    input: construct
+    config: { name: out, type: json, path: out.json, include_unmapped: false }
+"#;
+
+const NESTED_MODULE: &str = r#"
+fn key(x) = x
+fn source(x) = [x]
+fn item(x) = x
+fn keep(x) = x == x
+fn payload(x) = {
+  static: item.call(x),
+  [key.call(x)]: [item.call(entry) for entry in source.call(x) if keep.call(entry)],
+}
+"#;
+
+fn write_workspace(module: &str) -> (tempfile::TempDir, PathBuf) {
+    let workspace = tempfile::tempdir().expect("create temporary workspace");
+    let rules = workspace.path().join("rules");
+    std::fs::create_dir_all(&rules).expect("create rules directory");
+    std::fs::write(rules.join("root.cxl"), module).expect("write root CXL module");
+    let pipeline = workspace.path().join("pipeline.yaml");
+    std::fs::write(&pipeline, PIPELINE).expect("write pipeline");
+    (workspace, pipeline)
+}
+
+fn module_registry(workspace: &Path) -> Result<CompiledModuleRegistry, String> {
+    let catalog = WorkspaceCatalog::load(workspace, &CatalogConfig::default())
+        .map_err(|error| error.to_string())?;
+    let rules_root = catalog
+        .select_rules_root(None, None)
+        .map_err(|error| error.to_string())?;
+    compile_module_closure(
+        &catalog,
+        &rules_root,
+        &[LogicalResourceId::parse("root").expect("valid logical module id")],
+        ModuleLimits::default(),
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn compile_workspace(workspace: &Path, pipeline: &Path) -> Result<CompiledPlan, Vec<Diagnostic>> {
+    let config = load_config(pipeline).expect("load pipeline");
+    let pipeline_dir = pipeline
+        .parent()
+        .expect("pipeline parent")
+        .strip_prefix(workspace)
+        .expect("pipeline is inside workspace");
+    let mut context = CompileContext::with_pipeline_dir(workspace, pipeline_dir);
+    let discovery = collect_cxl_fields_with_composition_identities(
+        &config.nodes,
+        context.workspace_root(),
+        &context.pipeline_dir,
+    )
+    .expect("collect CXL-bearing fields");
+    context.composition_body_identities = discovery.identities;
+    let roots = collect_direct_imports(&discovery.fields).expect("collect module roots");
+    let catalog = WorkspaceCatalog::load(workspace, &CatalogConfig::default())
+        .expect("load workspace catalog");
+    let rules_root = catalog
+        .select_rules_root(None, config.pipeline.rules_path.as_deref().map(Path::new))
+        .expect("select rules root");
+    context.cxl_modules =
+        compile_module_closure(&catalog, &rules_root, &roots, ModuleLimits::default())
+            .expect("compile module closure");
+    config.compile(&context)
+}
+
+fn fingerprint(module: &str) -> [u8; 32] {
+    let (workspace, pipeline) = write_workspace(module);
+    compile_workspace(workspace.path(), &pipeline)
+        .expect("nested module pipeline must compile")
+        .semantic_fingerprint()
+        .expect("nested module plan must fingerprint")
+        .digest()
+}
+
+fn declaration(name: &str) -> ResolvedDeclarationId {
+    ResolvedDeclarationId {
+        module: "root".to_owned(),
+        name: name.to_owned(),
+        kind: ResolvedDeclarationKind::Function,
+    }
+}
+
+#[test]
+fn nested_module_expansion_and_dependency_collection_keep_every_child() {
+    let (workspace, _) = write_workspace(NESTED_MODULE);
+    let registry = module_registry(workspace.path()).expect("compile nested module");
+
+    let dependencies = registry
+        .declaration_graph()
+        .dependencies(&declaration("payload"))
+        .expect("payload declaration is retained")
+        .iter()
+        .map(ResolvedDeclarationId::label)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        dependencies,
+        ["root.item", "root.keep", "root.key", "root.source"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+        "function references in the static value, computed key, comprehension source, item, and predicate must all survive collection",
+    );
+
+    let call_span = Span::new(401, 429);
+    let (_, expanded) = registry
+        .runtime_modules()
+        .expand_function("root", "payload", call_span)
+        .expect("expand retained module function");
+    let Expr::MapLiteral { entries, span, .. } = expanded else {
+        panic!("payload must expand to a map literal");
+    };
+    assert_eq!(span, call_span, "expansion must retain the caller span");
+    assert!(matches!(entries[0].key, MapKey::Static(ref key) if key.as_ref() == "static"));
+    assert!(matches!(entries[1].key, MapKey::Computed(_)));
+    let Expr::ArrayComprehension {
+        binding,
+        source,
+        item,
+        predicate: Some(predicate),
+        span,
+        ..
+    } = &entries[1].value
+    else {
+        panic!("computed entry must retain its complete array comprehension");
+    };
+    assert_eq!(binding.as_ref(), "entry");
+    for child in [source.as_ref(), item.as_ref(), predicate.as_ref()] {
+        assert_eq!(
+            child.span(),
+            call_span,
+            "every expanded child keeps the call span"
+        );
+    }
+    assert_eq!(*span, call_span);
+}
+
+#[test]
+fn nested_module_semantic_fingerprint_is_layout_stable_and_child_sensitive() {
+    let baseline = fingerprint(NESTED_MODULE);
+    let reformatted = fingerprint(
+        "fn key ( x ) = x\n\nfn source(x)=[x]\nfn item(x)=x\nfn keep(x)=x==x\nfn payload(x)={ static:item.call(x), [key.call(x)]:[ item.call(entry) for entry in source.call(x) if keep.call(entry) ], }\n",
+    );
+    assert_eq!(baseline, reformatted, "layout and spans are not semantic");
+
+    for (role, changed) in [
+        ("static key", NESTED_MODULE.replace("static:", "renamed:")),
+        (
+            "computed key",
+            NESTED_MODULE.replace("[key.call(x)]", "[\"changed\"]"),
+        ),
+        (
+            "comprehension source",
+            NESTED_MODULE.replace("source.call(x)", "[x, x]"),
+        ),
+        (
+            "comprehension item",
+            NESTED_MODULE.replace("item.call(entry)", "\"changed\""),
+        ),
+        (
+            "comprehension predicate",
+            NESTED_MODULE.replace("keep.call(entry)", "false"),
+        ),
+        (
+            "map value",
+            NESTED_MODULE.replace("static: item.call(x)", "static: \"changed\""),
+        ),
+    ] {
+        assert_ne!(
+            baseline,
+            fingerprint(&changed),
+            "changing the {role} must change semantic identity",
+        );
+    }
+}
+
+#[test]
+fn nested_module_unresolved_references_report_the_original_child_span() {
+    for expression in [
+        "{[missing_key]: value}",
+        "{static: missing_value}",
+        "[entry for entry in missing_source]",
+        "[missing_item for entry in [value]]",
+        "[entry for entry in [value] if missing_predicate]",
+    ] {
+        let module = format!("fn payload(value) = {expression}\n");
+        let expected_start = module
+            .find("missing_")
+            .expect("fixture contains unresolved child");
+        let (workspace, _) = write_workspace(&module);
+        let error = module_registry(workspace.path()).expect_err("unresolved child must fail");
+        assert!(
+            error.contains(&format!("authored span {expected_start}..")),
+            "failure must name the original child span for {expression:?}: {error}",
+        );
+    }
+}
+
+fn compile_inline(yaml: &str) -> Result<CompiledPlan, Vec<Diagnostic>> {
+    parse_config(yaml)
+        .expect("fixture must pass YAML admission")
+        .compile(&CompileContext::default())
+}
+
+#[test]
+fn nested_scope_reads_reach_post_merge_validation() {
+    let yaml = r#"
+pipeline: { name: nested_scope_read }
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: csv
+      path: left.csv
+      schema: [{ name: value, type: string }]
+  - type: source
+    name: right
+    config:
+      name: right
+      type: csv
+      path: right.csv
+      schema: [{ name: value, type: string }]
+  - type: transform
+    name: declare_batch
+    input: left
+    config:
+      cxl: emit $source.batch_tag = value
+      declares: [{ name: batch_tag, scope: source, type: string, default: "" }]
+  - type: merge
+    name: merged
+    inputs: [declare_batch, right]
+  - type: transform
+    name: read_batch
+    input: merged
+    config:
+      cxl: 'emit payload = {static: [entry for entry in [$source.batch_tag] if true]}'
+  - type: output
+    name: out
+    input: read_batch
+    config: { name: out, type: json, path: out.json }
+"#;
+    let diagnostics = compile_inline(yaml).expect_err("post-merge source read must fail");
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "E172")
+        .unwrap_or_else(|| panic!("expected E172 from nested scope read: {diagnostics:?}"));
+    assert!(diagnostic.message.contains("$source.batch_tag"));
+    assert_ne!(diagnostic.primary.span, clinker_core_types::Span::SYNTHETIC);
+}
+
+#[test]
+fn nested_body_fields_reach_envelope_header_validation_but_static_keys_do_not() {
+    let pipeline = |header: &str| {
+        format!(
+            r#"
+pipeline:
+  name: nested_header
+  vars:
+    label: {{ type: string, default: "ok" }}
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: rows.csv
+      schema:
+        - {{ name: amount, type: int }}
+  - type: envelope
+    name: framed
+    body: rows
+    config:
+      strategy: concat
+      header:
+        metadata:
+          payload: '{header}'
+  - type: output
+    name: out
+    input: framed
+    config: {{ name: out, type: json, path: out.json }}
+"#,
+        )
+    };
+
+    compile_inline(&pipeline("{static: [$vars.label]}"))
+        .expect("a static key and document-open value must compile");
+    let diagnostics = compile_inline(&pipeline(
+        "{static: [entry for entry in [amount] if entry > 0]}",
+    ))
+    .expect_err("nested body field must fail header validation");
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "E353")
+        .unwrap_or_else(|| panic!("expected E353 from nested body read: {diagnostics:?}"));
+    assert!(diagnostic.message.contains("amount"));
+    assert_ne!(diagnostic.primary.span, clinker_core_types::Span::SYNTHETIC);
+}
+
+fn combine_pipeline(where_expr: &str, body_expr: &str) -> String {
+    format!(
+        r#"
+pipeline: {{ name: nested_combine }}
+nodes:
+  - type: source
+    name: left_src
+    config:
+      name: left_src
+      type: csv
+      path: left.csv
+      schema: [{{ name: id, type: string }}]
+  - type: source
+    name: right_src
+    config:
+      name: right_src
+      type: csv
+      path: right.csv
+      schema: [{{ name: id, type: string }}]
+  - type: combine
+    name: joined
+    input: {{ left: left_src, right: right_src }}
+    config:
+      where: '{where_expr}'
+      cxl: 'emit payload = {body_expr}'
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config: {{ name: out, type: json, path: out.json }}
+"#,
+    )
+}
+
+#[test]
+fn nested_qualifiers_reach_combine_classification_and_column_resolution() {
+    let plan = compile_inline(&combine_pipeline(
+        "[left.id] == [right.id]",
+        "{[left.id]: [right.id]}",
+    ))
+    .expect("nested qualified references must compile");
+    let combine = plan
+        .dag()
+        .graph
+        .node_weights()
+        .find(|node| node.name() == "joined")
+        .expect("combine node");
+    let PlanNode::Combine {
+        decomposed_predicate: Some(predicate),
+        resolved_column_map,
+        ..
+    } = combine
+    else {
+        panic!("joined node must retain its decomposed predicate");
+    };
+    assert_eq!(predicate.equalities.len(), 1);
+    let resolved = resolved_column_map
+        .keys()
+        .map(ToString::to_string)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        resolved,
+        ["left.id", "right.id"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+        "nested body and predicate qualifiers must reach the retained column map",
+    );
+}
+
+#[test]
+fn nested_unknown_qualified_reference_reports_the_combine_source_span() {
+    let diagnostics = compile_inline(&combine_pipeline(
+        "left.id == right.id",
+        "{static: [right.missing]}",
+    ))
+    .expect_err("unknown nested qualified field must fail");
+    let diagnostic = diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("right.missing"))
+        .unwrap_or_else(|| panic!("expected nested unknown-field diagnostic: {diagnostics:?}"));
+    assert_ne!(diagnostic.primary.span, clinker_core_types::Span::SYNTHETIC);
+}

--- a/crates/clinker-record/src/lib.rs
+++ b/crates/clinker-record/src/lib.rs
@@ -7,6 +7,7 @@ pub mod field_path;
 pub mod field_str;
 pub mod group_key;
 pub mod minimal;
+pub mod nested_key;
 pub mod provenance;
 pub mod record;
 pub mod record_view;

--- a/crates/clinker-record/src/nested_key.rs
+++ b/crates/clinker-record/src/nested_key.rs
@@ -1,0 +1,222 @@
+//! Canonical escaping and depth limits for nested neutral values.
+
+use std::borrow::Cow;
+
+use crate::Value;
+
+/// Maximum number of nested array/map containers accepted by CXL and native
+/// recursive writers.
+pub const MAX_NESTED_VALUE_DEPTH: usize = 64;
+
+/// A decoded neutral map key. `escaped` distinguishes a literal key from an
+/// unescaped spelling that a format may assign a structural role.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NestedKey<'a> {
+    pub text: Cow<'a, str>,
+    pub escaped: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NestedKeyError {
+    NonCanonicalEscape { key: String },
+    DuplicateLogicalKey { key: String },
+    DepthExceeded { depth: usize, limit: usize },
+}
+
+impl std::fmt::Display for NestedKeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonCanonicalEscape { key } => write!(
+                f,
+                "non-canonical nested key escape in {key:?}; only `\\@...`, `\\#text`, and `\\\\...` are valid escaped forms"
+            ),
+            Self::DuplicateLogicalKey { key } => {
+                write!(f, "duplicate logical nested key {key:?}")
+            }
+            Self::DepthExceeded { depth, limit } => {
+                write!(
+                    f,
+                    "nested value depth {depth} exceeds the maximum of {limit}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for NestedKeyError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NestedDepthError {
+    pub depth: usize,
+    pub limit: usize,
+}
+
+impl std::fmt::Display for NestedDepthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "nested value depth {} exceeds the maximum of {}",
+            self.depth, self.limit
+        )
+    }
+}
+
+impl std::error::Error for NestedDepthError {}
+
+impl<'a> NestedKey<'a> {
+    /// Decode one canonical key spelling without interpreting format roles.
+    pub fn decode(key: &'a str) -> Result<Self, NestedKeyError> {
+        let Some(rest) = key.strip_prefix('\\') else {
+            return Ok(Self {
+                text: Cow::Borrowed(key),
+                escaped: false,
+            });
+        };
+        if rest.starts_with('@') || rest == "#text" || rest.starts_with('\\') {
+            Ok(Self {
+                text: Cow::Borrowed(rest),
+                escaped: true,
+            })
+        } else {
+            Err(NestedKeyError::NonCanonicalEscape {
+                key: key.to_string(),
+            })
+        }
+    }
+
+    /// Return the unique canonical spelling for a literal logical key.
+    pub fn encode_literal(key: &'a str) -> Cow<'a, str> {
+        if key.starts_with('@') || key == "#text" || key.starts_with('\\') {
+            Cow::Owned(format!("\\{key}"))
+        } else {
+            Cow::Borrowed(key)
+        }
+    }
+}
+
+/// Validate the shared nested depth cap iteratively. Scalars have depth zero;
+/// each array or map container adds one level.
+pub fn validate_nested_depth(value: &Value) -> Result<(), NestedDepthError> {
+    fn visit(value: &Value, depth: usize) -> Result<(), NestedDepthError> {
+        match value {
+            Value::Array(values) => {
+                let next = depth + 1;
+                if next > MAX_NESTED_VALUE_DEPTH {
+                    return Err(NestedDepthError {
+                        depth: next,
+                        limit: MAX_NESTED_VALUE_DEPTH,
+                    });
+                }
+                for value in values {
+                    visit(value, next)?;
+                }
+            }
+            Value::Map(values) => {
+                let next = depth + 1;
+                if next > MAX_NESTED_VALUE_DEPTH {
+                    return Err(NestedDepthError {
+                        depth: next,
+                        limit: MAX_NESTED_VALUE_DEPTH,
+                    });
+                }
+                for value in values.values() {
+                    visit(value, next)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    visit(value, 0)
+}
+
+/// Validate canonical key spellings throughout a neutral value tree.
+pub fn validate_nested_keys(value: &Value) -> Result<(), NestedKeyError> {
+    fn visit(value: &Value, depth: usize) -> Result<(), NestedKeyError> {
+        match value {
+            Value::Array(values) => {
+                let next = depth + 1;
+                if next > MAX_NESTED_VALUE_DEPTH {
+                    return Err(NestedKeyError::DepthExceeded {
+                        depth: next,
+                        limit: MAX_NESTED_VALUE_DEPTH,
+                    });
+                }
+                for value in values {
+                    visit(value, next)?;
+                }
+            }
+            Value::Map(values) => {
+                let next = depth + 1;
+                if next > MAX_NESTED_VALUE_DEPTH {
+                    return Err(NestedKeyError::DepthExceeded {
+                        depth: next,
+                        limit: MAX_NESTED_VALUE_DEPTH,
+                    });
+                }
+                for (position, (key, value)) in values.iter().enumerate() {
+                    let decoded = NestedKey::decode(key)?;
+                    for prior in values.keys().take(position) {
+                        if NestedKey::decode(prior)?.text == decoded.text {
+                            return Err(NestedKeyError::DuplicateLogicalKey {
+                                key: decoded.text.into_owned(),
+                            });
+                        }
+                    }
+                    visit(value, next)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    visit(value, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_key_escapes_round_trip() {
+        for logical in ["name", "@id", "#text", "\\leading"] {
+            let encoded = NestedKey::encode_literal(logical);
+            let decoded = NestedKey::decode(&encoded).unwrap();
+            assert_eq!(decoded.text, logical);
+            assert_eq!(decoded.escaped, encoded != logical);
+        }
+    }
+
+    #[test]
+    fn noncanonical_escape_is_rejected() {
+        assert!(NestedKey::decode("\\ordinary").is_err());
+        assert!(NestedKey::decode("\\#other").is_err());
+    }
+
+    #[test]
+    fn duplicate_logical_keys_are_rejected_after_escape_decoding() {
+        let mut values = indexmap::IndexMap::new();
+        values.insert("@id".into(), Value::Integer(1));
+        values.insert("\\@id".into(), Value::Integer(2));
+        let value = Value::Map(Box::new(values));
+        assert_eq!(
+            validate_nested_keys(&value),
+            Err(NestedKeyError::DuplicateLogicalKey { key: "@id".into() })
+        );
+    }
+
+    #[test]
+    fn depth_cap_accepts_cap_and_rejects_cap_plus_one() {
+        fn nested(depth: usize) -> Value {
+            let mut value = Value::Null;
+            for _ in 0..depth {
+                value = Value::Array(vec![value]);
+            }
+            value
+        }
+        assert!(validate_nested_depth(&nested(MAX_NESTED_VALUE_DEPTH)).is_ok());
+        assert!(validate_nested_depth(&nested(MAX_NESTED_VALUE_DEPTH + 1)).is_err());
+    }
+}

--- a/crates/clinker/src/refactor.rs
+++ b/crates/clinker/src/refactor.rs
@@ -724,6 +724,31 @@ fn collect_qualifier_ranges_expr(
         Expr::Unary { operand, .. } => {
             collect_qualifier_ranges_expr(operand, old, offset, src_len, out)
         }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_qualifier_ranges_expr(element, old, offset, src_len, out);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let cxl::ast::MapKey::Computed(key) = &entry.key {
+                    collect_qualifier_ranges_expr(key, old, offset, src_len, out);
+                }
+                collect_qualifier_ranges_expr(&entry.value, old, offset, src_len, out);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_qualifier_ranges_expr(source, old, offset, src_len, out);
+            collect_qualifier_ranges_expr(item, old, offset, src_len, out);
+            if let Some(predicate) = predicate {
+                collect_qualifier_ranges_expr(predicate, old, offset, src_len, out);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             collect_qualifier_ranges_expr(receiver, old, offset, src_len, out);
             for a in args {

--- a/crates/cxl-cli/src/main.rs
+++ b/crates/cxl-cli/src/main.rs
@@ -640,11 +640,54 @@ fn format_expr(expr: &cxl::ast::Expr) -> String {
         cxl::ast::Expr::Literal { value, .. } => match value {
             cxl::ast::LiteralValue::Int(n) => n.to_string(),
             cxl::ast::LiteralValue::Float(f) => f.to_string(),
-            cxl::ast::LiteralValue::String(s) => format!("\"{}\"", s),
+            cxl::ast::LiteralValue::String(s) => format!("{s:?}"),
             cxl::ast::LiteralValue::Date(d) => format!("#{}", d.format("%Y-%m-%d")),
             cxl::ast::LiteralValue::Bool(b) => b.to_string(),
             cxl::ast::LiteralValue::Null => "null".into(),
         },
+        cxl::ast::Expr::ArrayLiteral { elements, .. } => format!(
+            "[{}]",
+            elements
+                .iter()
+                .map(format_expr)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        cxl::ast::Expr::MapLiteral { entries, .. } => format!(
+            "{{{}}}",
+            entries
+                .iter()
+                .map(|entry| {
+                    let key = match &entry.key {
+                        cxl::ast::MapKey::Static(key) => format!("{key:?}"),
+                        cxl::ast::MapKey::Computed(key) => {
+                            format!("[{}]", format_expr(key))
+                        }
+                    };
+                    format!("{key}: {}", format_expr(&entry.value))
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        cxl::ast::Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            let mut formatted = format!(
+                "[{} for {} in {}",
+                format_expr(item),
+                binding,
+                format_expr(source)
+            );
+            if let Some(predicate) = predicate {
+                formatted.push_str(&format!(" if {}", format_expr(predicate)));
+            }
+            formatted.push(']');
+            formatted
+        }
         cxl::ast::Expr::FieldRef { name, .. } => name.to_string(),
         cxl::ast::Expr::QualifiedFieldRef { parts, .. } => {
             parts.iter().map(|p| &**p).collect::<Vec<_>>().join(".")
@@ -940,5 +983,21 @@ mod tests {
         // format_statement should normalize whitespace
         let formatted = format_statement(&parsed.ast.statements[0]);
         assert!(formatted.contains("emit x = 1 + 2"));
+    }
+
+    #[test]
+    fn test_cxl_fmt_nested_constructors_are_canonical_and_reparse() {
+        let source = r##"emit payload = {
+  "@kind": "event",
+  items: [item * 2 for item in values if item > 0],
+}"##;
+        let parsed = cxl::parser::Parser::parse(source);
+        assert!(parsed.errors.is_empty());
+        let formatted = format_statement(&parsed.ast.statements[0]);
+        assert_eq!(
+            formatted,
+            r#"emit payload = {"@kind": "event", "items": [item * 2 for item in values if item > 0]}"#
+        );
+        assert!(cxl::parser::Parser::parse(&formatted).errors.is_empty());
     }
 }

--- a/crates/cxl/src/analyzer/mod.rs
+++ b/crates/cxl/src/analyzer/mod.rs
@@ -306,6 +306,20 @@ mod tests {
     }
 
     #[test]
+    fn nested_constructors_keep_all_value_dependencies_visible() {
+        let typed = compile(
+            "emit payload = {dept: dept, values: [item + amount for item in [score] if region == \"west\"]}",
+        );
+        let analysis = analyze_transform("test", &typed);
+        for field in ["dept", "amount", "score", "region"] {
+            assert!(
+                analysis.accessed_fields.contains(field),
+                "nested value dependency {field:?} must remain visible"
+            );
+        }
+    }
+
+    #[test]
     fn test_analyzer_aggregate_window() {
         let typed = compile("emit total = $window.sum(amount)");
         let analysis = analyze_transform("test", &typed);

--- a/crates/cxl/src/analyzer/visitor.rs
+++ b/crates/cxl/src/analyzer/visitor.rs
@@ -86,6 +86,31 @@ pub fn walk_expr<V: Visitor + ?Sized>(visitor: &mut V, expr: &Expr) {
             visitor.visit_expr(rhs);
         }
         Expr::Unary { operand, .. } => visitor.visit_expr(operand),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                visitor.visit_expr(element);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let crate::ast::MapKey::Computed(key) = &entry.key {
+                    visitor.visit_expr(key);
+                }
+                visitor.visit_expr(&entry.value);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            visitor.visit_expr(item);
+            visitor.visit_expr(source);
+            if let Some(predicate) = predicate {
+                visitor.visit_expr(predicate);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             visitor.visit_expr(receiver);
             for arg in args {

--- a/crates/cxl/src/ast.rs
+++ b/crates/cxl/src/ast.rs
@@ -190,6 +190,27 @@ pub enum Expr {
         value: LiteralValue,
         span: Span,
     },
+    /// Ordered array construction: `[expr, ...]`.
+    ArrayLiteral {
+        node_id: NodeId,
+        elements: Vec<Expr>,
+        span: Span,
+    },
+    /// Insertion-ordered map construction: `{ key: expr, [expr]: expr }`.
+    MapLiteral {
+        node_id: NodeId,
+        entries: Vec<MapEntry>,
+        span: Span,
+    },
+    /// Single-clause array comprehension: `[item for binding in source if predicate]`.
+    ArrayComprehension {
+        node_id: NodeId,
+        item: Box<Expr>,
+        binding: Box<str>,
+        source: Box<Expr>,
+        predicate: Option<Box<Expr>>,
+        span: Span,
+    },
     FieldRef {
         node_id: NodeId,
         name: Box<str>,
@@ -378,6 +399,21 @@ pub enum Expr {
     },
 }
 
+/// One entry in a map literal, retained in author order.
+#[derive(Debug, Clone)]
+pub struct MapEntry {
+    pub key: MapKey,
+    pub value: Expr,
+    pub span: Span,
+}
+
+/// A map key is either author text or a computed string expression.
+#[derive(Debug, Clone)]
+pub enum MapKey {
+    Static(Box<str>),
+    Computed(Box<Expr>),
+}
+
 impl Expr {
     /// Get the span of this expression.
     pub fn span(&self) -> Span {
@@ -385,6 +421,9 @@ impl Expr {
             Expr::Binary { span, .. }
             | Expr::Unary { span, .. }
             | Expr::Literal { span, .. }
+            | Expr::ArrayLiteral { span, .. }
+            | Expr::MapLiteral { span, .. }
+            | Expr::ArrayComprehension { span, .. }
             | Expr::FieldRef { span, .. }
             | Expr::QualifiedFieldRef { span, .. }
             | Expr::MethodCall { span, .. }
@@ -415,6 +454,9 @@ impl Expr {
             Expr::Binary { node_id, .. }
             | Expr::Unary { node_id, .. }
             | Expr::Literal { node_id, .. }
+            | Expr::ArrayLiteral { node_id, .. }
+            | Expr::MapLiteral { node_id, .. }
+            | Expr::ArrayComprehension { node_id, .. }
             | Expr::FieldRef { node_id, .. }
             | Expr::QualifiedFieldRef { node_id, .. }
             | Expr::MethodCall { node_id, .. }
@@ -475,6 +517,31 @@ impl Expr {
                 rhs.support_into(fields);
             }
             Expr::Unary { operand, .. } => operand.support_into(fields),
+            Expr::ArrayLiteral { elements, .. } => {
+                for element in elements {
+                    element.support_into(fields);
+                }
+            }
+            Expr::MapLiteral { entries, .. } => {
+                for entry in entries {
+                    if let MapKey::Computed(key) = &entry.key {
+                        key.support_into(fields);
+                    }
+                    entry.value.support_into(fields);
+                }
+            }
+            Expr::ArrayComprehension {
+                item,
+                source,
+                predicate,
+                ..
+            } => {
+                source.support_into(fields);
+                item.support_into(fields);
+                if let Some(predicate) = predicate {
+                    predicate.support_into(fields);
+                }
+            }
             Expr::IfThenElse {
                 condition,
                 then_branch,
@@ -647,6 +714,31 @@ fn fold_config_expr(expr: &mut Expr, resolve: &impl Fn(&str) -> Option<LiteralVa
             fold_config_expr(rhs, resolve);
         }
         Expr::Unary { operand, .. } => fold_config_expr(operand, resolve),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                fold_config_expr(element, resolve);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    fold_config_expr(key, resolve);
+                }
+                fold_config_expr(&mut entry.value, resolve);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            fold_config_expr(item, resolve);
+            fold_config_expr(source, resolve);
+            if let Some(predicate) = predicate {
+                fold_config_expr(predicate, resolve);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             fold_config_expr(receiver, resolve);
             for a in args.iter_mut() {
@@ -742,6 +834,39 @@ pub fn offset_node_ids(expr: &mut Expr, base: u32) {
         } => {
             shift(node_id, base);
             offset_node_ids(operand, base);
+        }
+        Expr::ArrayLiteral {
+            node_id, elements, ..
+        } => {
+            shift(node_id, base);
+            for element in elements {
+                offset_node_ids(element, base);
+            }
+        }
+        Expr::MapLiteral {
+            node_id, entries, ..
+        } => {
+            shift(node_id, base);
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    offset_node_ids(key, base);
+                }
+                offset_node_ids(&mut entry.value, base);
+            }
+        }
+        Expr::ArrayComprehension {
+            node_id,
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            shift(node_id, base);
+            offset_node_ids(item, base);
+            offset_node_ids(source, base);
+            if let Some(predicate) = predicate {
+                offset_node_ids(predicate, base);
+            }
         }
         Expr::MethodCall {
             node_id,
@@ -857,6 +982,36 @@ pub fn rebase_expr_spans(expr: &mut Expr, delta: u32) {
         Expr::Unary { span, operand, .. } => {
             shift(span, delta);
             rebase_expr_spans(operand, delta);
+        }
+        Expr::ArrayLiteral { span, elements, .. } => {
+            shift(span, delta);
+            for element in elements {
+                rebase_expr_spans(element, delta);
+            }
+        }
+        Expr::MapLiteral { span, entries, .. } => {
+            shift(span, delta);
+            for entry in entries {
+                shift(&mut entry.span, delta);
+                if let MapKey::Computed(key) = &mut entry.key {
+                    rebase_expr_spans(key, delta);
+                }
+                rebase_expr_spans(&mut entry.value, delta);
+            }
+        }
+        Expr::ArrayComprehension {
+            span,
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            shift(span, delta);
+            rebase_expr_spans(item, delta);
+            rebase_expr_spans(source, delta);
+            if let Some(predicate) = predicate {
+                rebase_expr_spans(predicate, delta);
+            }
         }
         Expr::MethodCall {
             span,

--- a/crates/cxl/src/eval/compiled.rs
+++ b/crates/cxl/src/eval/compiled.rs
@@ -57,7 +57,7 @@ use clinker_record::{GroupByKey, RecordStorage, Value, value_to_group_key};
 use regex::Regex;
 use rust_decimal::Decimal;
 
-use crate::ast::{BinOp, EmitTarget, Expr, LiteralValue, Statement, TraceLevel, UnaryOp};
+use crate::ast::{BinOp, EmitTarget, Expr, LiteralValue, MapKey, Statement, TraceLevel, UnaryOp};
 use crate::lexer::Span;
 use crate::resolve::ResolvedBinding;
 use crate::resolve::traits::{FieldResolver, WindowContext};
@@ -84,6 +84,57 @@ struct Frame<'a, 'w, S: RecordStorage + 'w> {
     resolver: &'a dyn FieldResolver,
     window: Option<&'a dyn WindowContext<'w, S>>,
     env: HashMap<String, Value>,
+    construction: ConstructionBudget,
+}
+
+/// Per-record budget for author-constructed arrays and maps. The budget is
+/// charged before container growth and is shared by every nested constructor
+/// evaluated for the record.
+struct ConstructionBudget {
+    retained_bytes: usize,
+    depth: usize,
+}
+
+const MAX_CONSTRUCTED_BYTES: usize = 10 * 1024 * 1024;
+
+impl ConstructionBudget {
+    fn enter(&mut self, span: Span) -> Result<(), EvalError> {
+        if self.depth >= clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+            return Err(EvalError::new(
+                EvalErrorKind::ConstructionDepthExceeded {
+                    limit: clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH,
+                },
+                span,
+            ));
+        }
+        self.depth += 1;
+        Ok(())
+    }
+
+    fn leave(&mut self) {
+        self.depth = self.depth.saturating_sub(1);
+    }
+
+    fn charge(&mut self, bytes: usize, span: Span) -> Result<(), EvalError> {
+        let next = self.retained_bytes.checked_add(bytes).ok_or_else(|| {
+            EvalError::new(
+                EvalErrorKind::ConstructionLimitExceeded {
+                    limit: MAX_CONSTRUCTED_BYTES,
+                },
+                span,
+            )
+        })?;
+        if next > MAX_CONSTRUCTED_BYTES {
+            return Err(EvalError::new(
+                EvalErrorKind::ConstructionLimitExceeded {
+                    limit: MAX_CONSTRUCTED_BYTES,
+                },
+                span,
+            ));
+        }
+        self.retained_bytes = next;
+        Ok(())
+    }
 }
 
 /// Mutable cross-record evaluation state threaded into `eval_record`.
@@ -238,6 +289,10 @@ impl CompiledScalar {
             resolver,
             window: None,
             env: HashMap::new(),
+            construction: ConstructionBudget {
+                retained_bytes: 0,
+                depth: 0,
+            },
         };
         (self.expr)(&mut frame)
     }
@@ -346,6 +401,10 @@ impl<S: RecordStorage + 'static> CompiledProgram<S> {
             resolver,
             window,
             env: HashMap::new(),
+            construction: ConstructionBudget {
+                retained_bytes: 0,
+                depth: 0,
+            },
         };
         // The cumulative fan-out budget is per input record; reset it
         // before any `emit each` block runs so one record's expansion
@@ -866,6 +925,173 @@ fn compile_expr<S: RecordStorage + 'static>(typed: &TypedProgram, expr: &Expr) -
             // is one `Value` clone with no variant re-match.
             let baked = literal_to_value(value);
             Box::new(move |_frame| Ok(baked.clone()))
+        }
+        Expr::ArrayLiteral { elements, span, .. } => {
+            let elements = elements
+                .iter()
+                .map(|element| compile_expr::<S>(typed, element))
+                .collect::<Vec<_>>();
+            let span = *span;
+            Box::new(move |frame| {
+                frame.construction.enter(span)?;
+                let result = (|| {
+                    frame
+                        .construction
+                        .charge(elements.len() * std::mem::size_of::<Value>(), span)?;
+                    let mut values = Vec::with_capacity(elements.len());
+                    for element in &elements {
+                        let value = element(frame)?;
+                        frame.construction.charge(value.heap_size(), span)?;
+                        values.push(value);
+                    }
+                    Ok(Value::Array(values))
+                })();
+                frame.construction.leave();
+                result
+            })
+        }
+        Expr::MapLiteral { entries, span, .. } => {
+            enum CompiledKey<S: RecordStorage + 'static> {
+                Static(Box<str>),
+                Computed(CompiledExpr<S>),
+            }
+            let entries = entries
+                .iter()
+                .map(|entry| {
+                    let key = match &entry.key {
+                        MapKey::Static(key) => CompiledKey::Static(key.clone()),
+                        MapKey::Computed(key) => {
+                            CompiledKey::Computed(compile_expr::<S>(typed, key))
+                        }
+                    };
+                    (key, compile_expr::<S>(typed, &entry.value), entry.span)
+                })
+                .collect::<Vec<_>>();
+            let span = *span;
+            Box::new(move |frame| {
+                frame.construction.enter(span)?;
+                let result = (|| {
+                    let entry_bytes = std::mem::size_of::<Box<str>>()
+                        + std::mem::size_of::<Value>()
+                        + std::mem::size_of::<u64>()
+                        + std::mem::size_of::<usize>();
+                    frame
+                        .construction
+                        .charge(entries.len() * entry_bytes, span)?;
+                    let mut values: indexmap::IndexMap<Box<str>, Value> =
+                        indexmap::IndexMap::with_capacity(entries.len());
+                    for (key, value, entry_span) in &entries {
+                        let key_text: Box<str> = match key {
+                            CompiledKey::Static(key) => key.clone(),
+                            CompiledKey::Computed(key) => match key(frame)? {
+                                Value::String(key) => key.as_str().into(),
+                                other => {
+                                    return Err(EvalError::type_mismatch(
+                                        "non-null String map key",
+                                        other.type_name(),
+                                        *entry_span,
+                                    ));
+                                }
+                            },
+                        };
+                        frame.construction.charge(key_text.len(), *entry_span)?;
+                        let decoded = clinker_record::nested_key::NestedKey::decode(&key_text)
+                            .map_err(|error| {
+                                EvalError::new(
+                                    EvalErrorKind::InvalidNestedKey {
+                                        key: key_text.to_string(),
+                                        message: error.to_string(),
+                                    },
+                                    *entry_span,
+                                )
+                            })?;
+                        let logical_key = decoded.text.as_ref();
+                        if values.keys().any(|prior| {
+                            clinker_record::nested_key::NestedKey::decode(prior)
+                                .expect("previous keys were validated before insertion")
+                                .text
+                                == logical_key
+                        }) {
+                            return Err(EvalError::new(
+                                EvalErrorKind::DuplicateMapKey {
+                                    key: logical_key.to_string(),
+                                },
+                                *entry_span,
+                            ));
+                        }
+                        let value = value(frame)?;
+                        frame.construction.charge(value.heap_size(), *entry_span)?;
+                        values.insert(key_text, value);
+                    }
+                    Ok(Value::Map(Box::new(values)))
+                })();
+                frame.construction.leave();
+                result
+            })
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            span,
+            ..
+        } => {
+            let item = compile_expr::<S>(typed, item);
+            let source = compile_expr::<S>(typed, source);
+            let predicate = predicate
+                .as_ref()
+                .map(|predicate| compile_expr::<S>(typed, predicate));
+            let binding = binding.to_string();
+            let span = *span;
+            Box::new(move |frame| {
+                frame.construction.enter(span)?;
+                let result = (|| {
+                    let source_value = source(frame)?;
+                    let Value::Array(source_values) = source_value else {
+                        return Err(EvalError::type_mismatch(
+                            "Array comprehension source",
+                            source_value.type_name(),
+                            span,
+                        ));
+                    };
+                    frame
+                        .construction
+                        .charge(source_values.len() * std::mem::size_of::<Value>(), span)?;
+                    let previous = frame.env.remove(&binding);
+                    let values_result = (|| {
+                        let mut values = Vec::with_capacity(source_values.len());
+                        for source_value in source_values {
+                            frame.env.insert(binding.clone(), source_value);
+                            if let Some(predicate) = &predicate {
+                                match predicate(frame)? {
+                                    Value::Bool(true) => {}
+                                    Value::Bool(false) => continue,
+                                    other => {
+                                        return Err(EvalError::type_mismatch(
+                                            "Bool comprehension predicate",
+                                            other.type_name(),
+                                            span,
+                                        ));
+                                    }
+                                }
+                            }
+                            let value = item(frame)?;
+                            frame.construction.charge(value.heap_size(), span)?;
+                            values.push(value);
+                        }
+                        Ok(Value::Array(values))
+                    })();
+                    if let Some(previous) = previous {
+                        frame.env.insert(binding.clone(), previous);
+                    } else {
+                        frame.env.remove(&binding);
+                    }
+                    values_result
+                })();
+                frame.construction.leave();
+                result
+            })
         }
         Expr::FieldRef { name, .. } => {
             let name = name.to_string();
@@ -1501,9 +1727,17 @@ fn window_predicate_fold<'a, 'w, S: RecordStorage + 'w>(
             resolver: &row,
             window,
             env,
+            construction: std::mem::replace(
+                &mut frame.construction,
+                ConstructionBudget {
+                    retained_bytes: 0,
+                    depth: 0,
+                },
+            ),
         };
         let raw = predicate(&mut sub);
         env = std::mem::take(&mut sub.env);
+        frame.construction = sub.construction;
         let raw = match raw {
             Ok(v) => v,
             Err(e) => {

--- a/crates/cxl/src/eval/compiled/tests.rs
+++ b/crates/cxl/src/eval/compiled/tests.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use clinker_record::{RecordStorage, Value};
 use proptest::prelude::*;
 
-use super::program_has_distinct;
+use super::{ConstructionBudget, MAX_CONSTRUCTED_BYTES, program_has_distinct};
 use crate::eval::context::{EvalContext, StableEvalContext};
 use crate::eval::error::EvalError;
 use crate::eval::{EvalResult, ProgramEvaluator, SkipReason};
@@ -58,6 +58,41 @@ impl RecordStorage for NullStorage {
 
 fn empty_row() -> Row {
     Row::closed(indexmap::IndexMap::new(), crate::lexer::Span::new(0, 0))
+}
+
+#[test]
+fn construction_budget_checks_limits_before_committing_growth() {
+    let span = crate::lexer::Span::new(0, 1);
+    let mut budget = ConstructionBudget {
+        retained_bytes: 0,
+        depth: 0,
+    };
+    budget.charge(MAX_CONSTRUCTED_BYTES, span).unwrap();
+    let error = budget.charge(1, span).unwrap_err();
+    assert!(matches!(
+        error.kind,
+        crate::eval::error::EvalErrorKind::ConstructionLimitExceeded { limit }
+            if limit == MAX_CONSTRUCTED_BYTES
+    ));
+    assert_eq!(budget.retained_bytes, MAX_CONSTRUCTED_BYTES);
+
+    let mut depth = ConstructionBudget {
+        retained_bytes: 0,
+        depth: 0,
+    };
+    for _ in 0..clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH {
+        depth.enter(span).unwrap();
+    }
+    let error = depth.enter(span).unwrap_err();
+    assert!(matches!(
+        error.kind,
+        crate::eval::error::EvalErrorKind::ConstructionDepthExceeded { limit }
+            if limit == clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH
+    ));
+    assert_eq!(
+        depth.depth,
+        clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH
+    );
 }
 
 /// Parse → resolve → typecheck a CXL program against the given input

--- a/crates/cxl/src/eval/error.rs
+++ b/crates/cxl/src/eval/error.rs
@@ -70,6 +70,19 @@ pub enum EvalErrorKind {
         size: usize,
         limit: usize,
     },
+    DuplicateMapKey {
+        key: String,
+    },
+    InvalidNestedKey {
+        key: String,
+        message: String,
+    },
+    ConstructionLimitExceeded {
+        limit: usize,
+    },
+    ConstructionDepthExceeded {
+        limit: usize,
+    },
     /// `emit each` produced more records from a single input than the
     /// transform's `max_expansion` ceiling allows. The originating
     /// record is routed to DLQ; the fan-out is aborted at the
@@ -114,6 +127,20 @@ impl std::fmt::Display for EvalErrorKind {
                 f,
                 "string output exceeds maximum size ({} bytes, limit {})",
                 size, limit
+            ),
+            Self::DuplicateMapKey { key } => {
+                write!(f, "duplicate map key '{key}'")
+            }
+            Self::InvalidNestedKey { key, message } => {
+                write!(f, "invalid nested map key {key:?}: {message}")
+            }
+            Self::ConstructionLimitExceeded { limit } => write!(
+                f,
+                "nested value construction exceeds the per-record memory limit ({limit} bytes)"
+            ),
+            Self::ConstructionDepthExceeded { limit } => write!(
+                f,
+                "nested value construction exceeds the maximum depth ({limit})"
             ),
             Self::ExpansionLimitExceeded { limit } => write!(
                 f,
@@ -222,6 +249,10 @@ pub fn extract_triggering_value(kind: &EvalErrorKind) -> Option<Value> {
         | EvalErrorKind::InvariantViolation { .. }
         | EvalErrorKind::IntegerOverflow { .. }
         | EvalErrorKind::StringTooLarge { .. }
+        | EvalErrorKind::DuplicateMapKey { .. }
+        | EvalErrorKind::InvalidNestedKey { .. }
+        | EvalErrorKind::ConstructionLimitExceeded { .. }
+        | EvalErrorKind::ConstructionDepthExceeded { .. }
         | EvalErrorKind::ExpansionLimitExceeded { .. } => None,
     }
 }
@@ -238,6 +269,14 @@ impl miette::Diagnostic for EvalError {
             EvalErrorKind::InvariantViolation { .. } => "cxl::eval::internal_invariant",
             EvalErrorKind::IntegerOverflow { .. } => "cxl::eval::integer_overflow",
             EvalErrorKind::StringTooLarge { .. } => "cxl::eval::string_too_large",
+            EvalErrorKind::DuplicateMapKey { .. } => "cxl::eval::duplicate_map_key",
+            EvalErrorKind::InvalidNestedKey { .. } => "cxl::eval::invalid_nested_key",
+            EvalErrorKind::ConstructionLimitExceeded { .. } => {
+                "cxl::eval::construction_limit_exceeded"
+            }
+            EvalErrorKind::ConstructionDepthExceeded { .. } => {
+                "cxl::eval::construction_depth_exceeded"
+            }
             EvalErrorKind::ExpansionLimitExceeded { .. } => "cxl::eval::expansion_limit_exceeded",
         };
         Some(Box::new(s))

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -96,6 +96,143 @@ fn eval_single(src: &str, fields: &[&str], record: HashMap<String, Value>) -> Va
     output.into_values().next().unwrap_or(Value::Null)
 }
 
+fn eval_error(src: &str, fields: &[&str], record: HashMap<String, Value>) -> EvalError {
+    let parsed = Parser::parse(src);
+    assert!(
+        parsed.errors.is_empty(),
+        "Parse errors: {:?}",
+        parsed.errors
+    );
+    let resolved = resolve_program(parsed.ast, fields, parsed.node_count).unwrap();
+    let typed = type_check(resolved, &empty_row()).unwrap();
+    let stable = StableEvalContext::test_default();
+    let ctx = EvalContext::test_default_borrowed(&stable);
+    let resolver = HashMapResolver::new(record);
+    run_fields::<NullStorage>(typed, &ctx, &resolver, None).expect_err("expected eval error")
+}
+
+#[test]
+fn nested_literals_evaluate_in_author_order() {
+    let value = eval_single(
+        "emit payload = {first: [1, 2], [key]: {active: true}, last: null}",
+        &["key"],
+        HashMap::from([("key".into(), Value::String("computed".into()))]),
+    );
+    let Value::Map(map) = value else {
+        panic!("expected map");
+    };
+    assert_eq!(
+        map.keys().map(|key| key.as_ref()).collect::<Vec<_>>(),
+        vec!["first", "computed", "last"]
+    );
+    assert_eq!(
+        map["first"],
+        Value::Array(vec![Value::Integer(1), Value::Integer(2)])
+    );
+    assert!(matches!(map["computed"], Value::Map(_)));
+    assert_eq!(map["last"], Value::Null);
+}
+
+#[test]
+fn array_comprehension_filters_and_preserves_order() {
+    let value = eval_single(
+        "emit doubled = [item * 2 for item in values if item > 0]",
+        &["values"],
+        HashMap::from([(
+            "values".into(),
+            Value::Array(vec![
+                Value::Integer(3),
+                Value::Integer(-1),
+                Value::Integer(2),
+            ]),
+        )]),
+    );
+    assert_eq!(
+        value,
+        Value::Array(vec![Value::Integer(6), Value::Integer(4)])
+    );
+}
+
+#[test]
+fn duplicate_map_key_fails_at_first_duplicate() {
+    let error = eval_error(
+        "emit payload = {name: 1, [key]: 2}",
+        &["key"],
+        HashMap::from([("key".into(), Value::String("name".into()))]),
+    );
+    assert!(matches!(
+        error.kind,
+        EvalErrorKind::DuplicateMapKey { ref key } if key == "name"
+    ));
+}
+
+#[test]
+fn null_computed_key_and_null_comprehension_source_fail() {
+    let key_error = eval_error(
+        "emit payload = {[key]: 1}",
+        &["key"],
+        HashMap::from([("key".into(), Value::Null)]),
+    );
+    assert!(matches!(
+        key_error.kind,
+        EvalErrorKind::TypeMismatch {
+            expected: "non-null String map key",
+            got: "null"
+        }
+    ));
+
+    let source_error = eval_error(
+        "emit values = [item for item in source]",
+        &["source"],
+        HashMap::from([("source".into(), Value::Null)]),
+    );
+    assert!(matches!(
+        source_error.kind,
+        EvalErrorKind::TypeMismatch {
+            expected: "Array comprehension source",
+            got: "null"
+        }
+    ));
+}
+
+#[test]
+fn computed_map_keys_use_the_same_canonical_escape_grammar() {
+    let error = eval_error(
+        "emit payload = {[key]: 1}",
+        &["key"],
+        HashMap::from([("key".into(), Value::String("\\ordinary".into()))]),
+    );
+    assert!(matches!(
+        error.kind,
+        EvalErrorKind::InvalidNestedKey { ref key, .. } if key == "\\ordinary"
+    ));
+}
+
+#[test]
+fn constructed_nested_values_accept_the_depth_cap_and_reject_cap_plus_one() {
+    let source_at_depth = |depth: usize| {
+        format!(
+            "emit payload = {}null{}",
+            "[".repeat(depth),
+            "]".repeat(depth)
+        )
+    };
+
+    let at_cap = source_at_depth(clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH);
+    assert!(matches!(
+        eval_single(&at_cap, &[], HashMap::new()),
+        Value::Array(_)
+    ));
+
+    let over_cap = source_at_depth(clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH + 1);
+    let error = eval_error(&over_cap, &[], HashMap::new());
+    assert!(matches!(
+        error.kind,
+        EvalErrorKind::ConstructionDepthExceeded { limit }
+            if limit == clinker_record::nested_key::MAX_NESTED_VALUE_DEPTH
+    ));
+}
+
 fn dec(mantissa: i64, scale: u32) -> Value {
     Value::Decimal(rust_decimal::Decimal::new(mantissa, scale))
 }

--- a/crates/cxl/src/lexer.rs
+++ b/crates/cxl/src/lexer.rs
@@ -20,7 +20,7 @@ impl Span {
 /// CXL token produced by the lexer.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
-    // --- Keywords (21) ---
+    // --- Keywords (23) ---
     Let,
     Emit,
     If,
@@ -42,6 +42,8 @@ pub enum Token {
     Filter,
     Distinct,
     By,
+    For,
+    In,
 
     // --- Operators (14) ---
     Plus,
@@ -433,6 +435,8 @@ impl<'src> Lexer<'src> {
             "filter" => Token::Filter,
             "distinct" => Token::Distinct,
             "by" => Token::By,
+            "for" => Token::For,
+            "in" => Token::In,
             _ => Token::Ident(text.into()),
         };
 
@@ -467,7 +471,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_lex_keywords_all_21() {
+    fn test_lex_keywords_all_23() {
         let keywords = [
             ("let", Token::Let),
             ("emit", Token::Emit),
@@ -490,8 +494,10 @@ mod tests {
             ("filter", Token::Filter),
             ("distinct", Token::Distinct),
             ("by", Token::By),
+            ("for", Token::For),
+            ("in", Token::In),
         ];
-        assert_eq!(keywords.len(), 21);
+        assert_eq!(keywords.len(), 23);
         for (src, expected) in keywords {
             let tokens = Lexer::tokenize(src);
             assert_eq!(tokens[0].0, expected, "keyword '{}' failed", src);

--- a/crates/cxl/src/module_eval.rs
+++ b/crates/cxl/src/module_eval.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
-use crate::ast::{Expr, FnDecl, MatchArm, Module, ModuleConst, NodeId};
+use crate::ast::{Expr, FnDecl, MapEntry, MapKey, MatchArm, Module, ModuleConst, NodeId};
 use crate::lexer::Span;
 
 const RUNTIME_MODULE_NODE: NodeId = NodeId(u32::MAX);
@@ -366,6 +366,37 @@ fn collect_declaration_dependencies(
             visit(rhs, lexical, dependencies)
         }
         Expr::Unary { operand, .. } => visit(operand, lexical, dependencies),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                visit(element, lexical, dependencies)?;
+            }
+            Ok(())
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &entry.key {
+                    visit(key, lexical, dependencies)?;
+                }
+                visit(&entry.value, lexical, dependencies)?;
+            }
+            Ok(())
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            visit(source, lexical, dependencies)?;
+            let mut nested = lexical.clone();
+            nested.insert(binding.to_string());
+            visit(item, &nested, dependencies)?;
+            if let Some(predicate) = predicate {
+                visit(predicate, &nested, dependencies)?;
+            }
+            Ok(())
+        }
         Expr::IfThenElse {
             condition,
             then_branch,
@@ -773,6 +804,76 @@ impl RuntimeModuleRegistry {
                 operand: Box::new(expand(operand, stack)?),
                 span: call_span,
             },
+            Expr::ArrayLiteral { elements, .. } => Expr::ArrayLiteral {
+                node_id: RUNTIME_MODULE_NODE,
+                elements: elements
+                    .iter()
+                    .map(|element| expand(element, stack))
+                    .collect::<Result<Vec<_>, _>>()?,
+                span: call_span,
+            },
+            Expr::MapLiteral { entries, .. } => Expr::MapLiteral {
+                node_id: RUNTIME_MODULE_NODE,
+                entries: entries
+                    .iter()
+                    .map(|entry| {
+                        Ok(MapEntry {
+                            key: match &entry.key {
+                                MapKey::Static(key) => MapKey::Static(key.clone()),
+                                MapKey::Computed(key) => {
+                                    MapKey::Computed(Box::new(expand(key, stack)?))
+                                }
+                            },
+                            value: expand(&entry.value, stack)?,
+                            span: call_span,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, String>>()?,
+                span: call_span,
+            },
+            Expr::ArrayComprehension {
+                item,
+                binding,
+                source,
+                predicate,
+                ..
+            } => {
+                let source = Box::new(expand(source, stack)?);
+                let mut nested_substitutions = substitutions.clone();
+                nested_substitutions.remove(binding.as_ref());
+                let mut nested_protected = protected.clone();
+                nested_protected.insert(binding.to_string());
+                let item = Box::new(self.expand_expr(
+                    module_id,
+                    item,
+                    &nested_substitutions,
+                    &nested_protected,
+                    stack,
+                    call_span,
+                )?);
+                let predicate = predicate
+                    .as_ref()
+                    .map(|predicate| {
+                        self.expand_expr(
+                            module_id,
+                            predicate,
+                            &nested_substitutions,
+                            &nested_protected,
+                            stack,
+                            call_span,
+                        )
+                        .map(Box::new)
+                    })
+                    .transpose()?;
+                Expr::ArrayComprehension {
+                    node_id: RUNTIME_MODULE_NODE,
+                    item,
+                    binding: binding.clone(),
+                    source,
+                    predicate,
+                    span: call_span,
+                }
+            }
             Expr::Coalesce { lhs, rhs, .. } => Expr::Coalesce {
                 node_id: RUNTIME_MODULE_NODE,
                 lhs: Box::new(expand(lhs, stack)?),
@@ -1027,6 +1128,31 @@ fn walk_expr(expr: &Expr, refs: &mut Vec<String>) {
         Expr::Unary { operand, .. } => {
             walk_expr(operand, refs);
         }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                walk_expr(element, refs);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &entry.key {
+                    walk_expr(key, refs);
+                }
+                walk_expr(&entry.value, refs);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            walk_expr(source, refs);
+            walk_expr(item, refs);
+            if let Some(predicate) = predicate {
+                walk_expr(predicate, refs);
+            }
+        }
         Expr::Coalesce { lhs, rhs, .. } => {
             walk_expr(lhs, refs);
             walk_expr(rhs, refs);
@@ -1198,6 +1324,31 @@ fn collect_function_refs(expr: &Expr, names: &HashMap<&str, usize>, refs: &mut V
             collect_function_refs(rhs, names, refs);
         }
         Expr::Unary { operand, .. } => collect_function_refs(operand, names, refs),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                collect_function_refs(element, names, refs);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &entry.key {
+                    collect_function_refs(key, names, refs);
+                }
+                collect_function_refs(&entry.value, names, refs);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            collect_function_refs(source, names, refs);
+            collect_function_refs(item, names, refs);
+            if let Some(predicate) = predicate {
+                collect_function_refs(predicate, names, refs);
+            }
+        }
         Expr::IfThenElse {
             condition,
             then_branch,

--- a/crates/cxl/src/parser.rs
+++ b/crates/cxl/src/parser.rs
@@ -499,11 +499,9 @@ impl Parser {
                 ));
             }
         };
-        // The `in` separator is an identifier (CXL has no `in` keyword);
-        // accept the literal text "in" to keep the grammar surface from
-        // adding another reserved word.
+        // `in` is shared by emit_each and collection comprehensions.
         match self.peek().clone() {
-            Token::Ident(name) if name.as_ref() == "in" => {
+            Token::In => {
                 self.advance();
             }
             other => {
@@ -805,6 +803,8 @@ impl Parser {
                     | Token::FatArrow
                     | Token::Then
                     | Token::Else
+                    | Token::For
+                    | Token::If
             ) {
                 break;
             }
@@ -1002,6 +1002,9 @@ impl Parser {
                 self.expect_token(&Token::RParen, "')'")?;
                 Ok(expr)
             }
+
+            Token::LBracket => self.parse_array_expr(),
+            Token::LBrace => self.parse_map_expr(),
 
             // if/then/else
             Token::If => self.parse_if_expr(),
@@ -1252,6 +1255,153 @@ impl Parser {
                 "Check for missing operands or mismatched delimiters",
             )),
         }
+    }
+
+    fn parse_array_expr(&mut self) -> Result<Expr, ParseError> {
+        let node_id = self.alloc_id();
+        let start = self.current_span();
+        self.advance();
+        self.skip_newlines();
+
+        if *self.peek() == Token::RBracket {
+            self.advance();
+            let end = self.prev_span();
+            return Ok(Expr::ArrayLiteral {
+                node_id,
+                elements: Vec::new(),
+                span: Span::new(start.start as usize, end.end as usize),
+            });
+        }
+
+        let first = self.parse_expr(0)?;
+        self.skip_newlines();
+        if *self.peek() == Token::For {
+            self.advance();
+            self.skip_newlines();
+            let binding = self.expect_ident("array-comprehension binding")?;
+            self.expect_token(&Token::In, "'in'")?;
+            self.skip_newlines();
+            let source = self.parse_expr(0)?;
+            self.skip_newlines();
+            let predicate = if *self.peek() == Token::If {
+                self.advance();
+                self.skip_newlines();
+                let predicate = self.parse_expr(0)?;
+                self.skip_newlines();
+                Some(Box::new(predicate))
+            } else {
+                None
+            };
+            self.expect_token(&Token::RBracket, "']'")?;
+            let end = self.prev_span();
+            return Ok(Expr::ArrayComprehension {
+                node_id,
+                item: Box::new(first),
+                binding: binding.into(),
+                source: Box::new(source),
+                predicate,
+                span: Span::new(start.start as usize, end.end as usize),
+            });
+        }
+
+        let mut elements = vec![first];
+        while *self.peek() == Token::Comma {
+            self.advance();
+            self.skip_newlines();
+            if *self.peek() == Token::RBracket {
+                break;
+            }
+            elements.push(self.parse_expr(0)?);
+            self.skip_newlines();
+        }
+        self.expect_token(&Token::RBracket, "']'")?;
+        let end = self.prev_span();
+        Ok(Expr::ArrayLiteral {
+            node_id,
+            elements,
+            span: Span::new(start.start as usize, end.end as usize),
+        })
+    }
+
+    fn parse_map_expr(&mut self) -> Result<Expr, ParseError> {
+        let node_id = self.alloc_id();
+        let start = self.current_span();
+        self.advance();
+        self.skip_newlines();
+        let mut entries = Vec::new();
+        let mut static_keys = Vec::<String>::new();
+
+        while *self.peek() != Token::RBrace {
+            let entry_start = self.current_span();
+            let key = match self.peek().clone() {
+                Token::Ident(key) | Token::StringLit(key) => {
+                    self.advance();
+                    let decoded = clinker_record::nested_key::NestedKey::decode(&key).map_err(
+                        |error| {
+                            self.error(
+                                &error.to_string(),
+                                "nested map keys use one canonical backslash escape grammar",
+                                "use `\\@name`, `\\#text`, or `\\\\name` only when escaping a reserved-looking literal key",
+                            )
+                        },
+                    )?;
+                    if static_keys
+                        .iter()
+                        .any(|existing| existing == decoded.text.as_ref())
+                    {
+                        return Err(self.error(
+                            &format!("duplicate map key {:?}", decoded.text),
+                            "static map keys must be unique after canonical escape decoding",
+                            "remove or rename the duplicate key",
+                        ));
+                    }
+                    static_keys.push(decoded.text.into_owned());
+                    MapKey::Static(key)
+                }
+                Token::LBracket => {
+                    self.advance();
+                    self.skip_newlines();
+                    let key = self.parse_expr(0)?;
+                    self.skip_newlines();
+                    self.expect_token(&Token::RBracket, "']'")?;
+                    MapKey::Computed(Box::new(key))
+                }
+                _ => {
+                    return Err(self.error(
+                        "map keys must be identifiers, strings, or computed string expressions",
+                        "CXL maps use `{ name: value }`, `{ \"name\": value }`, or `{ [expr]: value }`",
+                        "quote the key or wrap a string-valued expression in brackets",
+                    ));
+                }
+            };
+            self.skip_newlines();
+            self.expect_token(&Token::Colon, "':'")?;
+            self.skip_newlines();
+            let value = self.parse_expr(0)?;
+            let value_span = value.span();
+            entries.push(MapEntry {
+                key,
+                value,
+                span: Span::new(entry_start.start as usize, value_span.end as usize),
+            });
+            self.skip_newlines();
+            if *self.peek() != Token::Comma {
+                break;
+            }
+            self.advance();
+            self.skip_newlines();
+            if *self.peek() == Token::RBrace {
+                break;
+            }
+        }
+
+        self.expect_token(&Token::RBrace, "'}'")?;
+        let end = self.prev_span();
+        Ok(Expr::MapLiteral {
+            node_id,
+            entries,
+            span: Span::new(start.start as usize, end.end as usize),
+        })
     }
 
     fn parse_if_expr(&mut self) -> Result<Expr, ParseError> {
@@ -1688,6 +1838,109 @@ mod tests {
             }
             _ => panic!("expected Emit"),
         }
+    }
+
+    #[test]
+    fn parses_nested_array_and_map_literals() {
+        let r = parse_ok("let payload = [{name: \"Ada\", scores: [10, 20]}, null]");
+        let Expr::ArrayLiteral { elements, .. } = let_expr(&r) else {
+            panic!("expected array literal");
+        };
+        assert_eq!(elements.len(), 2);
+        let Expr::MapLiteral { entries, .. } = &elements[0] else {
+            panic!("expected nested map literal");
+        };
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(&entries[0].key, MapKey::Static(key) if &**key == "name"));
+        assert!(
+            matches!(&entries[1].value, Expr::ArrayLiteral { elements, .. } if elements.len() == 2)
+        );
+    }
+
+    #[test]
+    fn parses_multiline_nested_constructors_for_yaml_block_scalars() {
+        let r = parse_ok(
+            r##"let payload = {
+  "@kind": "event",
+  items: [
+    {"#text": "first"},
+    {"#text": "second"},
+  ],
+}"##,
+        );
+        let Expr::MapLiteral { entries, .. } = let_expr(&r) else {
+            panic!("expected map literal");
+        };
+        assert_eq!(entries.len(), 2);
+        assert!(matches!(
+            &entries[1].value,
+            Expr::ArrayLiteral { elements, .. } if elements.len() == 2
+        ));
+    }
+
+    #[test]
+    fn parses_computed_map_keys_in_author_order() {
+        let r = parse_ok("let payload = {first: 1, [prefix + suffix]: 2, \"last\": 3}");
+        let Expr::MapLiteral { entries, .. } = let_expr(&r) else {
+            panic!("expected map literal");
+        };
+        assert_eq!(entries.len(), 3);
+        assert!(matches!(&entries[1].key, MapKey::Computed(_)));
+    }
+
+    #[test]
+    fn parses_single_clause_array_comprehension() {
+        let r = parse_ok("let doubled = [item * 2 for item in values if item > 0]");
+        let Expr::ArrayComprehension {
+            binding, predicate, ..
+        } = let_expr(&r)
+        else {
+            panic!("expected array comprehension");
+        };
+        assert_eq!(&**binding, "item");
+        assert!(predicate.is_some());
+    }
+
+    #[test]
+    fn rejects_noncanonical_map_key_syntax() {
+        let result = Parser::parse("let payload = {1: \"nope\"}");
+        assert!(result.errors.iter().any(|error| {
+            error
+                .message
+                .contains("map keys must be identifiers, strings, or computed string expressions")
+        }));
+    }
+
+    #[test]
+    fn canonical_map_key_escapes_are_preserved_for_format_roles() {
+        let r = parse_ok(r#"let payload = {"\\@literal": 1, "\\#text": 2}"#);
+        let Expr::MapLiteral { entries, .. } = let_expr(&r) else {
+            panic!("expected map literal");
+        };
+        assert!(matches!(&entries[0].key, MapKey::Static(key) if &**key == "\\@literal"));
+        assert!(matches!(&entries[1].key, MapKey::Static(key) if &**key == "\\#text"));
+    }
+
+    #[test]
+    fn duplicate_static_keys_are_rejected_after_escape_decoding() {
+        let result = Parser::parse(r#"let payload = {"@id": 1, "\\@id": 2}"#);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.message.contains("duplicate map key \"@id\""))
+        );
+    }
+
+    #[test]
+    fn noncanonical_map_key_escape_is_rejected() {
+        let result = Parser::parse(r#"let payload = {"\\ordinary": 1}"#);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.message.contains("non-canonical nested key escape"))
+        );
     }
 
     #[test]

--- a/crates/cxl/src/plan/extract_aggregates.rs
+++ b/crates/cxl/src/plan/extract_aggregates.rs
@@ -17,7 +17,7 @@ use std::fmt::Write as _;
 use clinker_record::accumulator::AggregateType;
 
 use super::{AggregateBinding, BindingArg, CompiledAggregate, CompiledEmit};
-use crate::ast::{BinOp, Expr, LiteralValue, NodeId, Statement};
+use crate::ast::{BinOp, Expr, LiteralValue, MapKey, NodeId, Statement};
 use crate::lexer::Span;
 use crate::typecheck::{TypeDiagnostic, TypedProgram};
 
@@ -166,6 +166,31 @@ fn extract_aggs_from_expr(
         }
         Expr::Unary { operand, .. } => {
             extract_aggs_from_expr(operand, bindings, dedup, input_schema)?;
+        }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                extract_aggs_from_expr(element, bindings, dedup, input_schema)?;
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    extract_aggs_from_expr(key, bindings, dedup, input_schema)?;
+                }
+                extract_aggs_from_expr(&mut entry.value, bindings, dedup, input_schema)?;
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            extract_aggs_from_expr(source, bindings, dedup, input_schema)?;
+            extract_aggs_from_expr(item, bindings, dedup, input_schema)?;
+            if let Some(predicate) = predicate {
+                extract_aggs_from_expr(predicate, bindings, dedup, input_schema)?;
+            }
         }
         Expr::MethodCall { receiver, args, .. } => {
             extract_aggs_from_expr(receiver, bindings, dedup, input_schema)?;
@@ -322,6 +347,31 @@ fn rewrite_group_key_refs(
         Expr::Unary { operand, .. } => {
             rewrite_group_key_refs(operand, group_by_set, group_by_fields);
         }
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                rewrite_group_key_refs(element, group_by_set, group_by_fields);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    rewrite_group_key_refs(key, group_by_set, group_by_fields);
+                }
+                rewrite_group_key_refs(&mut entry.value, group_by_set, group_by_fields);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            rewrite_group_key_refs(source, group_by_set, group_by_fields);
+            rewrite_group_key_refs(item, group_by_set, group_by_fields);
+            if let Some(predicate) = predicate {
+                rewrite_group_key_refs(predicate, group_by_set, group_by_fields);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             rewrite_group_key_refs(receiver, group_by_set, group_by_fields);
             for a in args {
@@ -414,6 +464,31 @@ fn substitute_let_bindings(expr: &mut Expr, let_bindings: &HashMap<Box<str>, Exp
             substitute_let_bindings(rhs, let_bindings);
         }
         Expr::Unary { operand, .. } => substitute_let_bindings(operand, let_bindings),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                substitute_let_bindings(element, let_bindings);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let MapKey::Computed(key) = &mut entry.key {
+                    substitute_let_bindings(key, let_bindings);
+                }
+                substitute_let_bindings(&mut entry.value, let_bindings);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            substitute_let_bindings(source, let_bindings);
+            substitute_let_bindings(item, let_bindings);
+            if let Some(predicate) = predicate {
+                substitute_let_bindings(predicate, let_bindings);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             substitute_let_bindings(receiver, let_bindings);
             for a in args {
@@ -491,6 +566,21 @@ fn contains_agg_call(expr: &Expr) -> bool {
             contains_agg_call(lhs) || contains_agg_call(rhs)
         }
         Expr::Unary { operand, .. } => contains_agg_call(operand),
+        Expr::ArrayLiteral { elements, .. } => elements.iter().any(contains_agg_call),
+        Expr::MapLiteral { entries, .. } => entries.iter().any(|entry| {
+            matches!(&entry.key, MapKey::Computed(key) if contains_agg_call(key))
+                || contains_agg_call(&entry.value)
+        }),
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            contains_agg_call(source)
+                || contains_agg_call(item)
+                || predicate.as_deref().map(contains_agg_call).unwrap_or(false)
+        }
         Expr::MethodCall { receiver, args, .. } => {
             contains_agg_call(receiver) || args.iter().any(contains_agg_call)
         }
@@ -575,6 +665,54 @@ fn write_struct_form(buf: &mut String, expr: &Expr) {
         },
         Expr::FieldRef { name, .. } => {
             let _ = write!(buf, "f:{name}");
+        }
+        Expr::ArrayLiteral { elements, .. } => {
+            buf.push('[');
+            for (index, element) in elements.iter().enumerate() {
+                if index > 0 {
+                    buf.push(',');
+                }
+                write_struct_form(buf, element);
+            }
+            buf.push(']');
+        }
+        Expr::MapLiteral { entries, .. } => {
+            buf.push('{');
+            for (index, entry) in entries.iter().enumerate() {
+                if index > 0 {
+                    buf.push(',');
+                }
+                match &entry.key {
+                    MapKey::Static(key) => {
+                        let _ = write!(buf, "{:?}", key);
+                    }
+                    MapKey::Computed(key) => {
+                        buf.push('[');
+                        write_struct_form(buf, key);
+                        buf.push(']');
+                    }
+                }
+                buf.push(':');
+                write_struct_form(buf, &entry.value);
+            }
+            buf.push('}');
+        }
+        Expr::ArrayComprehension {
+            item,
+            binding,
+            source,
+            predicate,
+            ..
+        } => {
+            buf.push_str("[comp ");
+            write_struct_form(buf, item);
+            let _ = write!(buf, " for {binding} in ");
+            write_struct_form(buf, source);
+            if let Some(predicate) = predicate {
+                buf.push_str(" if ");
+                write_struct_form(buf, predicate);
+            }
+            buf.push(']');
         }
         Expr::QualifiedFieldRef { parts, .. } => {
             buf.push_str("qf:");

--- a/crates/cxl/src/resolve/pass.rs
+++ b/crates/cxl/src/resolve/pass.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::levenshtein::best_match;
 use super::scoped_vars::ScopedVarsRegistry;
-use crate::ast::{Expr, MatchArm, NodeId, Program, Statement};
+use crate::ast::{Expr, MapKey, MatchArm, NodeId, Program, Statement};
 use crate::lexer::Span;
 
 /// What a resolved identifier binds to.
@@ -543,6 +543,47 @@ impl<'a> Resolver<'a> {
             }
             Expr::Literal { .. } => {
                 // Literals don't need resolution
+            }
+            Expr::ArrayLiteral { elements, .. } => {
+                for element in elements {
+                    self.resolve_expr(element);
+                }
+            }
+            Expr::MapLiteral { entries, .. } => {
+                for entry in entries {
+                    if let MapKey::Computed(key) = &entry.key {
+                        self.resolve_expr(key);
+                    }
+                    self.resolve_expr(&entry.value);
+                }
+            }
+            Expr::ArrayComprehension {
+                item,
+                binding,
+                source,
+                predicate,
+                span,
+                ..
+            } => {
+                self.resolve_expr(source);
+                if self.let_vars.iter().any(|name| name == binding.as_ref())
+                    || self.fields.contains(&binding.as_ref())
+                {
+                    self.diagnostics.push(ResolveDiagnostic {
+                        span: *span,
+                        message: format!(
+                            "array-comprehension binding '{binding}' shadows an existing name"
+                        ),
+                        help: Some("choose a fresh binding name for the comprehension".into()),
+                    });
+                }
+                let saved_len = self.let_vars.len();
+                self.let_vars.push(binding.to_string());
+                self.resolve_expr(item);
+                if let Some(predicate) = predicate {
+                    self.resolve_expr(predicate);
+                }
+                self.let_vars.truncate(saved_len);
             }
             Expr::Binary { lhs, rhs, .. } => {
                 self.resolve_expr(lhs);
@@ -1127,6 +1168,36 @@ mod tests {
             .iter()
             .any(|b| matches!(b, Some(ResolvedBinding::LetVar(0))));
         assert!(has_let, "Expected LetVar(0) — let should shadow field");
+    }
+
+    #[test]
+    fn array_comprehension_binding_resolves_only_inside_body() {
+        let resolved = resolve_ok(
+            "emit values = [element * 2 for element in items if element > 0]",
+            &["items"],
+        );
+        let let_bindings = resolved
+            .bindings
+            .iter()
+            .filter(|binding| matches!(binding, Some(ResolvedBinding::LetVar(_))))
+            .count();
+        assert_eq!(
+            let_bindings, 2,
+            "item and predicate should resolve to the binder"
+        );
+    }
+
+    #[test]
+    fn array_comprehension_rejects_shadowing() {
+        let diagnostics = resolve_err(
+            "let element = 1\nemit values = [element for element in items]",
+            &["items"],
+        );
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("array-comprehension binding 'element' shadows an existing name")
+        }));
     }
 
     #[test]

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -540,6 +540,72 @@ impl<'a> TypeChecker<'a> {
                 ty
             }
 
+            Expr::ArrayLiteral {
+                node_id, elements, ..
+            } => {
+                for element in elements {
+                    self.check_expr(element, in_predicate);
+                }
+                self.set_type(*node_id, Type::Array);
+                Type::Array
+            }
+
+            Expr::MapLiteral {
+                node_id, entries, ..
+            } => {
+                for entry in entries {
+                    if let crate::ast::MapKey::Computed(key) = &entry.key {
+                        let key_ty = self.check_expr(key, in_predicate);
+                        if !matches!(key_ty.unwrap_nullable(), Type::String | Type::Any) {
+                            self.error(
+                                key.span(),
+                                format!("computed map key must be String, got {key_ty}"),
+                                Some("convert the key explicitly with `.to_string()`".into()),
+                            );
+                        }
+                    }
+                    self.check_expr(&entry.value, in_predicate);
+                }
+                self.set_type(*node_id, Type::Map);
+                Type::Map
+            }
+
+            Expr::ArrayComprehension {
+                node_id,
+                item,
+                binding,
+                source,
+                predicate,
+                ..
+            } => {
+                let source_ty = self.check_expr(source, in_predicate);
+                if !matches!(source_ty.unwrap_nullable(), Type::Array | Type::Any) {
+                    self.error(
+                        source.span(),
+                        format!("array comprehension requires an Array source, got {source_ty}"),
+                        Some("handle null explicitly or provide an Array-valued expression".into()),
+                    );
+                }
+                self.lexical_types
+                    .push(HashMap::from([(binding.clone(), Type::Any)]));
+                self.check_expr(item, in_predicate);
+                if let Some(predicate) = predicate {
+                    let predicate_ty = self.check_expr(predicate, in_predicate);
+                    if !matches!(predicate_ty, Type::Bool | Type::Any) {
+                        self.error(
+                            predicate.span(),
+                            format!(
+                                "array-comprehension predicate must be Bool, got {predicate_ty}"
+                            ),
+                            Some("use an explicit boolean comparison".into()),
+                        );
+                    }
+                }
+                self.lexical_types.pop();
+                self.set_type(*node_id, Type::Array);
+                Type::Array
+            }
+
             Expr::FieldRef {
                 node_id,
                 name,
@@ -1513,6 +1579,31 @@ impl<'a> TypeChecker<'a> {
                 self.walk_agg_ctx(rhs, let_exprs);
             }
             Expr::Unary { operand, .. } => self.walk_agg_ctx(operand, let_exprs),
+            Expr::ArrayLiteral { elements, .. } => {
+                for element in elements {
+                    self.walk_agg_ctx(element, let_exprs);
+                }
+            }
+            Expr::MapLiteral { entries, .. } => {
+                for entry in entries {
+                    if let crate::ast::MapKey::Computed(key) = &entry.key {
+                        self.walk_agg_ctx(key, let_exprs);
+                    }
+                    self.walk_agg_ctx(&entry.value, let_exprs);
+                }
+            }
+            Expr::ArrayComprehension {
+                item,
+                source,
+                predicate,
+                ..
+            } => {
+                self.walk_agg_ctx(source, let_exprs);
+                self.walk_agg_ctx(item, let_exprs);
+                if let Some(predicate) = predicate {
+                    self.walk_agg_ctx(predicate, let_exprs);
+                }
+            }
             Expr::Coalesce { lhs, rhs, .. } => {
                 self.walk_agg_ctx(lhs, let_exprs);
                 self.walk_agg_ctx(rhs, let_exprs);
@@ -2038,6 +2129,9 @@ fn reindex_expr(expr: &mut Expr, next_id: &mut u32) {
         Expr::Binary { node_id, .. }
         | Expr::Unary { node_id, .. }
         | Expr::Literal { node_id, .. }
+        | Expr::ArrayLiteral { node_id, .. }
+        | Expr::MapLiteral { node_id, .. }
+        | Expr::ArrayComprehension { node_id, .. }
         | Expr::FieldRef { node_id, .. }
         | Expr::QualifiedFieldRef { node_id, .. }
         | Expr::MethodCall { node_id, .. }
@@ -2071,6 +2165,31 @@ fn reindex_expr(expr: &mut Expr, next_id: &mut u32) {
             reindex_expr(rhs, next_id);
         }
         Expr::Unary { operand, .. } => reindex_expr(operand, next_id),
+        Expr::ArrayLiteral { elements, .. } => {
+            for element in elements {
+                reindex_expr(element, next_id);
+            }
+        }
+        Expr::MapLiteral { entries, .. } => {
+            for entry in entries {
+                if let crate::ast::MapKey::Computed(key) = &mut entry.key {
+                    reindex_expr(key, next_id);
+                }
+                reindex_expr(&mut entry.value, next_id);
+            }
+        }
+        Expr::ArrayComprehension {
+            item,
+            source,
+            predicate,
+            ..
+        } => {
+            reindex_expr(item, next_id);
+            reindex_expr(source, next_id);
+            if let Some(predicate) = predicate {
+                reindex_expr(predicate, next_id);
+            }
+        }
         Expr::MethodCall { receiver, args, .. } => {
             reindex_expr(receiver, next_id);
             for arg in args {
@@ -2168,6 +2287,50 @@ mod tests {
         assert!(parsed.errors.is_empty());
         let resolved = resolve_program(parsed.ast, fields, parsed.node_count).unwrap();
         type_check(resolved, schema).expect_err("Expected type errors but got Ok")
+    }
+
+    #[test]
+    fn nested_constructor_types_are_checked() {
+        let typed = typecheck_ok(
+            "emit payload = {items: [1, 2], selected: [item for item in values if item > 0]}",
+            &["values"],
+            &empty_row(),
+        );
+        let Statement::Emit { expr, .. } = &typed.program.statements[0] else {
+            panic!("expected emit");
+        };
+        assert_eq!(typed.types[expr.node_id().0 as usize], Some(Type::Map));
+    }
+
+    #[test]
+    fn computed_map_key_requires_string() {
+        let diagnostics = typecheck_err("emit payload = {[1]: true}", &[], &empty_row());
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("computed map key must be String")
+        }));
+    }
+
+    #[test]
+    fn comprehension_rejects_null_source_and_non_bool_predicate() {
+        let null_source = typecheck_err("emit values = [item for item in null]", &[], &empty_row());
+        assert!(null_source.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("array comprehension requires an Array source")
+        }));
+
+        let non_bool = typecheck_err(
+            "emit values = [item for item in [1, 2] if 42]",
+            &[],
+            &empty_row(),
+        );
+        assert!(non_bool.iter().any(|diagnostic| {
+            diagnostic
+                .message
+                .contains("array-comprehension predicate must be Bool")
+        }));
     }
 
     fn typecheck_with_module(

--- a/docs/engine/src/auto-widen-internals.md
+++ b/docs/engine/src/auto-widen-internals.md
@@ -46,11 +46,17 @@ When `include_unmapped: true` (the default), fields the source absorbed into `$w
 
 `include_unmapped` composes independently with `include_correlation_keys`; the two flags are orthogonal — `include_correlation_keys` does not surface `$widened`. Because expansion is a projection-layer operation, a CSV source under `auto_widen` feeding a JSON output under `include_unmapped: true` produces JSON objects whose top-level keys include both declared columns and absorbed input columns, with no sidecar key remaining.
 
-## Writer rejection of `Value::Map` payloads
+## Writer handling of `Value::Map` payloads
 
-CSV, XML, and fixed-width writers refuse any record carrying a `Value::Map` payload at any column slot, raising `FormatError::UnserializableMapValue { format, column }`. The rejection lives in **each writer's value-to-string helper** — a single point of truth, with no defensive prechecks scattered ahead of it. JSON serializes `Value::Map` natively as a nested object and never raises.
+CSV and fixed-width writers refuse a user-visible `Value::Map` column, raising
+`FormatError::UnserializableMapValue { format, column }`. JSON writes a map as
+a native object; XML recursively maps it to elements, attributes, and text.
 
-The common trigger is the `$widened` sidecar reaching one of those three writers because the Output node set `include_unmapped: false` (which suppresses the projection-layer expansion that would otherwise have flattened the map to top-level scalars). Two remediations exist, and the error message names both: leave `include_unmapped` at its default `true` so projection expands the map before write, or coerce the map to a scalar in CXL before the emit.
+The `$widened` map is different from a user-visible nested value: Output
+projection expands it to top-level fields under `include_unmapped: true`, or
+strips it under `include_unmapped: false`. It is never passed through as the
+author's JSON/XML nested structure. That projection rule keeps schema-drift
+handling separate from the recursive writer vocabulary.
 
 ### DLQ filtering
 

--- a/docs/engine/src/cxl-internals.md
+++ b/docs/engine/src/cxl-internals.md
@@ -47,6 +47,16 @@ records. Statements execute top to bottom; later statements can reference
 fields produced by earlier `emit` or `let` statements, and a false `filter`
 excludes the record. Evaluation performs no type inference.
 
+Array literals, map literals, and array comprehensions are ordinary expression
+nodes throughout this pipeline, including inside aggregate residuals. Every AST
+walker must recurse into item/value expressions, computed map keys,
+comprehension sources, and predicates; otherwise schema binding, dependency
+analysis, semantic identity, or lineage can silently miss an input. Runtime
+construction preserves author order, rejects duplicate logical keys after
+canonical escape decoding, and shares a per-record 10 MiB allocation budget and
+64-container depth cap across nested constructors. The aggregate residual
+evaluator enforces the same rules.
+
 The phase split is what makes CXL's compile-time guarantee meaningful: a `cxl check transform.cxl` runs Parse → Resolve → Typecheck and reports any error with a span before a single record is read, e.g.
 
 ```text

--- a/docs/engine/src/output-internals.md
+++ b/docs/engine/src/output-internals.md
@@ -1,6 +1,6 @@
 # Streaming Output Writes
 
-Output nodes are the terminal sinks of a pipeline. When the planner certifies a single linear producer feeding one Output, the executor can take a **streaming handoff** that wires the producer arm to a dedicated writer thread through a bounded crossbeam channel and fires `Writer::write_record` per record, concurrent with producer emission. Other producer shapes materialize their output before the writer fires. This page covers the topology that selects the streaming handoff, its relationship to Source-to-Merge fusion, the back-pressure chain, the counter semantics that must match the buffered arm, and the writer contract that rejects `Value::Map` payloads.
+Output nodes are the terminal sinks of a pipeline. When the planner certifies a single linear producer feeding one Output, the executor can take a **streaming handoff** that wires the producer arm to a dedicated writer thread through a bounded crossbeam channel and fires `Writer::write_record` per record, concurrent with producer emission. Other producer shapes materialize their output before the writer fires. This page covers the topology that selects the streaming handoff, its relationship to Source-to-Merge fusion, the back-pressure chain, the counter semantics that must match the buffered arm, and the per-format nested-value contract.
 
 *User-facing view: the User Guide's "Output Nodes" page.*
 
@@ -296,14 +296,23 @@ Counter behavior under the streaming path matches the buffered Output arm **exac
 
 Stage metrics (`SchemaScan`, `Write`, `Projection`) accumulate into the same fields the buffered path uses. The dispatcher folds the streaming task's per-task accounting back into the run-wide totals at end of DAG, so a streaming run and a buffered run over the same input produce identical counter output.
 
-## Writer rejection of `Value::Map` payloads
+## Writer handling of `Value::Map` payloads
 
-CSV, XML, fixed-width, EDIFACT, X12, and HL7 writers **refuse** records carrying a `Value::Map` payload at any column slot, raising:
+CSV, fixed-width, EDIFACT, X12, and HL7 writers **refuse** records carrying a `Value::Map` payload at any column slot, raising:
 
 ```
 FormatError::UnserializableMapValue { format, column }
 ```
 
-JSON is the exception — it serializes `Value::Map` natively as a nested object.
+JSON serializes `Value::Map` natively as a nested object. XML also accepts a
+map at an element field and recursively maps ordinary keys to child elements,
+unescaped `@...` keys to attributes, `#text` to text, and arrays to repeated
+children. Both recursive writers validate the shared key grammar, decoded-key
+collisions, and the 64-container depth cap before any record bytes reach the
+sink.
 
-The typical cause is a `$widened` sidecar reaching a non-JSON writer because the Output node set `include_unmapped: false`, which strips the sidecar's expansion and leaves the raw `Value::Map` slot to hit the writer. The contract is the same on the streaming and buffered paths: the writer rejects the map-valued record rather than emitting a malformed row. See [Schema Drift & the `$widened` Sidecar](auto-widen-internals.md) for the sidecar lifecycle, the `include_unmapped` interaction, and the remediation routes for this rejection.
+The engine-stamped `$widened` sidecar is handled at projection: it is expanded
+or stripped rather than exposed as author XML. The contract is the same on the
+streaming and buffered paths. See
+[Schema Drift & the `$widened` Sidecar](auto-widen-internals.md) for that
+lifecycle.

--- a/docs/user/src/cxl/aggregates.md
+++ b/docs/user/src/cxl/aggregates.md
@@ -98,10 +98,10 @@ cxl: |
   emit all_order_ids = collect(order_id)
 ```
 
-Because `collect` emits an array, route the result to a JSON output
-(which serializes arrays natively) or coerce it to a scalar in a
-downstream `Transform` (for example `emit ids = all_order_ids.join(";")`).
-The CSV, XML, and fixed-width writers reject an array-valued field.
+Because `collect` emits an array, JSON writes it as a native array, XML as
+repeated child elements, and CSV as a delimited cell. Coerce it to a scalar for
+a format such as fixed-width (for example
+`emit ids = all_order_ids.join(";")`).
 
 ### weighted_avg(value, weight) -> Float or Decimal
 

--- a/docs/user/src/cxl/types.md
+++ b/docs/user/src/cxl/types.md
@@ -1,6 +1,6 @@
 # Types & Literals
 
-CXL has 9 value types. Every field value, literal, and expression result is one of these types.
+CXL has 10 value types. Every field value, literal, and expression result is one of these types.
 
 ## Value types
 
@@ -106,6 +106,51 @@ $ cxl eval -e 'emit nothing = null'
   "nothing": null
 }
 ```
+
+### Arrays and comprehensions
+
+Array literals accept full expressions and preserve their written order:
+
+```cxl
+emit values = [order_id, amount * 2, null]
+```
+
+Use one `for` clause and an optional trailing `if` to construct an array from
+another array:
+
+```cxl
+emit positive_doubles = [item * 2 for item in values if item > 0]
+```
+
+The source must be an array; `null` and scalar sources are errors. The binding
+is local to the item expression and predicate, cannot destructure, and cannot
+shadow an input field or surrounding `let` binding.
+
+### Maps
+
+Map literals preserve key insertion order. Bare identifiers and quoted strings
+are static keys; brackets hold a computed expression whose result must be a
+non-null string:
+
+```cxl
+emit payload = {
+  customer: customer_name,
+  items: [{sku: item.sku, quantity: item.quantity} for item in line_items],
+  [dynamic_key]: dynamic_value,
+}
+```
+
+Duplicate keys are errors, including two differently escaped spellings that
+decode to the same logical key. Nested maps and arrays are limited to 64
+container levels, and CXL construction is limited to 10 MiB per input record;
+both limits fail the record instead of growing without bound.
+
+Nested keys use one canonical escape grammar. After CXL string decoding, one
+leading backslash makes a reserved-looking key literal: `\@name`, `\#text`,
+or `\\name`. In CXL source each backslash in a quoted string is itself escaped,
+so write `"\\@name"`, `"\\#text"`, or `"\\\\name"`. Other leading-backslash
+forms are rejected. Output formats decide how the neutral nested value is
+encoded; their format documentation defines that boundary.
 
 ## Schema types
 

--- a/docs/user/src/cxl/types.md
+++ b/docs/user/src/cxl/types.md
@@ -150,7 +150,13 @@ leading backslash makes a reserved-looking key literal: `\@name`, `\#text`,
 or `\\name`. In CXL source each backslash in a quoted string is itself escaped,
 so write `"\\@name"`, `"\\#text"`, or `"\\\\name"`. Other leading-backslash
 forms are rejected. Output formats decide how the neutral nested value is
-encoded; their format documentation defines that boundary.
+encoded. JSON removes the structural escape when writing the key; XML assigns
+roles to the unescaped forms as described in
+[Writing XML](../formats/xml.md#native-map-and-array-values).
+
+The runnable `examples/pipelines/nested_values.yaml` pipeline sends one
+constructed value to both JSON and XML so the two native encodings can be
+compared directly.
 
 ## Schema types
 

--- a/docs/user/src/cxl/windows.md
+++ b/docs/user/src/cxl/windows.md
@@ -221,11 +221,10 @@ Collects distinct values of the field in the window into an array.
 emit unique_regions = $window.distinct(region)
 ```
 
-`$window.collect` and `$window.distinct` emit arrays. The CSV, XML,
-and fixed-width writers reject an array-valued field, so route such a
-result to a JSON output, or coerce the emitted array to a scalar in a
-downstream `Transform` (for example `emit regions = unique_regions.join(";")`)
-before a tabular sink.
+`$window.collect` and `$window.distinct` emit arrays. JSON writes them as native
+arrays, XML as repeated child elements, and CSV as a delimited cell. Before a
+scalar-only sink such as fixed-width, coerce the value in a downstream
+`Transform` (for example `emit regions = unique_regions.join(";")`).
 
 ## Complete example
 

--- a/docs/user/src/formats/auto-widen.md
+++ b/docs/user/src/formats/auto-widen.md
@@ -76,7 +76,12 @@ Different records can carry different auto-widened columns — for example a `Me
 
 ### Writer errors on unexpanded columns
 
-The CSV, XML, and fixed-width writers can only write flat scalar columns. If a `$widened` sidecar map reaches one of these writers without being expanded — which happens when you set `include_unmapped: false` but a nested value is still present — the write fails with an `UnserializableMapValue` error naming the format and column. (JSON has no such limit; it writes nested values natively.)
+CSV and fixed-width writers can only write flat scalar columns. If an
+unexpanded map reaches one of those writers, the write fails with an
+`UnserializableMapValue` error naming the format and column. JSON and XML can
+write a user-visible nested value natively, although the engine-stamped
+`$widened` sidecar is still expanded or stripped by the Output projection and
+is never an author-facing XML structure.
 
 The fix is to either leave `include_unmapped` at its default of `true`, so the columns are expanded to top-level before writing, or to convert the value to a scalar in CXL before emitting it. The error message lists both routes.
 

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -188,6 +188,7 @@ single array (`format: array`, the default) or one object per line
     name: enriched
     type: json
     path: "./output/enriched.json"
+    preserve_nulls: false  # omit null columns; native map/array nulls remain values
     options:
       format: ndjson     # array | ndjson
       pretty: false      # indent the emitted objects
@@ -234,15 +235,33 @@ emit payload = {
 }
 ```
 
-The output contains `"payload"` as an object with an `"items"` array. There is
-no implicit stringification or fallback encoding. Canonically escaped neutral
-keys are decoded before JSON writes them: the CXL key spelling `"\\@literal"`
-writes the JSON key `"@literal"`.
+The output contains `"payload"` as an object with an `"items"` array. Native
+maps and arrays are values, so the default `preserve_nulls: false` does not remove null map
+entries or array items inside them; it controls null output columns and null
+leaves created by dotted-column expansion.
 
-Before writing any bytes for a record, the writer validates all nested keys,
-rejects duplicate logical keys, and enforces the shared 64-container depth
-limit. A failed nested value therefore cannot leave a partial JSON record in
-the output.
+JSON and XML share one neutral-map key grammar. After CXL has decoded the string
+literal, an unescaped key is its ordinary logical spelling. Exactly one leading
+backslash marks a literal reserved-looking key only in these three forms:
+`\@name`, `\#text`, or `\\name`. The neutral decoder removes that one marker.
+In CXL source, where the string literal itself must escape the backslash, write
+`"\\@name"`, `"\\#text"`, or `"\\\\name"`. Other leading-backslash
+forms are non-canonical and fail. JSON assigns no structural role to `@name` or
+`#text`, but it still uses this same decoder: `"\\@literal"` writes the JSON
+key `"@literal"`.
+
+Static and computed map keys follow the same rule. Two authored spellings that
+decode to the same logical key are a duplicate and fail rather than selecting a
+winner. Before writing any bytes for a record, the writer validates the entire
+neutral tree. Scalars have depth zero and each map or array adds one container;
+depth 64 is accepted and depth 65 is rejected. A failed nested value therefore
+cannot leave a partial JSON record in the output.
+
+This recursive behavior is native to JSON/NDJSON and XML. Flat, positional, and
+message formats do not silently turn a map or array into JSON text. Use an
+explicit encoding the destination format declares—such as `join_values` for a
+multi-value flat field—or reshape the value before that output. Without one,
+the structured value is rejected before bytes for that record are written.
 
 ### Keeping a literal `.` in a key
 

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -221,6 +221,29 @@ in full on [Field Paths](../cxl/field-paths.md):
   as that map or array. Expansion adds structure above the value, never inside
   it.
 
+### Native map and array values
+
+CXL can construct maps, arrays, and array comprehensions directly; a JSON
+output writes those values recursively as native objects and arrays. Map key
+insertion order and array item order are preserved:
+
+```cxl
+emit payload = {
+  customer: customer_name,
+  items: [{sku: item.sku, quantity: item.quantity} for item in line_items],
+}
+```
+
+The output contains `"payload"` as an object with an `"items"` array. There is
+no implicit stringification or fallback encoding. Canonically escaped neutral
+keys are decoded before JSON writes them: the CXL key spelling `"\\@literal"`
+writes the JSON key `"@literal"`.
+
+Before writing any bytes for a record, the writer validates all nested keys,
+rejects duplicate logical keys, and enforces the shared 64-container depth
+limit. A failed nested value therefore cannot leave a partial JSON record in
+the output.
+
 ### Keeping a literal `.` in a key
 
 To emit a key that genuinely contains a `.`, escape the separator in the column

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -124,6 +124,7 @@ the way back in.
     name: xml_out
     type: xml
     path: "./output/result.xml"
+    preserve_nulls: false              # omit null elements; null attributes always omit
     options:
       root_element: "Root"              # default Root
       record_element: "Record"          # default Record
@@ -181,6 +182,16 @@ writes:
 <payload kind="event">before<item id="1">alpha</item><item id="2">beta</item><tail>after</tail></payload>
 ```
 
+JSON and XML share one neutral-map key grammar. After CXL string decoding,
+ordinary keys are unescaped. Exactly one leading backslash marks a literal key
+only as `\@name`, `\#text`, or `\\name`, and the neutral decoder removes that
+one marker. Because the CXL string literal must encode the backslash too, the
+source spellings are `"\\@name"`, `"\\#text"`, and `"\\\\name"`.
+Other leading-backslash forms are non-canonical and fail. An escape disables
+XML's attribute or text classification; it does not make the decoded spelling a
+legal XML name. For example, a decoded `@literal` still cannot be an element
+name, while JSON can write it as an ordinary object key.
+
 The rules are deliberately strict:
 
 - Attribute and `#text` values must be scalar or null; maps and arrays there
@@ -188,16 +199,34 @@ The rules are deliberately strict:
 - A direct array inside another array is rejected because XML has no child name
   to repeat. Put the inner array under a map key to supply that name.
 - Every decoded ordinary key and attribute name must be a well-formed XML name.
-  A canonical escape (`"\\@literal"`, `"\\#text"`, or `"\\\\name"` in CXL
-  source) disables the structural role, but it does not make an otherwise
-  illegal XML name legal.
-- Duplicate logical keys, malformed escapes, and values deeper than 64
-  containers reject the whole record before its first byte is emitted. XML
-  never silently falls back to JSON text.
+- Static and computed keys use identical decoding. Two spellings that decode to
+  the same logical key—including attribute-looking or `#text` spellings—are a
+  collision and reject rather than selecting a winner.
+- Scalars have depth zero and each map or array adds one container. Depth 64 is
+  accepted; depth 65, malformed escapes, duplicate logical keys, and invalid
+  names reject the whole record before its first byte is emitted. XML never
+  silently falls back to JSON text.
 
-With `preserve_nulls: false`, null child elements and null array items are
-omitted; with it enabled they emit as self-closing elements. Null attributes
-are always omitted.
+With the default `preserve_nulls: false`, null child elements and null array
+items are omitted; with it enabled they emit as self-closing elements. Null
+attributes are always omitted.
+
+The XML writer is deliberately two-pass per record. Its first borrowed pass
+validates the complete schema/value shape, XML names, and scalar roles before
+writing any bytes for that record. Its second pass streams directly from the
+original record. Authored strings remain borrowed; other scalars are formatted
+in a fixed 128-byte stack scratch buffer. The writer does not clone or
+materialize a second nested tree, and it retains no record values or rendered
+scalar capacity between calls. Its only memoized preparation heap state is the
+schema-derived element plan, whose size is independent of record value widths;
+recursive calls are capped at 64 containers. This is separate from the XML
+reader's optional envelope pre-scan described below.
+
+Native recursion belongs to XML and JSON/NDJSON. Flat, positional, and message
+formats do not stringify maps or arrays implicitly. Declare an encoding that
+the destination supports—such as `join_values` for a multi-value flat
+field—or reshape the value before that output; otherwise the structured value
+is rejected before bytes for that record are written.
 
 ### Writing multi-value fields (repeated elements)
 

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -154,6 +154,51 @@ Attribute handling details:
 - An element with only attribute fields and no children self-closes:
   `Address.@type` alone emits `<Address type="home"/>`.
 
+### Native map and array values
+
+An element-valued CXL map is written recursively. Ordinary keys become child
+elements, an unescaped key beginning with `attribute_prefix` becomes an
+attribute on the current element, and the unescaped key `#text` becomes text in
+the current element. Map insertion order controls text/child order; attributes
+are collected onto the start tag. Arrays held under an ordinary key repeat that
+key as the element name.
+
+```cxl
+emit payload = {
+  "@kind": "event",
+  "#text": "before",
+  item: [
+    {"@id": 1, "#text": "alpha"},
+    {"@id": 2, "#text": "beta"},
+  ],
+  tail: "after",
+}
+```
+
+writes:
+
+```xml
+<payload kind="event">before<item id="1">alpha</item><item id="2">beta</item><tail>after</tail></payload>
+```
+
+The rules are deliberately strict:
+
+- Attribute and `#text` values must be scalar or null; maps and arrays there
+  are rejected.
+- A direct array inside another array is rejected because XML has no child name
+  to repeat. Put the inner array under a map key to supply that name.
+- Every decoded ordinary key and attribute name must be a well-formed XML name.
+  A canonical escape (`"\\@literal"`, `"\\#text"`, or `"\\\\name"` in CXL
+  source) disables the structural role, but it does not make an otherwise
+  illegal XML name legal.
+- Duplicate logical keys, malformed escapes, and values deeper than 64
+  containers reject the whole record before its first byte is emitted. XML
+  never silently falls back to JSON text.
+
+With `preserve_nulls: false`, null child elements and null array items are
+omitted; with it enabled they emit as self-closing elements. Null attributes
+are always omitted.
+
 ### Writing multi-value fields (repeated elements)
 
 A `multiple:` field is written as **repeated child elements**, one per value, in

--- a/docs/user/src/nodes/aggregate.md
+++ b/docs/user/src/nodes/aggregate.md
@@ -385,9 +385,8 @@ cargo run -p clinker -- run examples/pipelines/multi_source_session.yaml
     path: "./output/account_summary.json"
 ```
 
-The output is JSON because `collect(category)` emits an array. The
-CSV, XML, and fixed-width writers reject an array-valued field (a
-stray collection reaching a tabular sink is treated as a routing
-bug); route such a pipeline to JSON, which serializes arrays
-natively, or coerce the array to a scalar first with a downstream
-`Transform` (for example `emit categories = categories.join(";")`).
+The output is JSON because `collect(category)` emits an array. JSON serializes
+it as a native array; XML can instead write it as repeated child elements, and
+CSV can join it into a delimited cell. For a scalar-only output such as
+fixed-width, coerce it first with a downstream `Transform` (for example
+`emit categories = categories.join(";")`).

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -216,9 +216,15 @@ When a source declares a `correlation_key:`, the engine tracks correlation-group
 
 `include_correlation_keys` does **not** surface auto-widened columns -- `include_unmapped` is the separate flag for that. The two are independent: each, both, or neither can be set.
 
-### Nested columns and non-JSON writers
+### Nested columns and writer capabilities
 
-The CSV, XML, fixed-width, EDIFACT, X12, and HL7 writers can only write flat scalar columns; a nested value reaching one of them fails with an `UnserializableMapValue` error. JSON writes nested values natively. The usual cause is an auto-widened column reaching a non-JSON writer with `include_unmapped: false` — see [Auto-Widen & Schema Drift](../formats/auto-widen.md#writer-errors-on-unexpanded-columns) for the fix.
+JSON and XML write map and array values recursively. JSON uses native objects
+and arrays; XML maps ordinary keys to child elements, reserves unescaped
+`@...`/`#text` keys for attributes/text, and repeats a child name for arrays.
+CSV, fixed-width, EDIFACT, X12, and HL7 remain scalar formats and reject a map
+that reaches a column slot. See [JSON](../formats/json.md#native-map-and-array-values),
+[XML](../formats/xml.md#native-map-and-array-values), and
+[Auto-Widen & Schema Drift](../formats/auto-widen.md#writer-errors-on-unexpanded-columns).
 
 ### Field mapping
 

--- a/examples/pipelines/data/nested_values.csv
+++ b/examples/pipelines/data/nested_values.csv
@@ -1,0 +1,3 @@
+event_id,first,second
+evt-1,2,-1
+evt-2,3,5

--- a/examples/pipelines/nested_values.yaml
+++ b/examples/pipelines/nested_values.yaml
@@ -1,0 +1,48 @@
+pipeline:
+  name: nested_values
+
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: ./data/nested_values.csv
+      options:
+        has_header: true
+      schema:
+        - { name: event_id, type: string }
+        - { name: first, type: int }
+        - { name: second, type: int }
+
+  - type: transform
+    name: construct_payload
+    input: rows
+    config:
+      cxl: |
+        emit event_id = event_id
+        emit payload = {
+          "@kind": "sample",
+          "#text": "values:",
+          value: [item for item in [first, second] if item > 0],
+        }
+
+  - type: output
+    name: json_result
+    input: construct_payload
+    config:
+      name: json_result
+      type: json
+      path: ./output/nested_values.json
+      include_unmapped: false
+      options:
+        format: ndjson
+
+  - type: output
+    name: xml_result
+    input: construct_payload
+    config:
+      name: xml_result
+      type: xml
+      path: ./output/nested_values.xml
+      include_unmapped: false


### PR DESCRIPTION
## Summary

- add bounded array, map, and array-comprehension construction to CXL
- preserve nested values through planning, execution, JSON output, and XML output
- stream XML records without retaining input-sized scalar buffers
- trace nested value, predicate, source, and computed-key reads with the correct lineage roles
- document the complete authoring surface and its shared depth, key, collision, and null rules

## Behavior

Nested construction is now one end-to-end feature instead of several disconnected pieces. CXL can construct bounded arrays and maps, compiled plans retain their dependencies, executor paths preserve the native value shape, and both recursive writers use the same decoded-key and depth contracts.

JSON and XML fail before emitting a record when a nested shape exceeds the shared cap or contains an invalid collision. XML validates the complete record before streaming borrowed values, so its retained state is schema-bounded rather than input-sized. Output null policy is propagated consistently to both writers.

Lineage distinguishes fields that produce nested values from fields that only select items or compute keys. Static key text creates no column dependency, and qualified references remain distinct through composition and combine binding.

## Verification

- `cargo test -p cxl --locked --offline` — 568 passed
- `cargo test -p clinker-format --test nested_write_symmetry --locked --offline` — 10 passed
- `cargo test -p clinker-plan --test nested_cxl_integration --locked --offline` — 7 passed
- `cargo test -p clinker-lineage --test composition_lineage nested_ --locked --offline` — 3 passed
- `cargo test -p clinker-exec --test json_nested_write_e2e --locked --offline` — 6 passed
- `cargo test -p clinker-exec --test xml_nested_write_e2e --locked --offline` — 7 passed
- `git diff --check origin/main..HEAD`

## Obligations

- Lineage is included for nested value production and selection influence.
- Runtime construction and writer state are bounded by fixed depth, item, key, and schema-derived limits; XML does not retain input-sized scalar copies.
- No new execution lifecycle is introduced, so existing execution telemetry remains the correct source of runtime work signals.
